### PR TITLE
支持dataNode节点的通配符支持

### DIFF
--- a/src/main/java/org/opencloudb/config/loader/xml/XMLSchemaLoader.java
+++ b/src/main/java/org/opencloudb/config/loader/xml/XMLSchemaLoader.java
@@ -312,18 +312,32 @@ public class XMLSchemaLoader implements SchemaLoader {
 				throw new ConfigException("dataNode " + dnNamePre
 						+ " define error ,attribute can't be empty");
 			}
+            String[] dnNames = org.opencloudb.util.SplitUtil.split(
+                    dnNamePre, ',', '$', '-');
 			String[] databases = org.opencloudb.util.SplitUtil.split(
 					databaseStr, ',', '$', '-');
-			if (databases.length > 1) {
-				for (int k = 0; k < databases.length; k++) {
-					String databaseName = databases[k].substring(0,
-							databases[k].length() - 1);
-					createDataNode(dnNamePre  + k , databaseName,
-							host);
-					// System.out.println("dn:"+dnNamePre + '[' + k +
-					// ']'+",databse:"+databaseName+",host:"+host);
-				}
-			} else {
+            String[] hostStrings = org.opencloudb.util.SplitUtil.split(
+                    host, ',', '$', '-');
+
+            if(dnNames.length>1&&(databases.length>1&&databases.length!=dnNames.length
+                    ||hostStrings.length>1&&hostStrings.length!=dnNames.length
+                    ||hostStrings.length==1&&databases.length==1))
+            {
+                throw new ConfigException("dataNode " + dnNamePre
+                        + " define error ,wildcard characters attribute  must has the same size");
+            }
+            if (dnNames.length > 1)
+            {
+                for (int k = 0; k < dnNames.length; k++) {
+                    String dnName = dnNames[k];
+                    String      databaseName = databases.length > 1 ? databases[k] : databaseStr;
+                    String hostName =hostStrings.length > 1? hostStrings[k]:host;
+                    createDataNode(dnName , databaseName,
+                            hostName);
+
+                }
+            }
+            else {
 				createDataNode(dnNamePre, databaseStr, host);
 			}
 

--- a/src/main/java/org/opencloudb/config/loader/xml/XMLSchemaLoader.java
+++ b/src/main/java/org/opencloudb/config/loader/xml/XMLSchemaLoader.java
@@ -319,29 +319,49 @@ public class XMLSchemaLoader implements SchemaLoader {
             String[] hostStrings = org.opencloudb.util.SplitUtil.split(
                     host, ',', '$', '-');
 
-            if(dnNames.length>1&&(databases.length>1&&databases.length!=dnNames.length
-                    ||hostStrings.length>1&&hostStrings.length!=dnNames.length
-                    ||hostStrings.length==1&&databases.length==1))
-            {
-                throw new ConfigException("dataNode " + dnNamePre
-                        + " define error ,wildcard characters attribute  must has the same size");
-            }
+			if(dnNames.length>1&&dnNames.length!=databases.length*hostStrings.length)
+			{
+				throw new ConfigException("dataNode " + dnNamePre
+						+ " define error ,dnNames.length must be=databases.length*hostStrings.length");
+			}
             if (dnNames.length > 1)
             {
-                for (int k = 0; k < dnNames.length; k++) {
-                    String dnName = dnNames[k];
-                    String      databaseName = databases.length > 1 ? databases[k] : databaseStr;
-                    String hostName =hostStrings.length > 1? hostStrings[k]:host;
-                    createDataNode(dnName , databaseName,
-                            hostName);
+				List<String[]> mhdList= mergerHostDatabase( hostStrings , databases);
+					for (int k = 0; k < dnNames.length; k++)
+					{
+						String[] hd=mhdList.get(k);
+						String dnName = dnNames[k];
+						String databaseName = hd[1];
+						String hostName = hd[0];
+						createDataNode(dnName, databaseName,
+								hostName);
 
-                }
+					}
+
             }
             else {
 				createDataNode(dnNamePre, databaseStr, host);
 			}
 
 		}
+	}
+
+	private List<String[]> mergerHostDatabase(String[] hostStrings ,String[] databases)
+	{
+		List<String[]> mhdList=new ArrayList<>();
+		for (int i = 0; i < hostStrings.length; i++)
+		{
+			String hostString = hostStrings[i];
+			for (int i1 = 0; i1 < databases.length; i1++)
+			{
+				String database = databases[i1];
+				String[] hd=new String[2];
+				hd[0]=hostString;
+				hd[1]=database;
+				mhdList.add(hd);
+			}
+		}
+		return mhdList;
 	}
 
 	private void createDataNode(String dnName, String database, String host) {

--- a/src/main/resources/schema.dtd
+++ b/src/main/resources/schema.dtd
@@ -40,8 +40,8 @@
 
 
 <!ELEMENT dataNode (property*)>
-<!ATTLIST dataNode name NMTOKEN #REQUIRED>
-<!ATTLIST dataNode dataHost NMTOKEN #REQUIRED>
+<!ATTLIST dataNode name CDATA #REQUIRED>
+<!ATTLIST dataNode dataHost CDATA #REQUIRED>
 <!ATTLIST dataNode database CDATA #REQUIRED>
 
 <!ELEMENT dataHost (heartbeat,(writeHost+))>

--- a/src/test/resources/route/schema.xml
+++ b/src/test/resources/route/schema.xml
@@ -59,7 +59,7 @@
 	<dataNode name="offer_dn$0-127" dataHost="localhost1" database="db1$0-127" />
 	<dataNode name="detail_dn$0-127" dataHost="localhost1" database="db2$0-127" />
     <dataNode name="test_wild1$1-3" dataHost="localhost$1-3" database="db1" />
-    <dataNode name="test_wild$1-3" dataHost="localhost$1-3" database="db1$1-3" />
+    <dataNode name="test_wild$1-6" dataHost="localhost$1-3" database="db1$1-2" />
 	<dataNode name="independent_dn$0-127" dataHost="localhost1"
 		database="db7_$0-127" />
 	<dataNode name="dubbo_dn" dataHost="localhost1" database="db8" />

--- a/src/test/resources/route/schema.xml
+++ b/src/test/resources/route/schema.xml
@@ -56,9 +56,11 @@
 	<dataNode name="dn2" dataHost="localhost1" database="db2" />
 	<dataNode name="dn3" dataHost="localhost1" database="db3" />
 	<dataNode name="cndb_dn" dataHost="localhost1" database="db4" />
-	<dataNode name="offer_dn" dataHost="localhost1" database="db1_$0-127" />
-	<dataNode name="detail_dn" dataHost="localhost1" database="db2_$0-127" />
-	<dataNode name="independent_dn" dataHost="localhost1"
+	<dataNode name="offer_dn$0-127" dataHost="localhost1" database="db1$0-127" />
+	<dataNode name="detail_dn$0-127" dataHost="localhost1" database="db2$0-127" />
+    <dataNode name="test_wild1$1-3" dataHost="localhost$1-3" database="db1" />
+    <dataNode name="test_wild$1-3" dataHost="localhost$1-3" database="db1$1-3" />
+	<dataNode name="independent_dn$0-127" dataHost="localhost1"
 		database="db7_$0-127" />
 	<dataNode name="dubbo_dn" dataHost="localhost1" database="db8" />
 	<dataNode name="solo1" dataHost="localhost1" database="db9" />
@@ -73,4 +75,26 @@
 				/> -->
 		</writeHost>
 	</dataHost>
+    <dataHost name="localhost2" maxCon="500" minCon="10" balance="0"
+              dbType="mysql" dbDriver="native">
+        <heartbeat>select user()</heartbeat>
+        <!-- can have multi write hosts -->
+        <writeHost host="hostM2" url="localhost:3306" user="root"
+                   password="123456">
+            <!-- can have multi read hosts -->
+            <!-- <readHost host="hostS1" url="localhost:3307" user="root" password="123456"
+                /> -->
+        </writeHost>
+    </dataHost>
+    <dataHost name="localhost3" maxCon="500" minCon="10" balance="0"
+              dbType="mysql" dbDriver="native">
+        <heartbeat>select user()</heartbeat>
+        <!-- can have multi write hosts -->
+        <writeHost host="hostM3" url="localhost:3306" user="root"
+                   password="123456">
+            <!-- can have multi read hosts -->
+            <!-- <readHost host="hostS1" url="localhost:3307" user="root" password="123456"
+                /> -->
+        </writeHost>
+    </dataHost>
 </mycat:schema>


### PR DESCRIPTION
支持三种情况的通配符配置：
1.  < dataNode name="dn$1-6" dataHost="test1" database="base$1-6" />
2. < dataNode name="dn$1-6" dataHost="test$1-6" database="base" />
3. < dataNode name="dn$1-6" dataHost="test$1-3" database="base$1-2" />
稍后补充详细用法到文档中