### PR TITLE
1.6 	兼容PhpAdmin's 控制台管理, 为此支持对MySQL元数据的模拟返回，现在达到可用状态

### DIFF
--- a/src/main/java/io/mycat/server/handler/MysqlInformationSchemaHandler.java
+++ b/src/main/java/io/mycat/server/handler/MysqlInformationSchemaHandler.java
@@ -1,0 +1,86 @@
+package io.mycat.server.handler;
+
+import java.nio.ByteBuffer;
+
+import io.mycat.backend.mysql.PacketUtil;
+import io.mycat.config.Fields;
+import io.mycat.net.mysql.EOFPacket;
+import io.mycat.net.mysql.FieldPacket;
+import io.mycat.net.mysql.OkPacket;
+import io.mycat.net.mysql.ResultSetHeaderPacket;
+import io.mycat.server.ServerConnection;
+import io.mycat.server.util.SchemaUtil;
+
+
+/**
+ * 对 PhpAdmin's 控制台操作进行支持 
+ * 
+ * 如：SELECT * FROM information_schema.CHARACTER_SETS 等相关语句进行模拟返回
+ * 
+ * @author zhuam
+ *
+ */
+public class MysqlInformationSchemaHandler {
+	
+	/**
+	 * 写入数据包
+	 * @param field_count
+	 * @param fields
+	 * @param c
+	 */
+	private static void doWrite(int field_count, FieldPacket[] fields, ServerConnection c) {
+		
+		ByteBuffer buffer = c.allocate();
+
+		// write header
+		ResultSetHeaderPacket header = PacketUtil.getHeader(field_count);
+		byte packetId = header.packetId;
+		buffer = header.write(buffer, c, true);
+
+		// write fields
+		for (FieldPacket field : fields) {
+			field.packetId = ++packetId;
+			buffer = field.write(buffer, c, true);
+		}
+
+		// write eof
+		EOFPacket eof = new EOFPacket();
+		eof.packetId = ++packetId;
+		buffer = eof.write(buffer, c, true);
+
+		// write last eof
+		EOFPacket lastEof = new EOFPacket();
+		lastEof.packetId = ++packetId;
+		buffer = lastEof.write(buffer, c, true);
+
+		// post write
+		c.write(buffer);
+		
+	}
+	
+	public static void handle(String sql, ServerConnection c) {
+		
+		SchemaUtil.SchemaInfo schemaInfo = SchemaUtil.parseSchema(sql);
+		if ( schemaInfo != null ) {
+			
+			if ( schemaInfo.table.toUpperCase().equals("CHARACTER_SETS") ) {
+				
+				//模拟列头
+				int field_count = 4;
+			    FieldPacket[] fields = new FieldPacket[field_count];
+			    fields[0] = PacketUtil.getField("CHARACTER_SET_NAME", Fields.FIELD_TYPE_VAR_STRING);
+				fields[1] = PacketUtil.getField("DEFAULT_COLLATE_NAME", Fields.FIELD_TYPE_VAR_STRING);
+			    fields[2] = PacketUtil.getField("DESCRIPTION", Fields.FIELD_TYPE_VAR_STRING);
+				fields[3] = PacketUtil.getField("MAXLEN", Fields.FIELD_TYPE_LONG);
+				
+				doWrite(field_count, fields, c);				
+				
+			} else {
+				c.write(c.writeToBuffer(OkPacket.OK, c.allocate()));
+			}			
+			
+		} else {
+			c.write(c.writeToBuffer(OkPacket.OK, c.allocate()));
+		}		
+	}
+}

--- a/src/main/java/io/mycat/server/handler/SetHandler.java
+++ b/src/main/java/io/mycat/server/handler/SetHandler.java
@@ -117,8 +117,25 @@ public final class SetHandler {
 			if (c.setCharset(charset)) {
 				c.write(c.writeToBuffer(OkPacket.OK, c.allocate()));
 			} else {
-				c.writeErrMessage(ErrorCode.ER_UNKNOWN_CHARACTER_SET,
-						"Unknown charset '" + charset + "'");
+				
+				/**
+				 * TODO：修复 phpAyAdmin's 的发包问题
+				 * 如： SET NAMES 'utf8' COLLATE 'utf8_general_ci' 错误
+				 */	
+				int beginIndex = stmt.toLowerCase().indexOf("names");
+				int endIndex = stmt.toLowerCase().indexOf("collate");
+				if ( beginIndex > -1 && endIndex > -1 ) {					
+					charset = stmt.substring(beginIndex + "names".length(), endIndex);					
+					//重试一次
+					if (c.setCharset( charset.trim() )) {
+						c.write(c.writeToBuffer(OkPacket.OK, c.allocate()));
+					} else {
+						c.writeErrMessage(ErrorCode.ER_UNKNOWN_CHARACTER_SET, "Unknown charset '" + charset + "'");
+					}	
+					
+				} else {				
+					c.writeErrMessage(ErrorCode.ER_UNKNOWN_CHARACTER_SET, "Unknown charset '" + charset + "'");
+				}
 			}
 			break;
 		case CHARACTER_SET_CLIENT:

--- a/src/main/java/io/mycat/server/util/SchemaUtil.java
+++ b/src/main/java/io/mycat/server/util/SchemaUtil.java
@@ -36,9 +36,19 @@ public class SchemaUtil
             {
                 db = schemaConfigMap.entrySet().iterator().next().getKey();
             }
-
-            if(schemaInfo!=null&&schemaInfo.schema!=null&&schemaConfigMap.containsKey(schemaInfo.schema)  )
-                db= schemaInfo.schema;
+            
+            if (schemaInfo != null && schemaInfo.schema != null ) {
+            	
+				if ( schemaConfigMap.containsKey(schemaInfo.schema) ) {
+					db = schemaInfo.schema;			
+					
+				/**
+				 * 对 MySQL 自带的元数据库 information_schema 进行返回
+				 */
+				} else if ( "information_schema".equalsIgnoreCase( schemaInfo.schema ) ) {
+					db = "information_schema";					
+				}
+			}
         }
         else
         if(ServerParse.INSERT==type||ServerParse.UPDATE==type||ServerParse.DELETE==type||ServerParse.DDL==type)


### PR DESCRIPTION
rt
1、 SET NAMES 'utf8' COLLATE 'utf8_general_ci' 错误处理
2、	兼容PhpAdmin's 控制台管理, 为此支持对MySQL元数据的模拟返回，现在达到可用状态