### PR TITLE
Empty statements should be removed

### DIFF
--- a/src/main/java/io/mycat/MycatServer.java
+++ b/src/main/java/io/mycat/MycatServer.java
@@ -248,7 +248,7 @@ public class MycatServer {
 				} catch (Exception e) {
 					LOGGER.warn("catletClassClear err " + e);
 				}
-			};
+			}
 		};
 	}
 	

--- a/src/main/java/io/mycat/route/function/PartitionByPattern.java
+++ b/src/main/java/io/mycat/route/function/PartitionByPattern.java
@@ -37,7 +37,7 @@ public class PartitionByPattern extends AbstractPartitionAlgorithm implements Ru
 	private int patternValue = PARTITION_LENGTH;// 分区长度，取模数值
 	private LongRange[] longRongs;
 	private int defaultNode = 0;// 包含非数值字符，默认存储节点
-    private static final  Pattern pattern = Pattern.compile("[0-9]*");;
+    private static final  Pattern pattern = Pattern.compile("[0-9]*");
 
 	@Override
 	public void init() {

--- a/src/main/java/io/mycat/route/parser/druid/impl/DruidSelectParser.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/DruidSelectParser.java
@@ -217,7 +217,7 @@ public class DruidSelectParser extends DefaultDruidParser {
         SQLBinaryOperator operator = expr.getOperator();
         SQLExpr right = expr.getRight();
 
-        String leftValue = null;;
+        String leftValue = null;
         if (left instanceof SQLAggregateExpr) {
             leftValue = ((SQLAggregateExpr) left).getMethodName() + "("
                     + ((SQLAggregateExpr) left).getArguments().get(0) + ")";

--- a/src/main/java/io/mycat/server/config/loader/ConfigFactory.java
+++ b/src/main/java/io/mycat/server/config/loader/ConfigFactory.java
@@ -85,8 +85,9 @@ public class ConfigFactory {
         ZookeeperLoader zookeeperLoader = new ZookeeperLoader();
         zookeeperLoader.initConfig();
         return null;
-	};
+	}
+
 	private static ConfigLoader instanceLocalLoader(){
 		return new LocalLoader();
-	};
+	}
 }

--- a/src/main/java/io/mycat/server/config/loader/LocalLoader.java
+++ b/src/main/java/io/mycat/server/config/loader/LocalLoader.java
@@ -106,7 +106,7 @@ public class LocalLoader implements ConfigLoader {
     private static Element loadRoot() {
         if(document == null){
         	try(InputStream dtd = ConfigFactory.class.getResourceAsStream("/mycat.dtd");
-        		InputStream xml = ConfigFactory.class.getResourceAsStream("/mycat.xml");){
+        		InputStream xml = ConfigFactory.class.getResourceAsStream("/mycat.xml")){
                 document = ConfigUtil.getDocument(dtd, xml);
                 return document.getDocumentElement();
             } catch (Exception e) {

--- a/src/main/java/io/mycat/server/sequence/SequenceHandler.java
+++ b/src/main/java/io/mycat/server/sequence/SequenceHandler.java
@@ -36,6 +36,6 @@ public abstract class SequenceHandler {
 	public abstract long nextId(String prefixName);
 	public static SequenceConfig getConfig(){
 		return MycatServer.getInstance().getConfig().getSequenceConfig();
-	};
+	}
 
 }

--- a/src/main/java/io/mycat/util/rehasher/HashType.java
+++ b/src/main/java/io/mycat/util/rehasher/HashType.java
@@ -1,5 +1,5 @@
 package io.mycat.util.rehasher;
 
 public enum HashType {
-	MURMUR,MOD;
+	MURMUR,MOD
 }

--- a/src/test/java/io/mycat/SimpleCachePool.java
+++ b/src/test/java/io/mycat/SimpleCachePool.java
@@ -75,4 +75,4 @@ public class SimpleCachePool implements LayerCachePool {
 	public long getMaxSize() {
 		return 100;
 	}
-};
+}

--- a/src/test/java/io/mycat/backend/postgresql/EchoServer.java
+++ b/src/test/java/io/mycat/backend/postgresql/EchoServer.java
@@ -51,7 +51,6 @@ public class EchoServer {
 			for (;;) {
 				Socket socket = serverSocket.accept();
 				new EchoThor(socket).start();
-				;
 			}
 
 		} catch (IOException e) {

--- a/src/test/java/io/mycat/backend/postgresql/PostgresqlKnightriders.java
+++ b/src/test/java/io/mycat/backend/postgresql/PostgresqlKnightriders.java
@@ -122,7 +122,6 @@ public class PostgresqlKnightriders {
 						sqlPacket = readParsePacket(socket);
 						for (PostgreSQLPacket p : sqlPacket) {
 							if (p instanceof DataRow) {
-								;
 								for (DataColumn c : ((DataRow) p).getColumns()) {
 									System.out.println(new String(c.getData(),
 											"utf-8"));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:EmptyStatementUsageCheck - Empty statements should be removed
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:EmptyStatementUsageCheck
Please let me know if you have any questions.
Kirill Vlasov