### PR TITLE
子查询的别名条件忽略掉,不参数路由计算，否则后面找不到表,测试语句SELECT  UM.UserId , UM.MenuId ,SM.Paren...

### DIFF
--- a/src/main/java/org/opencloudb/parser/druid/impl/DefaultDruidParser.java
+++ b/src/main/java/org/opencloudb/parser/druid/impl/DefaultDruidParser.java
@@ -129,7 +129,7 @@ public class DefaultDruidParser implements DruidParser {
 			if(checkConditionValues(values)) {
 				String columnName = removeBackquote(condition.getColumn().getName().toUpperCase());
 				String tableName = removeBackquote(condition.getColumn().getTable().toUpperCase());
-				if(visitor.getAliasMap().get(condition.getColumn().getTable()) == null) {//子查询的别名提交忽略掉,否则后面找不到表
+				if(visitor.getAliasMap() != null && visitor.getAliasMap().get(condition.getColumn().getTable()) == null) {//子查询的别名条件忽略掉,不参数路由计算，否则后面找不到表
 					continue;
 				}
 				


### PR DESCRIPTION
子查询的别名条件忽略掉,不参数路由计算，否则后面找不到表,测试语句：SELECT  UM.UserId , UM.MenuId ,SM.ParentId ,SM.FullName , SM.Description , SM.Img , SM.NavigateUrl ,SM.FormName ,SM.Target ,SM.IsUnfold FROM    Lever_SysMenu SM INNER JOIN ( SELECT UR.UserId AS UserId ,  RM.MenuId AS MenuId FROM   Lever_RoleMenu RM  INNER JOIN Lever_UserRole UR ON RM.RoleId = UR.RoleId  UNION SELECT UserId ,   MenuId FROM   Lever_UserMenu   UNION SELECT U.UserId ,      RM.MenuId   FROM   Lever_User U     LEFT JOIN Lever_RoleMenu RM ON U.RoleId = RM.RoleId    WHERE  U.UserId = '8d28533f-1762-4e79-b71f-64eb1a50cb8b' ) UM ON SM.MenuId = UM.MenuId   WHERE   UM.UserId = '8d28533f-1762-4e79-b71f-64eb1a50cb8b'  AND SM.Enabled = 1  ORDER BY SM.SortCode
