### PR TITLE
增加对自增序列的非空判断，如果没有配置，则抛出配置异常，提示没有序列的定义，避免直接抛出空指针异常。

### DIFF
--- a/src/main/java/org/opencloudb/config/loader/xml/XMLSchemaLoader.java
+++ b/src/main/java/org/opencloudb/config/loader/xml/XMLSchemaLoader.java
@@ -274,15 +274,7 @@ public class XMLSchemaLoader implements SchemaLoader {
 			}
 
 			if (tableNames.length == 1) {
-				TableConfig table = new TableConfig(tableNames[0], primaryKey,
-						autoIncrement, needAddLimit, tableType, dataNode,
-						getDbType(dataNode),
-						(tableRule != null) ? tableRule.getRule() : null,
-						ruleRequired, null, false, null, null);
-				checkDataNodeExists(table.getDataNodes());
-				if (distTableDns) {
-					distributeDataNodes(table.getDataNodes());
-				}
+				TableConfig table = tables.get(tableNames[0]);
 
 				// process child tables
 				processChildTables(tables, table, dataNode, tableElement);

--- a/src/main/java/org/opencloudb/sequence/handler/IncrSequenceMySQLHandler.java
+++ b/src/main/java/org/opencloudb/sequence/handler/IncrSequenceMySQLHandler.java
@@ -15,6 +15,7 @@ import org.opencloudb.MycatConfig;
 import org.opencloudb.MycatServer;
 import org.opencloudb.backend.BackendConnection;
 import org.opencloudb.backend.PhysicalDBNode;
+import org.opencloudb.config.util.ConfigException;
 import org.opencloudb.mysql.nio.handler.ResponseHandler;
 import org.opencloudb.net.mysql.ErrorPacket;
 import org.opencloudb.net.mysql.RowDataPacket;
@@ -102,6 +103,10 @@ public class IncrSequenceMySQLHandler implements SequenceHandler {
 	@Override
 	public long nextId(String seqName) {
 		SequenceVal seqVal = seqValueMap.get(seqName);
+		if (seqVal == null) {
+			throw new ConfigException("can't find definition for sequence :"
+					+ seqName);
+		}
 		if (!seqVal.isSuccessFetched()) {
 			return getSeqValueFromDB(seqVal);
 		} else {


### PR DESCRIPTION
根据seqName获取自增序列时，如果配置文件没有进行配置，取到的SequenceVal对象在后面的执行中会抛出空指针，对用户不友好，对运维排错也不方便。可以先对对象进行非空验证，抛出序列未定义的异常信息，便于排错。