### PR TITLE
Fixbug: 1. SQL error and tx rollback blocked in client. 2. MySQL backend connection error and Mycat response OK

### DIFF
--- a/src/main/java/org/opencloudb/mysql/nio/handler/MultiNodeHandler.java
+++ b/src/main/java/org/opencloudb/mysql/nio/handler/MultiNodeHandler.java
@@ -113,7 +113,15 @@ abstract class MultiNodeHandler implements ResponseHandler, Terminatable {
 	}
 
 	public void connectionError(Throwable e, BackendConnection conn) {
-		boolean canClose = decrementCountBy(1);
+		final boolean canClose = decrementCountBy(1);
+		// 需要把Throwable e的错误信息保存下来（setFail()）， 否则会导致响应 
+		//null信息，结果mysql命令行等客户端查询结果是"Query OK"！！
+		// @author Uncle-pan
+		// @since 2016-03-26
+		if(canClose){
+			setFail("backend connect: "+e);
+		}
+		LOGGER.warn("backend connect", e);
 		this.tryErrorFinished(canClose);
 	}
 

--- a/src/main/java/org/opencloudb/mysql/nio/handler/MultiNodeHandler.java
+++ b/src/main/java/org/opencloudb/mysql/nio/handler/MultiNodeHandler.java
@@ -45,8 +45,7 @@ abstract class MultiNodeHandler implements ResponseHandler, Terminatable {
 	protected volatile String error;
 	protected byte packetId;
 	protected final AtomicBoolean errorRepsponsed = new AtomicBoolean(false);
-	protected final AtomicBoolean isClosedByDiscard = new AtomicBoolean(false);
-
+	
 	public MultiNodeHandler(NonBlockingSession session) {
 		if (session == null) {
 			throw new IllegalArgumentException("session is null!");
@@ -206,10 +205,6 @@ abstract class MultiNodeHandler implements ResponseHandler, Terminatable {
 	}
 
 	public void connectionClose(BackendConnection conn, String reason) {
-		if(isClosedByDiscard.get()){
-			LOGGER.info(reason);
-			return;
-		}
 		this.setFail("closed connection:" + reason + " con:" + conn);
 		boolean finished = false;
 		lock.lock();

--- a/src/main/java/org/opencloudb/mysql/nio/handler/MultiNodeQueryHandler.java
+++ b/src/main/java/org/opencloudb/mysql/nio/handler/MultiNodeQueryHandler.java
@@ -241,7 +241,12 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements
 			LOGGER.debug("on row end reseponse " + conn);
 		}
 		if (errorRepsponsed.get()) {
-			conn.close(this.error);
+			// the connection has been closed or set to "txInterrupt" properly
+			//in tryErrorFinished() method! If we close it here, it can
+			// lead to tx error such as blocking rollback tx for ever.
+			// @author Uncle-pan
+			// @since 2016-03-25
+			// conn.close(this.error);
 			return;
 		}
 
@@ -469,7 +474,12 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements
 	@Override
 	public void rowResponse(final byte[] row, final BackendConnection conn) {
 		if (errorRepsponsed.get()) {
-			conn.close(error);
+			// the connection has been closed or set to "txInterrupt" properly
+			//in tryErrorFinished() method! If we close it here, it can
+			// lead to tx error such as blocking rollback tx for ever.
+			// @author Uncle-pan
+			// @since 2016-03-25
+			//conn.close(error);
 			return;
 		}
 		lock.lock();
@@ -478,12 +488,12 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements
 					.getAttachment();
 			String dataNode = rNode.getName();
 			if (dataMergeSvr != null) {
-				if (dataMergeSvr.onNewRecord(dataNode, row)) {
-					isClosedByDiscard.set(true);
-					// canClose(conn, false);
-					// conn.discardClose("discard data");
-					// LOGGER.warn(conn);
-				}
+				// even through discarding the all rest data, we can't
+				//close the connection for tx control such as rollback or commit.
+				// So the "isClosedByDiscard" variable is unnecessary.
+				// @author Uncle-pan
+				// @since 2016-03-25
+				dataMergeSvr.onNewRecord(dataNode, row);
 			} else {
 				// cache primaryKey-> dataNode
 				if (primaryKeyIndex != -1) {


### PR DESCRIPTION
一、客户端在SQL出错后回滚时被卡住(Mycat-1.4、1.5)
----------------------------------------------------------------------------------------------------------------------------
例1-1
mysql> begin;
Query OK, 0 rows affected (0.00 sec)

mysql> select id, count(username) from travelrecord group by username order by id;
ERROR 1105 (HY000): java.lang.IllegalArgumentException: all columns in group by clause should be in the selected column list.!username
mysql> select id, username, count(username) from travelrecord group by username order by id;
ERROR 1003 (HY000): Transaction error, need to rollback.java.lang.IllegalArgumentException: all columns in group by clause should be in the selected column list.!username
mysql> rollback;
# 卡住了！！
# 

例1-2
mysql> begin;
Query OK, 0 rows affected (0.00 sec)

mysql> select id, count(username) from travelrecord group by username order by id;
ERROR 1105 (HY000): java.lang.IllegalArgumentException: all columns in group by clause should be in the selected column list.!username
mysql> rollback;
# 卡住了！！
# 

原因是： 在tryErrorFinished()处理出错后，行包结束响应的那里处理时把后端连接关掉了， 导致前端发起rollback命令到后端执行时，抛出了通道关闭异常（这个异常是debug级别的日志记录，在debug开启时才被默默地记入日志！！）， 并不给应用端任何响应， 导致应用端一直在等待响应。

注意： 此bug与mycat进程被hang住的bug是显然不一样的， 由1.4被引入。

二、MySQL backend connection error then Mycat response OK to client

问题分析：当MySQL后端在执行开始查询之前连接错误，回调MultiNodeHandler.connectionError()时， 由于该方法没有保存连接出错的信息（setFail()）， 当canClose时， 把null消息发给了客户端， 结果客户端收到的“Query OK”。

解决方法： 调用setFail()保存异常信息即可。
