### PR TITLE
聚合函数COUNT.SUM等返回数据不对的问题

### DIFF
--- a/src/main/java/io/mycat/sqlengine/mpp/DataMergeService.java
+++ b/src/main/java/io/mycat/sqlengine/mpp/DataMergeService.java
@@ -218,7 +218,8 @@ public class DataMergeService implements Runnable {
 	public boolean onNewRecord(String dataNode, byte[] rowData) {
 		try {
 			// 对于无需排序的SQL,取前getLimitSize条就足够
-			if (!hasOrderBy && areadyAdd.get() >= rrs.getLimitSize()) {
+			//聚合函数COUNT.SUM.AVG等需要等待所有分片返回结果，所有需要添加条件!rrs.isHasAggrColumn()
+			if (!rrs.isHasAggrColumn() && !hasOrderBy && areadyAdd.get() >= rrs.getLimitSize()) {
 				packs.add(END_FLAG_PACK);
 				return true;
 			}


### PR DESCRIPTION
[问题现象]执行select sum等聚合函数语句，返回的结果比实际的少
[问题原因]DataMergeService合入多节点优化代码后引入
[解决方法]判断如果包含聚会函数的时候，要等所有分片返回结果后再返回