### PR TITLE
fix sharejoin bug

### DIFF
--- a/src/main/java/org/opencloudb/route/handler/HintHandlerFactory.java
+++ b/src/main/java/org/opencloudb/route/handler/HintHandlerFactory.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class HintHandlerFactory {
 	
-	private static boolean isInit = false;
+	private static volatile boolean isInit = false;
 	
 	 //sql注释的类型处理handler 集合，现在支持两种类型的处理：sql,schema
     private static Map<String,HintHandler> hintHandlerMap = new HashMap<String,HintHandler>();

--- a/src/main/java/org/opencloudb/route/handler/HintHandlerFactory.java
+++ b/src/main/java/org/opencloudb/route/handler/HintHandlerFactory.java
@@ -18,11 +18,16 @@ public class HintHandlerFactory {
         hintHandlerMap.put("schema",new HintSchemaHandler());
         hintHandlerMap.put("datanode",new HintDataNodeHandler());
         hintHandlerMap.put("catlet",new HintCatletHandler());
+        isInit = true;	// 修复多次初始化的bug
     }
     
+    // 双重校验锁 fix 线程安全问题
     public static HintHandler getHintHandler(String hintType) {
     	if(!isInit) {
-    		init();
+    		synchronized(HintHandlerFactory.class){
+    			if(!isInit)
+    				init();
+    		}
     	}
     	return hintHandlerMap.get(hintType);
     }

--- a/src/main/java/org/opencloudb/sharejoin/TableFilter.java
+++ b/src/main/java/org/opencloudb/sharejoin/TableFilter.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+
 import org.apache.log4j.Logger;
 /**  
  * 功能详细描述:分片join,单独的语句
@@ -270,13 +271,21 @@ public class TableFilter {
 			else
 			  sql=unionsql(sql,getFieldfrom(key)+" as "+val,",");  
 		  }
-        if (parent==null){
+        if (parent==null){	// on/where 等于号左边的表
+        	String parentJoinKey = getJoinKey(true);
+        	// fix sharejoin bug： 
+        	// (AbstractConnection.java:458) -close connection,reason:program err:java.lang.IndexOutOfBoundsException:
+        	// 原因是左表的select列没有包含 join 列，在获取结果时报上面的错误
+        	if(sql != null && parentJoinKey != null &&  
+        			sql.toUpperCase().indexOf(parentJoinKey.trim().toUpperCase()) == -1){
+        		sql += ", " + parentJoinKey;
+        	}
 		   sql="select "+sql+" from "+tName;
 		   if (!(where.trim().equals(""))){
 				sql+=" where "+where.trim(); 	
 			}
         }
-        else {
+        else {	// on/where 等于号右边边的表
         	if (allField) {
         	   sql="select "+sql+" from "+tName;
         	}


### PR DESCRIPTION
share join时，比如：
/*!mycat:catlet=demo.catlets.ShareJoin*/ 
select a.id as aid, b.id as bid, b.name as tit from customer a,company b where a.company_id=b.id 
会报错：close connection,reason:program err:java.lang.IndexOutOfBoundsException:
// 原因是左表的select列没有包含 join 列，在获取结果时报上没的错误
修复就是给他加上join列：
/*!mycat:catlet=demo.catlets.ShareJoin*/ 
select a.id as aid,company_id, b.id as bid, b.name as tit from customer a,company b where a.company_id=b.id 
这样就不会报错了。