### PR TITLE
修改dataHost.switchType默认值为1，之前是-1与权威指南描述不符。

### DIFF
--- a/src/main/java/org/opencloudb/config/loader/xml/XMLSchemaLoader.java
+++ b/src/main/java/org/opencloudb/config/loader/xml/XMLSchemaLoader.java
@@ -614,7 +614,7 @@ public class XMLSchemaLoader implements SchemaLoader {
 			int balance = Integer.valueOf(element.getAttribute("balance"));
 			
 			String switchTypeStr = element.getAttribute("switchType");
-			int switchType = switchTypeStr.equals("") ? -1 : Integer.valueOf(switchTypeStr);
+			int switchType = switchTypeStr.equals("") ? 1 : Integer.valueOf(switchTypeStr);
 			
 			String slaveThresholdStr = element.getAttribute("slaveThreshold");
 			int slaveThreshold = slaveThresholdStr.equals("") ? -1 : Integer.valueOf(slaveThresholdStr);


### PR DESCRIPTION
此问题带来的影响是从1.3升级1.4+时，如果套用1.3 schema.xml，会出现主机宕机后无法切换到从机写的问题且该问题不好排查。