### PR TITLE
修复:客户端字符集同步不一致.

### DIFF
--- a/src/main/resources/myid.properties
+++ b/src/main/resources/myid.properties
@@ -1,3 +1,3 @@
-loadZk=true
+loadZk=false
 zkURL=127.0.0.1:2181
 myid=mycat_fz_01


### PR DESCRIPTION
后端链接在同步完毕之后才回调修改当前后端链接的字符集,导致第一条发送出去的字符是使用后端链接的字符集进行编码的,而不是真正前端链接的字符集,导致编码出错.