### PR TITLE
select返回条数少于limit时报错

### DIFF
--- a/src/main/java/io/mycat/server/executors/MultiNodeQueryHandler.java
+++ b/src/main/java/io/mycat/server/executors/MultiNodeQueryHandler.java
@@ -319,7 +319,7 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements
 			List<RowDataPacket> results = dataMergeSvr.getResults(eof);
             if (start < 0)
                			start = 0;
-            if(rrs.getLimitSize()<0)
+            if(rrs.getLimitSize()<0 || end > results.size())
             {
                 end=results.size();
             }


### PR DESCRIPTION
[问题原因]select返回条数少于limit时，end=limit则大于返回条数，则for循环取数据报错
[问题修改]end不能大于results.size()，比较end与results.size()