### PR TITLE
修改解析配置TableConfig的dbType时以支持多个dataNode，添加postgresql的limit解析转换

### DIFF
--- a/src/main/java/org/opencloudb/config/loader/xml/XMLSchemaLoader.java
+++ b/src/main/java/org/opencloudb/config/loader/xml/XMLSchemaLoader.java
@@ -26,12 +26,7 @@ package org.opencloudb.config.loader.xml;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.opencloudb.backend.PhysicalDBPool;
 import org.opencloudb.config.loader.SchemaLoader;
@@ -43,6 +38,7 @@ import org.opencloudb.config.model.TableConfig;
 import org.opencloudb.config.model.rule.TableRuleConfig;
 import org.opencloudb.config.util.ConfigException;
 import org.opencloudb.config.util.ConfigUtil;
+import org.opencloudb.util.SplitUtil;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -249,10 +245,17 @@ public class XMLSchemaLoader implements SchemaLoader {
 
 		return tables;
 	}
-	private String getDbType(String dataNode){
-		DataNodeConfig datanode=dataNodes.get(dataNode);
-		DataHostConfig datahost=dataHosts.get(datanode.getDataHost());
-		return datahost.getDbType();
+	private Set<String> getDbType(String dataNode){
+        Set<String> dbTypes=new HashSet<>();
+      String[] dataNodeArr= SplitUtil.split(dataNode,',', '$', '-') ;
+        for (String node : dataNodeArr)
+        {
+            DataNodeConfig datanode=dataNodes.get(node);
+            DataHostConfig datahost=dataHosts.get(datanode.getDataHost());
+            dbTypes.add(datahost.getDbType());
+        }
+
+		return dbTypes;
 	}
 	private void processChildTables(Map<String, TableConfig> tables,
 			TableConfig parentTable, String dataNodes, Element tableNode) {

--- a/src/main/java/org/opencloudb/config/model/TableConfig.java
+++ b/src/main/java/org/opencloudb/config/model/TableConfig.java
@@ -25,6 +25,7 @@ package org.opencloudb.config.model;
 
 import java.util.ArrayList;
 import java.util.Random;
+import java.util.Set;
 
 import org.opencloudb.config.model.rule.RuleConfig;
 import org.opencloudb.util.SplitUtil;
@@ -39,7 +40,7 @@ public class TableConfig {
 	private final String primaryKey;
 	private final boolean autoIncrement;
 	private final boolean needAddLimit;
-	private final String dbType;
+	private final Set<String> dbTypes;
 	private final int tableType;
 	private final ArrayList<String> dataNodes;
 	private final RuleConfig rule;
@@ -56,7 +57,7 @@ public class TableConfig {
 	private final Random rand = new Random();
 
 	public TableConfig(String name, String primaryKey, boolean autoIncrement,boolean needAddLimit, int tableType,
-			String dataNode,String dbType, RuleConfig rule, boolean ruleRequired,
+			String dataNode,Set<String> dbType, RuleConfig rule, boolean ruleRequired,
 			TableConfig parentTC, boolean isChildTable, String joinKey,
 			String parentKey) {
 		if (name == null) {
@@ -68,7 +69,7 @@ public class TableConfig {
 		this.autoIncrement = autoIncrement;
 		this.needAddLimit=needAddLimit;
 		this.tableType = tableType;
-		this.dbType=dbType;
+		this.dbTypes=dbType;
 		if (ruleRequired && rule == null) {
 			throw new IllegalArgumentException("ruleRequired but rule is null");
 		}
@@ -105,11 +106,13 @@ public class TableConfig {
 	public String getPrimaryKey() {
 		return primaryKey;
 	}
-	
-	public String getDbType() {
-		return dbType;
-	}
-	public boolean isAutoIncrement() {
+
+    public Set<String> getDbTypes()
+    {
+        return dbTypes;
+    }
+
+    public boolean isAutoIncrement() {
 		return autoIncrement;
 	}
 

--- a/src/main/java/org/opencloudb/parser/druid/DruidParserFactory.java
+++ b/src/main/java/org/opencloudb/parser/druid/DruidParserFactory.java
@@ -29,17 +29,21 @@ public class DruidParserFactory {
 			List<String> tables=  parseTables(statement);
 			for (String table : tables)
 			{
-				if (schema.getTables().get(table).getDbType().equals("oracle"))//if(schema.getAllDbTypeSet().contains("oracle")&&schema.isTableInThisDb(table,"oracle"))
+				if (schema.getTables().get(table).getDbTypes().contains("oracle"))//if(schema.getAllDbTypeSet().contains("oracle")&&schema.isTableInThisDb(table,"oracle"))
 				{
 					parser=new DruidSelectOracleParser();
-				} else if(schema.getTables().get(table).getDbType().equals("db2"))
+				} else if(schema.getTables().get(table).getDbTypes().contains("db2"))
 				{
 					parser=new DruidSelectDb2Parser();
 				}
-				else if(schema.getTables().get(table).getDbType().equals("sqlserver"))
+				else if(schema.getTables().get(table).getDbTypes().contains("sqlserver"))
 				{
 					parser=new DruidSelectSqlServerParser();
 				}
+                else if(schema.getTables().get(table).getDbTypes().contains("postgresql"))
+                {
+                    parser=new DruidSelectPostgresqlParser();
+                }
 			}
 			if(parser==null)
 			{

--- a/src/main/java/org/opencloudb/parser/druid/impl/DruidSelectParser.java
+++ b/src/main/java/org/opencloudb/parser/druid/impl/DruidSelectParser.java
@@ -192,8 +192,12 @@ public class DruidSelectParser extends DefaultDruidParser {
 				}   else
 				{
 					//单节点也需要转换limit
-					String nativeSql=convertToNativePageSql(selectStmt.toString(),rrs.getLimitStart(),rrs.getLimitSize());
-					rrs.changeNodeSqlAfterAddLimit(nativeSql);
+                    String sql = selectStmt.toString();
+                    String nativeSql=convertToNativePageSql(sql,rrs.getLimitStart(),rrs.getLimitSize());
+                    if(!nativeSql.equals(sql))
+                    {
+                        rrs.changeNodeSqlAfterAddLimit(nativeSql);
+                    }
 				}
 				
 				

--- a/src/main/java/org/opencloudb/parser/druid/impl/DruidSelectPostgresqlParser.java
+++ b/src/main/java/org/opencloudb/parser/druid/impl/DruidSelectPostgresqlParser.java
@@ -1,0 +1,21 @@
+package org.opencloudb.parser.druid.impl;
+
+import com.alibaba.druid.sql.PagerUtils;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import com.alibaba.druid.sql.dialect.postgresql.parser.PGSQLStatementParser;
+
+public class DruidSelectPostgresqlParser extends DruidSelectParser
+{
+
+
+    protected String convertToNativePageSql(String sql, int offset, int count)
+    {
+        PGSQLStatementParser oracleParser = new PGSQLStatementParser(sql);
+        SQLSelectStatement oracleStmt = (SQLSelectStatement) oracleParser.parseStatement();
+
+        return PagerUtils.limit(oracleStmt.getSelect(), "postgresql", offset, count);
+
+    }
+
+
+}


### PR DESCRIPTION
1.修改解析配置TableConfig的dbType时以支持多个dataNode
2.添加postgresql的limit解析转换