### PR TITLE
解决了连接JDBC的出现空指针的小bug

### DIFF
--- a/src/main/java/org/opencloudb/jdbc/JDBCDatasource.java
+++ b/src/main/java/org/opencloudb/jdbc/JDBCDatasource.java
@@ -30,6 +30,7 @@ public class JDBCDatasource extends PhysicalDatasource {
 		c.setHost(dsc.getIp());
 		c.setPort(dsc.getPort());
 		c.setPool(this);
+		c.setSchema(schema);
 		try {
 			Connection con = DriverManager.getConnection(dsc.getUrl(),
 					dsc.getUser(), dsc.getPassword());


### PR DESCRIPTION
-connect error JDBCConnection [autocommit=true, txIsolation=0, running=false, borrowed=true, id=0, host=localhost, port=3306]java.lang.NullPointerException
