### PR TITLE
/*balance*/ 使用规则修改

### DIFF
--- a/src/main/java/org/opencloudb/route/RouteResultsetNode.java
+++ b/src/main/java/org/opencloudb/route/RouteResultsetNode.java
@@ -2,8 +2,8 @@
  * Copyright (c) 2013, OpenCloudDB/MyCAT and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * This code is free software;Designed and Developed mainly by many Chinese 
- * opensource volunteers. you can redistribute it and/or modify it under the 
+ * This code is free software;Designed and Developed mainly by many Chinese
+ * opensource volunteers. you can redistribute it and/or modify it under the
  * terms of the GNU General Public License version 2 only, as published by the
  * Free Software Foundation.
  *
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- * 
- * Any questions about this component can be directed to it's project Web address 
+ *
+ * Any questions about this component can be directed to it's project Web address
  * https://code.google.com/p/opencloudb/.
  *
  */
@@ -32,7 +32,7 @@ import java.io.Serializable;
  */
 public final class RouteResultsetNode implements Serializable {
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
 	private final String name; // 数据节点名称
@@ -69,7 +69,8 @@ public final class RouteResultsetNode implements Serializable {
 	}
 
 	public boolean canRunnINReadDB(boolean autocommit) {
-		return canRunInReadDB && (autocommit || hasBlanceFlag);
+		return canRunInReadDB && autocommit && !hasBlanceFlag
+			|| canRunInReadDB && !autocommit && hasBlanceFlag;
 	}
 
 	public String getName() {


### PR DESCRIPTION
1.  事务内的SQL，默认走写节点，以注释/*balance*/开头，则会根据balance=“1” 或“2” 去获取
2.  非事务内的SQL，开启读写分离默认根据balance=“1” 或“2” 去获取，以注释/*balance*/开头 则会走写
解决部分已经开启读写分离， 但是需要强一致性数据实时获取的场景走写