### PR TITLE
由于变量sf类型为Map，所以进行calculate操作时，应取Map中的value值。否则，当hashtype为mod时，Partiti…

### DIFF
--- a/src/main/java/io/mycat/util/rehasher/RehashLauncher.java
+++ b/src/main/java/io/mycat/util/rehasher/RehashLauncher.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -38,7 +39,7 @@ public class RehashLauncher {
         public void run(){
         	int pageSize=500;
         	int page=0;
-        	List list=null;
+        	List<Map<String, Object>> list=null;
         	
         	int total=0;
         	int rehashed=0;
@@ -52,8 +53,8 @@ public class RehashLauncher {
                     pageSize);
                 while (!CollectionUtil.isEmpty(list)) {
         			for(int i=0,l=list.size();i<l;i++){
-        				Object sf=list.get(i);
-        				Integer hash=alg.calculate(sf.toString());
+        				Map<String, Object> sf=list.get(i);
+        				Integer hash=alg.calculate(sf.get(args.getShardingField()).toString());
         				String host=rehashHosts[hash];
         				total++;
         				if(host.equals(hostWithDatabase)){


### PR DESCRIPTION
…onByMod进行calulate的代码为：BigInteger bigNum = new BigInteger(columnValue)，会将此值转换为BigInteger，而此时将会抛出NumberFormatException异常