### PR TITLE
fix sharejoin bug

### DIFF
--- a/src/main/java/demo/catlets/ShareJoin.java
+++ b/src/main/java/demo/catlets/ShareJoin.java
@@ -5,6 +5,7 @@ import io.mycat.route.RouteResultset;
 import io.mycat.route.RouteResultsetNode;
 import io.mycat.route.factory.RouteStrategyFactory;
 import io.mycat.server.ErrorCode;
+import io.mycat.server.Fields;
 import io.mycat.server.MySQLFrontConnection;
 import io.mycat.server.config.node.SchemaConfig;
 import io.mycat.server.config.node.SystemConfig;
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
 
 //import org.opencloudb.route.RouteStrategy;
 //import org.opencloudb.route.impl.DruidMysqlRouteStrategy;
@@ -57,6 +59,11 @@ public class ShareJoin implements Catlet {
 	private int sendField=0;
 	private boolean childRoute=false;
 	private boolean jointTableIsData=false;
+	
+	// join 字段的类型，一般情况都是int, long; 增加该字段为了支持非int,long类型的(一般为varchar)joinkey的sharejoin
+	// 参见：io.mycat.server.packet.FieldPacket 属性： public int type;
+	// 参见：http://dev.mysql.com/doc/internals/en/com-query-response.html#packet-Protocol::ColumnDefinition
+	private int joinKeyType = Fields.FIELD_TYPE_LONG; // 默认 join 字段为int型
 	
 	//重新路由使用
 	private SystemConfig sysConfig; 
@@ -197,7 +204,13 @@ public class ShareJoin implements Catlet {
 			theId=e.getKey();
 			batchRows.put(theId, rows.remove(theId));
 			if (!svalue.equals(e.getValue())){
-			  sb.append(e.getValue()).append(',');
+				if(joinKeyType == Fields.FIELD_TYPE_VAR_STRING 
+						|| joinKeyType == Fields.FIELD_TYPE_STRING){ // joinkey 为varchar
+					sb.append("'").append(e.getValue()).append("'").append(','); // ('digdeep','yuanfang') 
+				}else{ // 默认joinkey为int/long
+					sb.append(e.getValue()).append(','); // (1,2,3) 
+				}
+				EngineCtx.LOGGER.debug("sb::::::" + sb);
 			}
 			svalue=e.getValue();
 			if (count++ > batchSize) {
@@ -219,10 +232,12 @@ public class ShareJoin implements Catlet {
 		jointTableIsData=true;
 		sb.deleteCharAt(sb.length() - 1).append(')');
 		String sql = String.format(joinParser.getChildSQL(), sb);
+		EngineCtx.LOGGER.debug("sql::::::333" + sql); // select name, id from customer where name in (lexin3,b,yuanfang,digdeep,b,yuanfang)
 		//if (!childRoute){
 		  getRoute(sql);
 		 //childRoute=true;
 		//}
+		  EngineCtx.LOGGER.debug("sql::::::4444" + sql);
 		ctx.executeNativeSQLParallJob(getDataNodes(),sql, new ShareRowOutPutDataHandler(this,fields,joinindex,joinParser.getJoinRkey(), batchRows));
 		EngineCtx.LOGGER.info("SQLParallJob:"+getDataNode(getDataNodes())+" sql:" + sql);		
 	}  
@@ -253,12 +268,16 @@ public class ShareJoin implements Catlet {
 		ctx.writeRow(rowDataPkg);
 	}
 	
-	public static int getFieldIndex(List<byte[]> fields,String fkey){
+	public int getFieldIndex(List<byte[]> fields,String fkey){
 		int i=0;
 		for (byte[] field :fields) {	
 			  FieldPacket fieldPacket = new FieldPacket();
 			  fieldPacket.read(field);	
 			  if (ByteUtil.getString(fieldPacket.name).equals(fkey)){
+				  joinKeyType = fieldPacket.type;
+				  EngineCtx.LOGGER.info("fieldPacket.type::::::::" + fieldPacket.type);
+				  EngineCtx.LOGGER.info("fieldPacket.type:::::fkey:::" + fkey);
+				  EngineCtx.LOGGER.info("fieldPacket.type:::::joinKeyType:::" + joinKeyType);
 				  return i;				  
 			  }
 			  i++;

--- a/src/main/java/demo/catlets/ShareJoin.java
+++ b/src/main/java/demo/catlets/ShareJoin.java
@@ -210,7 +210,6 @@ public class ShareJoin implements Catlet {
 				}else{ // 默认joinkey为int/long
 					sb.append(e.getValue()).append(','); // (1,2,3) 
 				}
-				EngineCtx.LOGGER.debug("sb::::::" + sb);
 			}
 			svalue=e.getValue();
 			if (count++ > batchSize) {
@@ -232,12 +231,10 @@ public class ShareJoin implements Catlet {
 		jointTableIsData=true;
 		sb.deleteCharAt(sb.length() - 1).append(')');
 		String sql = String.format(joinParser.getChildSQL(), sb);
-		EngineCtx.LOGGER.debug("sql::::::333" + sql); // select name, id from customer where name in (lexin3,b,yuanfang,digdeep,b,yuanfang)
 		//if (!childRoute){
 		  getRoute(sql);
 		 //childRoute=true;
 		//}
-		  EngineCtx.LOGGER.debug("sql::::::4444" + sql);
 		ctx.executeNativeSQLParallJob(getDataNodes(),sql, new ShareRowOutPutDataHandler(this,fields,joinindex,joinParser.getJoinRkey(), batchRows));
 		EngineCtx.LOGGER.info("SQLParallJob:"+getDataNode(getDataNodes())+" sql:" + sql);		
 	}  
@@ -275,9 +272,6 @@ public class ShareJoin implements Catlet {
 			  fieldPacket.read(field);	
 			  if (ByteUtil.getString(fieldPacket.name).equals(fkey)){
 				  joinKeyType = fieldPacket.type;
-				  EngineCtx.LOGGER.info("fieldPacket.type::::::::" + fieldPacket.type);
-				  EngineCtx.LOGGER.info("fieldPacket.type:::::fkey:::" + fkey);
-				  EngineCtx.LOGGER.info("fieldPacket.type:::::joinKeyType:::" + joinKeyType);
 				  return i;				  
 			  }
 			  i++;

--- a/src/main/java/io/mycat/backend/heartbeat/MySQLDetector.java
+++ b/src/main/java/io/mycat/backend/heartbeat/MySQLDetector.java
@@ -151,7 +151,13 @@ public class MySQLDetector implements
 
     public void close(String msg) {
         SQLJob curJob = sqlJob;
-        if (curJob != null && !curJob.isFinished()) {
+        // 这里应该是写反了？？
+        // node 的 heartbeat失败，会调用到SQLJob.doFinished， MySQLHeartBeat.setError
+        // 如果超过重试次数，则调用detector.quit(); 然后到达此函数，但是 SQLJob.doFinished
+        // 已经设置 finished = true，所以导致 curJob.teminate(msg) 始终无法执行
+        // 无法关闭连接
+//        if (curJob != null && !curJob.isFinished()) {
+        if (curJob != null && curJob.isFinished()) {
             curJob.teminate(msg);
             sqlJob = null;
         }

--- a/src/main/java/io/mycat/net/Connection.java
+++ b/src/main/java/io/mycat/net/Connection.java
@@ -553,7 +553,7 @@ public abstract class Connection implements ClosableConnection{
 				if (written > 0) {
 					netOutBytes += written;
 					NetSystem.getInstance().addNetOutBytes(written);
-
+					lastWriteTime = TimeUtil.currentTimeMillis();
 				} else {
 					break;
 				}

--- a/src/main/java/io/mycat/route/handler/HintHandlerFactory.java
+++ b/src/main/java/io/mycat/route/handler/HintHandlerFactory.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class HintHandlerFactory {
-	private static boolean isInit = false;
+	private static volatile boolean isInit = false;
 	 //sql注释的类型处理handler 集合，现在支持两种类型的处理：sql,schema
     private static Map<String,HintHandler> hintHandlerMap = new HashMap<String,HintHandler>();
 

--- a/src/main/java/io/mycat/route/handler/HintHandlerFactory.java
+++ b/src/main/java/io/mycat/route/handler/HintHandlerFactory.java
@@ -16,11 +16,16 @@ public class HintHandlerFactory {
         hintHandlerMap.put("schema",new HintSchemaHandler());
         hintHandlerMap.put("datanode",new HintDataNodeHandler());
         hintHandlerMap.put("catlet",new HintCatletHandler());
+        isInit = true;	// 修复多次初始化的bug
     }
     
+    // 双重校验锁 fix 线程安全问题
     public static HintHandler getHintHandler(String hintType) {
     	if(!isInit) {
-    		init();
+    		synchronized(HintHandlerFactory.class){
+    			if(!isInit)
+    				init();
+    		}
     	}
     	return hintHandlerMap.get(hintType);
     }

--- a/src/main/java/io/mycat/server/interceptor/impl/DefaultSqlInterceptor.java
+++ b/src/main/java/io/mycat/server/interceptor/impl/DefaultSqlInterceptor.java
@@ -1,5 +1,7 @@
 package io.mycat.server.interceptor.impl;
 
+import io.mycat.MycatServer;
+import io.mycat.server.config.node.SystemConfig;
 import io.mycat.server.interceptor.SQLInterceptor;
 
 import java.util.regex.Matcher;
@@ -46,7 +48,9 @@ public class DefaultSqlInterceptor implements SQLInterceptor {
 	public String interceptSQL(String sql, int sqlType) {
 		String result = processEscape(sql);
 		// 全局表一致性 sql 改写拦截
-		result = GlobalTableUtil.interceptSQL(result, sqlType);
+		SystemConfig system = MycatServer.getInstance().getConfig().getSystem();
+		if(system != null && system.isGlobalTableCheckSwitchOn()) // 全局表一致性检测是否开启
+			result = GlobalTableUtil.interceptSQL(result, sqlType);
 		return result;
 	}
 

--- a/src/main/java/io/mycat/sqlengine/sharejoin/TableFilter.java
+++ b/src/main/java/io/mycat/sqlengine/sharejoin/TableFilter.java
@@ -274,13 +274,21 @@ public class TableFilter {
 			else
 			  sql=unionsql(sql,getFieldfrom(key)+" as "+val,",");  
 		  }
-        if (parent==null){
+        if (parent==null){	// on/where 等于号左边的表
+        	String parentJoinKey = getJoinKey(true);
+        	// fix sharejoin bug： 
+        	// (AbstractConnection.java:458) -close connection,reason:program err:java.lang.IndexOutOfBoundsException:
+        	// 原因是左表的select列没有包含 join 列，在获取结果时报上面的错误
+        	if(sql != null && parentJoinKey != null &&  
+        			sql.toUpperCase().indexOf(parentJoinKey.trim().toUpperCase()) == -1){
+        		sql += ", " + parentJoinKey;
+        	}
 		   sql="select "+sql+" from "+tName;
 		   if (!(where.trim().equals(""))){
 				sql+=" where "+where.trim(); 	
 			}
         }
-        else {
+        else {	// on/where 等于号右边边的表
         	if (allField) {
         	   sql="select "+sql+" from "+tName;
         	}


### PR DESCRIPTION
share join时，比如：
/*!mycat:catlet=demo.catlets.ShareJoin*/ 
select a.id as aid, b.id as bid, b.name as tit from customer a,company b where a.company_id=b.id 
会报错：close connection,reason:program err:java.lang.IndexOutOfBoundsException:
// 原因是左表的select列没有包含 join 列，在获取结果时报上没的错误
修复就是给他加上join列：
/*!mycat:catlet=demo.catlets.ShareJoin*/ 
select a.id as aid,company_id, b.id as bid, b.name as tit from customer a,company b where a.company_id=b.id 
这样就不会报错了。