### PR TITLE
按月分片添加结束日期（月份）从而循环使用分片

### DIFF
--- a/src/main/java/org/opencloudb/route/util/RouterUtil.java
+++ b/src/main/java/org/opencloudb/route/util/RouterUtil.java
@@ -991,7 +991,19 @@ public class RouterUtil {
 									LOGGER.warn(msg);
 									throw new SQLNonTransientException(msg);
 								}
-								String node = tableConfig.getDataNodes().get(nodeIndex);
+
+								ArrayList<String> dataNodes = tableConfig.getDataNodes();
+								String node;
+								if (nodeIndex >=0 && nodeIndex < dataNodes.size()) {
+									node = dataNodes.get(nodeIndex);
+								} else {
+									node = null;
+									String msg = "Can't find a valid data node for specified node index :"
+											+ tableConfig.getName() + " -> " + tableConfig.getPartitionColumn()
+											+ " -> " + pair.colValue + " -> " + "Index : " + nodeIndex;
+									LOGGER.warn(msg);
+									throw new SQLNonTransientException(msg);
+								}
 								if(node != null) {
 									if(tablesRouteMap.get(tableName) == null) {
 										tablesRouteMap.put(tableName, new HashSet<String>());
@@ -1002,8 +1014,17 @@ public class RouterUtil {
 							if(pair.rangeValue != null) {
 								Integer[] nodeIndexs = tableConfig.getRule().getRuleAlgorithm()
 										.calculateRange(pair.rangeValue.beginValue.toString(), pair.rangeValue.endValue.toString());
+								ArrayList<String> dataNodes = tableConfig.getDataNodes();
+								String node;
 								for(Integer idx : nodeIndexs) {
-									String node = tableConfig.getDataNodes().get(idx);
+									if (idx >= 0 && idx < dataNodes.size()) {
+										node = dataNodes.get(idx);
+									} else {
+										String msg = "Can't find valid data node(s) for some of specified node indexes :"
+												+ tableConfig.getName() + " -> " + tableConfig.getPartitionColumn();
+										LOGGER.warn(msg);
+										throw new SQLNonTransientException(msg);
+									}
 									if(node != null) {
 										if(tablesRouteMap.get(tableName) == null) {
 											tablesRouteMap.put(tableName, new HashSet<String>());

--- a/src/test/java/org/opencloudb/route/function/PartitionByMonthTest.java
+++ b/src/test/java/org/opencloudb/route/function/PartitionByMonthTest.java
@@ -46,5 +46,43 @@ public class PartitionByMonthTest {
 		Assert.assertEquals(true, 11 == partition.calculate("2014-12-31"));
 		Assert.assertEquals(true, 12 == partition.calculate("2015-01-31"));
 		Assert.assertEquals(true, 23 == partition.calculate("2015-12-31"));
+
+		partition.setDateFormat("yyyy-MM-dd");
+		partition.setsBeginDate("2015-01-01");
+		partition.setsEndDate("2015-12-01");
+
+		partition.init();
+
+		/**
+		 *  0 : 2016-01-01~31, 2015-01-01~31, 2014-01-01~31
+		 *  1 : 2016-02-01~28, 2015-02-01~28, 2014-02-01~28
+		 *  5 : 2016-06-01~30, 2015-06-01~30, 2014-06-01~30
+		 * 11 : 2016-12-01~31, 2015-12-01~31, 2014-12-01~31
+		 */
+
+		Assert.assertEquals(true, 0 == partition.calculate("2013-01-02"));
+		Assert.assertEquals(true, 0 == partition.calculate("2014-01-01"));
+		Assert.assertEquals(true, 0 == partition.calculate("2015-01-10"));
+		Assert.assertEquals(true, 0 == partition.calculate("2015-01-31"));
+		Assert.assertEquals(true, 0 == partition.calculate("2016-01-20"));
+
+		Assert.assertEquals(true, 1 == partition.calculate("2013-02-02"));
+		Assert.assertEquals(true, 1 == partition.calculate("2014-02-01"));
+		Assert.assertEquals(true, 1 == partition.calculate("2015-02-10"));
+		Assert.assertEquals(true, 1 == partition.calculate("2015-02-28"));
+		Assert.assertEquals(true, 1 == partition.calculate("2016-02-20"));
+
+		Assert.assertEquals(true, 5 == partition.calculate("2013-06-01"));
+		Assert.assertEquals(true, 5 == partition.calculate("2014-06-01"));
+		Assert.assertEquals(true, 5 == partition.calculate("2015-06-10"));
+		Assert.assertEquals(true, 5 == partition.calculate("2015-06-28"));
+		Assert.assertEquals(true, 5 == partition.calculate("2016-06-20"));
+
+		Assert.assertEquals(true, 11 == partition.calculate("2013-12-28"));
+		Assert.assertEquals(true, 11 == partition.calculate("2014-12-01"));
+		Assert.assertEquals(true, 11 == partition.calculate("2014-12-31"));
+		Assert.assertEquals(true, 11 == partition.calculate("2015-12-11"));
+		Assert.assertEquals(true, 11 == partition.calculate("2016-12-31"));
+
 	}
 }


### PR DESCRIPTION
代码改动
=======
1. 按月分片设置起始月份范围从而循环使用，对落在此范围外的数据通过计算偏移得到目标分片

2. 通过分片规则计算出节点值后检查节点值是否在对应的table合理的data node区间，如果计算出的
节点值没有对应的data node节点，则打印一条错误信息

单元测试
=======
1. 按月循环分片
测试四个分片，分片日期从2016年5月到2016年8月，日期格式为 20160501 和 2016-05-01
测试日期范围从2014年1月到2017年12月

2. 没有对应data node节点的情况
这里只测试了原始的按月分片情况下， 分片日期从2016年5月开始
MySQL [TESTDB]> explain insert into test4ptn_date2(id, date) values (1, '2016-09-22');
ERROR 1064 (HY000): Can't find a valid data node for specified node index :TEST4PTN_DATE2 -> DATE -> 2016-09-22 -> Index : 4
MySQL [TESTDB]> explain insert into test4ptn_date2(id, date) values (1, '2015-09-22');
ERROR 1064 (HY000): Can't find a valid data node for specified node index :TEST4PTN_DATE2 -> DATE -> 2015-09-22 -> Index: -8

之前遇到这种情况，mycat直接抛出 java.lang.IndexOutOfBoundsException: Index: 7, Size: 7 类似的
异常

其他综合测试
==========
分片规则相对其他模块相对独立，对单个分片规则的修改不会影响到其他的代码逻辑，因此
这里综合测试可以忽略。