### PR TITLE
修复 注解SQL的 sqlType 与 实际SQL的 sqlType 不一致问题

### DIFF
--- a/src/main/java/org/opencloudb/route/handler/HintSQLHandler.java
+++ b/src/main/java/org/opencloudb/route/handler/HintSQLHandler.java
@@ -16,6 +16,7 @@ import org.opencloudb.server.parser.ServerParse;
  * 处理注释中 类型为sql的情况 （按照 注释中的sql做路由解析，而不是实际的sql）
  */
 public class HintSQLHandler implements HintHandler {
+	
 	private RouteStrategy routeStrategy;
 	
 	public HintSQLHandler() {
@@ -27,9 +28,10 @@ public class HintSQLHandler implements HintHandler {
 			int sqlType, String realSQL, String charset, ServerConnection sc,
 			LayerCachePool cachePool, String hintSQLValue)
 			throws SQLNonTransientException {
-
+		
 		RouteResultset rrs = routeStrategy.route(sysConfig, schema, sqlType,
 				hintSQLValue, charset, sc, cachePool);
+		
 		// 替换RRS中的SQL执行
 		RouteResultsetNode[] oldRsNodes = rrs.getNodes();
 		RouteResultsetNode[] newRrsNodes = new RouteResultsetNode[oldRsNodes.length];

--- a/src/main/java/org/opencloudb/route/impl/AbstractRouteStrategy.java
+++ b/src/main/java/org/opencloudb/route/impl/AbstractRouteStrategy.java
@@ -20,7 +20,7 @@ public abstract class AbstractRouteStrategy implements RouteStrategy {
 	private static final Logger LOGGER = Logger.getLogger(AbstractRouteStrategy.class);
 
 	@Override
-	public RouteResultset route(SystemConfig sysConfig, SchemaConfig schema,int sqlType, String origSQL,
+	public RouteResultset route(SystemConfig sysConfig, SchemaConfig schema, int sqlType, String origSQL,
 			String charset, ServerConnection sc, LayerCachePool cachePool) throws SQLNonTransientException {
 
 		/**


### PR DESCRIPTION
rt
例如:/*!mycat: sql=select * from ttt where ttt='26246'*/INSERT INTO ttt
由于sqlType用的是Insert的type(4),会导致报出数组越界的错误