### PR TITLE
fix sharejoin bug

### DIFF
--- a/src/main/java/demo/catlets/ShareJoin.java
+++ b/src/main/java/demo/catlets/ShareJoin.java
@@ -6,8 +6,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 
+
 import org.opencloudb.cache.LayerCachePool;
 import org.opencloudb.config.ErrorCode;
+import org.opencloudb.config.Fields;
 import org.opencloudb.config.model.SchemaConfig;
 import org.opencloudb.config.model.SystemConfig;
 import org.opencloudb.net.mysql.FieldPacket;
@@ -24,6 +26,7 @@ import org.opencloudb.sqlengine.EngineCtx;
 import org.opencloudb.sqlengine.SQLJobHandler;
 import org.opencloudb.util.ByteUtil;
 import org.opencloudb.util.ResultSetUtil;
+
 
 
 //import org.opencloudb.route.RouteStrategy;
@@ -59,7 +62,11 @@ public class ShareJoin implements Catlet {
 	private int sendField=0;
 	private boolean childRoute=false;
 	private boolean jointTableIsData=false;
-	
+	// join 字段的类型，一般情况都是int, long; 增加该字段为了支持非int,long类型的(一般为varchar)joinkey的sharejoin
+ 	// 参见：io.mycat.server.packet.FieldPacket 属性： public int type;
+ 	// 参见：http://dev.mysql.com/doc/internals/en/com-query-response.html#packet-Protocol::ColumnDefinition
+ 	private int joinKeyType = Fields.FIELD_TYPE_LONG; // 默认 join 字段为int型
+ 	
 	//重新路由使用
 	private SystemConfig sysConfig; 
 	private SchemaConfig schema;
@@ -199,7 +206,12 @@ public class ShareJoin implements Catlet {
 			theId=e.getKey();
 			batchRows.put(theId, rows.remove(theId));
 			if (!svalue.equals(e.getValue())){
-			  sb.append(e.getValue()).append(',');
+				if(joinKeyType == Fields.FIELD_TYPE_VAR_STRING 
+						|| joinKeyType == Fields.FIELD_TYPE_STRING){ // joinkey 为varchar
+						sb.append("'").append(e.getValue()).append("'").append(','); // ('digdeep','yuanfang') 
+				}else{ // 默认joinkey为int/long
+					sb.append(e.getValue()).append(','); // (1,2,3) 
+				}
 			}
 			svalue=e.getValue();
 			if (count++ > batchSize) {
@@ -255,12 +267,13 @@ public class ShareJoin implements Catlet {
 		ctx.writeRow(rowDataPkg);
 	}
 	
-	public static int getFieldIndex(List<byte[]> fields,String fkey){
+	public int getFieldIndex(List<byte[]> fields,String fkey){
 		int i=0;
 		for (byte[] field :fields) {	
 			  FieldPacket fieldPacket = new FieldPacket();
 			  fieldPacket.read(field);	
 			  if (ByteUtil.getString(fieldPacket.name).equals(fkey)){
+				  joinKeyType = fieldPacket.type;
 				  return i;				  
 			  }
 			  i++;

--- a/src/main/java/org/opencloudb/route/handler/HintHandlerFactory.java
+++ b/src/main/java/org/opencloudb/route/handler/HintHandlerFactory.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class HintHandlerFactory {
 	
-	private static boolean isInit = false;
+	private static volatile boolean isInit = false;
 	
 	 //sql注释的类型处理handler 集合，现在支持两种类型的处理：sql,schema
     private static Map<String,HintHandler> hintHandlerMap = new HashMap<String,HintHandler>();

--- a/src/main/java/org/opencloudb/route/handler/HintHandlerFactory.java
+++ b/src/main/java/org/opencloudb/route/handler/HintHandlerFactory.java
@@ -18,11 +18,16 @@ public class HintHandlerFactory {
         hintHandlerMap.put("schema",new HintSchemaHandler());
         hintHandlerMap.put("datanode",new HintDataNodeHandler());
         hintHandlerMap.put("catlet",new HintCatletHandler());
+        isInit = true;	// 修复多次初始化的bug
     }
     
+    // 双重校验锁 fix 线程安全问题
     public static HintHandler getHintHandler(String hintType) {
     	if(!isInit) {
-    		init();
+    		synchronized(HintHandlerFactory.class){
+    			if(!isInit)
+    				init();
+    		}
     	}
     	return hintHandlerMap.get(hintType);
     }

--- a/src/main/java/org/opencloudb/sharejoin/TableFilter.java
+++ b/src/main/java/org/opencloudb/sharejoin/TableFilter.java
@@ -270,13 +270,21 @@ public class TableFilter {
 			else
 			  sql=unionsql(sql,getFieldfrom(key)+" as "+val,",");  
 		  }
-        if (parent==null){
+        if (parent==null){	// on/where 等于号左边的表
+        	String parentJoinKey = getJoinKey(true);
+        	// fix sharejoin bug： 
+        	// (AbstractConnection.java:458) -close connection,reason:program err:java.lang.IndexOutOfBoundsException:
+        	// 原因是左表的select列没有包含 join 列，在获取结果时报上面的错误
+        	if(sql != null && parentJoinKey != null &&  
+        			sql.toUpperCase().indexOf(parentJoinKey.trim().toUpperCase()) == -1){
+        		sql += ", " + parentJoinKey;
+        	}
 		   sql="select "+sql+" from "+tName;
 		   if (!(where.trim().equals(""))){
 				sql+=" where "+where.trim(); 	
 			}
         }
-        else {
+        else {	// on/where 等于号右边边的表
         	if (allField) {
         	   sql="select "+sql+" from "+tName;
         	}


### PR DESCRIPTION
share join时，比如：
/*!mycat:catlet=demo.catlets.ShareJoin*/ 
select a.id as aid, b.id as bid, b.name as tit from customer a,company b where a.company_id=b.id 
会报错：close connection,reason:program err:java.lang.IndexOutOfBoundsException:
// 原因是左表的select列没有包含 join 列，在获取结果时报上没的错误
修复就是给他加上join列：
/*!mycat:catlet=demo.catlets.ShareJoin*/ 
select a.id as aid,company_id, b.id as bid, b.name as tit from customer a,company b where a.company_id=b.id 
这样就不会报错了。