### PR TITLE
fix the quote bug in DefaultSqlInterceptor

### DIFF
--- a/src/main/java/org/opencloudb/interceptor/impl/DefaultSqlInterceptor.java
+++ b/src/main/java/org/opencloudb/interceptor/impl/DefaultSqlInterceptor.java
@@ -1,18 +1,9 @@
 package org.opencloudb.interceptor.impl;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.opencloudb.MycatServer;
 import org.opencloudb.interceptor.SQLInterceptor;
 
 public class DefaultSqlInterceptor implements SQLInterceptor {
-//	private static final Pattern p = Pattern.compile("\\'", Pattern.LITERAL);
-	// fix bug: 无法在字符串的末尾插入 \ 字符的问题. by: digdeep@126.com
-	private static final Pattern p = Pattern.compile("[^\\]\\'", Pattern.LITERAL);
-
-	private static final String TARGET_STRING = "''";
-
 	private static final char ESCAPE_CHAR = '\\';
 
 	private static final int TARGET_STRING_LENGTH = 2;
@@ -21,9 +12,9 @@ public class DefaultSqlInterceptor implements SQLInterceptor {
 	 * mysql driver对'转义与\',解析前改为foundationdb parser支持的'' add by sky
 	 * 
 	 * @param stmt
-	 * @note: 该函数会导致无法正确的插入 \ 字符的问题：
-	 * update travelrecord set name='test\\' where id=1;
- 	 * 插入的name的值会变成：test' 而不是我们期望的 test\
+	 * @update by jason@dayima.com replace regex with general string walking
+	 * avoid sql being destroyed in case of some mismatch
+	 * maybe some performance enchanced
 	 * @return
 	 */
 	public static String processEscape(String sql) {
@@ -31,15 +22,20 @@ public class DefaultSqlInterceptor implements SQLInterceptor {
 		if ((sql == null) || ((firstIndex = sql.indexOf(ESCAPE_CHAR)) == -1)) {
 			return sql;
 		} else {
-			int lastIndex = sql.lastIndexOf(ESCAPE_CHAR, sql.length() - 2);// 不用考虑结尾字符为转义符
-			Matcher matcher = p.matcher(sql.substring(firstIndex, lastIndex
-					+ TARGET_STRING_LENGTH));
-			String replacedStr = (lastIndex == firstIndex) ? matcher
-					.replaceFirst(TARGET_STRING) : matcher
-					.replaceAll(TARGET_STRING);
+			int lastIndex = sql.lastIndexOf(ESCAPE_CHAR, sql.length() - 2) + TARGET_STRING_LENGTH;
 			StringBuilder sb = new StringBuilder(sql);
-			sb.replace(firstIndex, lastIndex + TARGET_STRING_LENGTH,
-					replacedStr);
+			for (int i = firstIndex; i < lastIndex; i ++) {
+				if (sb.charAt(i) == '\\') {
+					if (i + 1 < lastIndex) {
+						if (sb.charAt(i + 1) == '\'') {
+							//replace
+							sb.setCharAt(i, '\'');
+						}
+					}
+					//roll over
+					i ++;
+				}
+			}
 			return sb.toString();
 		}
 	}

--- a/src/test/java/org/opencloudb/parser/TestEscapeProcess.java
+++ b/src/test/java/org/opencloudb/parser/TestEscapeProcess.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNull;
 import java.sql.SQLSyntaxErrorException;
 
 import org.junit.Test;
+import org.opencloudb.MycatServer;
 import org.opencloudb.interceptor.impl.DefaultSqlInterceptor;
 
 public class TestEscapeProcess {
@@ -41,6 +42,7 @@ public class TestEscapeProcess {
 	
 	@Test
 	public void testEscapeProcess() {
+		MycatServer.getInstance().getConfig().getSystem().setDefaultSqlParser("fdbparser");
 		String sqlProcessed = DefaultSqlInterceptor.processEscape(sql);
 		assertEquals(sqlProcessed, sqlret);
 		String sqlProcessed1 = DefaultSqlInterceptor


### PR DESCRIPTION
之前的修正有问题，Pattern为普通字符模式结果修成了正则，但依然应该无法解决sql中边界符单引号的区分问题，可能导致sql破坏。
虽然逻辑目前已不用但代码仍然存在的情况下改为了字符串遍历，另外修复了测试的bug