### PR TITLE
String强转换报ClassCastException

### DIFF
--- a/src/main/java/io/mycat/server/config/node/MycatConfig.java
+++ b/src/main/java/io/mycat/server/config/node/MycatConfig.java
@@ -119,7 +119,7 @@ public class MycatConfig implements ConfigReLoader{
 		   || !this.hostIndexConfig.getProps().containsKey(hostName)){
 			return index;
 		}
-		return (String) hostIndexConfig.getProps().get(hostName);
+		return String.valueOf(hostIndexConfig.getProps().get(hostName));
 	}
 	public void setHostIndex(String hostName, int index) {
 		this.hostIndexConfig.getProps().put(hostName, index);

--- a/src/main/java/io/mycat/sqlengine/SQLJob.java
+++ b/src/main/java/io/mycat/sqlengine/SQLJob.java
@@ -151,6 +151,8 @@ public class SQLJob implements ResponseHandler, Runnable {
 
 	@Override
 	public void rowEofResponse(byte[] eof, BackendConnection conn) {
+		//connection do synchronization
+		conn.syncAndExcute();
 		conn.release();
 		doFinished(false);
 	}


### PR DESCRIPTION
之前一直好好的，突然有一次更新了一下，重启就会一直报Integer cannot be cast to java.lang.String，死活起不来，在eclipse里调试确正常，不知道其他人有没有碰到过这个问题， 没办法，我只能在自己的版本中改为String.valueOf，应该改为String.valueOf更好一点吧