### PR TITLE
解决mysql客户端中编辑表报表不存在的错误

### DIFF
--- a/src/main/java/io/mycat/route/util/RouterUtil.java
+++ b/src/main/java/io/mycat/route/util/RouterUtil.java
@@ -141,6 +141,9 @@ public class RouterUtil {
 		if (tableName.contains(" ")){
 			tableName = tableName.substring(0,tableName.indexOf(" "));
 		}
+		if (tableName.contains("\n")){
+			tableName = tableName.substring(0,tableName.indexOf("\n"));
+		}
 		int ind2 = tableName.indexOf('.');
 		if (ind2 > 0) {
 			tableName = tableName.substring(ind2 + 1);


### PR DESCRIPTION
【问题原因】在navicat for mysql等mysql客户端软件中，sql标准格式后以多行形式，这样就会报表名不存在
【解决方法】取表名getTableName方法中，增加判断是否有\n字符