### PR TITLE
1. 改善两种基于ZK的全局ID生成算法单元测试2. 在MyCat载入配置中正式加入两种基于ZK的全局ID生成算法

### DIFF
--- a/src/main/java/demo/catlets/BatchInsertSequence.java
+++ b/src/main/java/demo/catlets/BatchInsertSequence.java
@@ -1,5 +1,6 @@
 package demo.catlets;
 
+import io.mycat.route.sequence.handler.*;
 import org.slf4j.Logger; import org.slf4j.LoggerFactory;
 
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -18,10 +19,6 @@ import io.mycat.config.model.TableConfig;
 import io.mycat.route.RouteResultset;
 import io.mycat.route.RouteResultsetNode;
 import io.mycat.route.factory.RouteStrategyFactory;
-import io.mycat.route.sequence.handler.IncrSequenceMySQLHandler;
-import io.mycat.route.sequence.handler.IncrSequencePropHandler;
-import io.mycat.route.sequence.handler.IncrSequenceTimeHandler;
-import io.mycat.route.sequence.handler.SequenceHandler;
 import io.mycat.server.ServerConnection;
 import io.mycat.server.parser.ServerParse;
 import io.mycat.sqlengine.Catlet;
@@ -104,6 +101,12 @@ public class BatchInsertSequence implements Catlet {
 							break;
 						case SystemConfig.SEQUENCEHANDLER_LOCAL_TIME:
 							sequenceHandler = IncrSequenceTimeHandler.getInstance();
+							break;
+						case SystemConfig.SEQUENCEHANDLER_ZK_DISTRIBUTED:
+							sequenceHandler = DistributedSequenceHandler.getInstance(MycatServer.getInstance().getConfig().getSystem());
+							break;
+						case SystemConfig.SEQUENCEHANDLER_ZK_GLOBAL_INCREMENT:
+							sequenceHandler = IncrSequenceZKHandler.getInstance();
 							break;
 						default:
 							throw new java.lang.IllegalArgumentException("Invalid sequnce handler type "+seqHandlerType);

--- a/src/main/java/io/mycat/config/ConfigInitializer.java
+++ b/src/main/java/io/mycat/config/ConfigInitializer.java
@@ -45,8 +45,10 @@ import io.mycat.config.model.SchemaConfig;
 import io.mycat.config.model.SystemConfig;
 import io.mycat.config.model.UserConfig;
 import io.mycat.config.util.ConfigException;
+import io.mycat.route.sequence.handler.DistributedSequenceHandler;
 import io.mycat.route.sequence.handler.IncrSequenceMySQLHandler;
 import io.mycat.route.sequence.handler.IncrSequenceTimeHandler;
+import io.mycat.route.sequence.handler.IncrSequenceZKHandler;
 
 /**
  * @author mycat
@@ -84,6 +86,12 @@ public class ConfigInitializer {
 		}
 		if (system.getSequnceHandlerType() == SystemConfig.SEQUENCEHANDLER_LOCAL_TIME) {
 			IncrSequenceTimeHandler.getInstance().load();
+		}
+		if (system.getSequnceHandlerType() == SystemConfig.SEQUENCEHANDLER_ZK_DISTRIBUTED) {
+			DistributedSequenceHandler.getInstance(system).load();
+		}
+		if (system.getSequnceHandlerType() == SystemConfig.SEQUENCEHANDLER_ZK_GLOBAL_INCREMENT) {
+			IncrSequenceZKHandler.getInstance().load();
 		}
 		//检查user与schema配置对应以及schema配置不为空
 		this.checkConfig();

--- a/src/main/java/io/mycat/config/model/SystemConfig.java
+++ b/src/main/java/io/mycat/config/model/SystemConfig.java
@@ -96,6 +96,8 @@ public final class SystemConfig {
 	public static final int SEQUENCEHANDLER_LOCALFILE = 0;
 	public static final int SEQUENCEHANDLER_MYSQLDB = 1;
 	public static final int SEQUENCEHANDLER_LOCAL_TIME = 2;
+	public static final int SEQUENCEHANDLER_ZK_DISTRIBUTED = 3;
+	public static final int SEQUENCEHANDLER_ZK_GLOBAL_INCREMENT = 4;
 	private int sequnceHandlerType = SEQUENCEHANDLER_LOCALFILE;
 	private String sqlInterceptor = "io.mycat.server.interceptor.impl.DefaultSqlInterceptor";
 	private String sqlInterceptorType = "select";

--- a/src/main/java/io/mycat/route/parser/ManagerParseShow.java
+++ b/src/main/java/io/mycat/route/parser/ManagerParseShow.java
@@ -75,7 +75,8 @@ public final class ManagerParseShow {
 
     public static final int WHITE_HOST=42;
     public static final int WHITE_HOST_SET=43;
-    
+
+
     public static int parse(String stmt, int offset) {
         int i = offset;
         for (; i < stmt.length(); i++) {

--- a/src/main/java/io/mycat/route/parser/druid/DruidSequenceHandler.java
+++ b/src/main/java/io/mycat/route/parser/druid/DruidSequenceHandler.java
@@ -1,80 +1,85 @@
 package io.mycat.route.parser.druid;
 
+import io.mycat.MycatServer;
+import io.mycat.config.model.SystemConfig;
+import io.mycat.route.sequence.handler.*;
+
 import java.io.UnsupportedEncodingException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.mycat.config.model.SystemConfig;
-import io.mycat.route.sequence.handler.IncrSequenceMySQLHandler;
-import io.mycat.route.sequence.handler.IncrSequencePropHandler;
-import io.mycat.route.sequence.handler.IncrSequenceTimeHandler;
-import io.mycat.route.sequence.handler.SequenceHandler;
-
 /**
  * 使用Druid解析器实现对Sequence处理
+ *
  * @author 兵临城下
  * @date 2015/03/13
  */
 public class DruidSequenceHandler {
-	private final SequenceHandler sequenceHandler;
+    private final SequenceHandler sequenceHandler;
 
-	/** 获取MYCAT SEQ的匹配语句 */
-	private final static String MATCHED_FEATURE = "NEXT VALUE FOR MYCATSEQ_";
+    /**
+     * 获取MYCAT SEQ的匹配语句
+     */
+    private final static String MATCHED_FEATURE = "NEXT VALUE FOR MYCATSEQ_";
 
-    private final static   Pattern pattern = Pattern.compile("(?:(\\s*next\\s+value\\s+for\\s*MYCATSEQ_(\\w+))(,|\\)|\\s)*)+", Pattern.CASE_INSENSITIVE);
-	
-	public DruidSequenceHandler(int seqHandlerType) {
-		switch(seqHandlerType){
-		case SystemConfig.SEQUENCEHANDLER_MYSQLDB:
-			sequenceHandler = IncrSequenceMySQLHandler.getInstance();
-			break;
-		case SystemConfig.SEQUENCEHANDLER_LOCALFILE:
-			sequenceHandler = IncrSequencePropHandler.getInstance();
-			break;
-		case SystemConfig.SEQUENCEHANDLER_LOCAL_TIME:
-			sequenceHandler = IncrSequenceTimeHandler.getInstance();
-			break;
-		default:
-			throw new java.lang.IllegalArgumentException("Invalid sequnce handler type "+seqHandlerType);
-		}
-	}
+    private final static Pattern pattern = Pattern.compile("(?:(\\s*next\\s+value\\s+for\\s*MYCATSEQ_(\\w+))(,|\\)|\\s)*)+", Pattern.CASE_INSENSITIVE);
 
-	/**
-	 * 根据原sql获取可执行的sql
-	 * @param sql
-	 * @return
-	 * @throws UnsupportedEncodingException
-	 */
-	public String getExecuteSql(String sql,String charset) throws UnsupportedEncodingException{
-		String executeSql = null;
-		if (null!=sql && !"".equals(sql)) {
-             //sql不能转大写，因为sql可能是insert语句会把values也给转换了
-			// 获取表名。
+    public DruidSequenceHandler(int seqHandlerType) {
+        switch (seqHandlerType) {
+            case SystemConfig.SEQUENCEHANDLER_MYSQLDB:
+                sequenceHandler = IncrSequenceMySQLHandler.getInstance();
+                break;
+            case SystemConfig.SEQUENCEHANDLER_LOCALFILE:
+                sequenceHandler = IncrSequencePropHandler.getInstance();
+                break;
+            case SystemConfig.SEQUENCEHANDLER_LOCAL_TIME:
+                sequenceHandler = IncrSequenceTimeHandler.getInstance();
+                break;
+            case SystemConfig.SEQUENCEHANDLER_ZK_DISTRIBUTED:
+                sequenceHandler = DistributedSequenceHandler.getInstance(MycatServer.getInstance().getConfig().getSystem());
+                break;
+            case SystemConfig.SEQUENCEHANDLER_ZK_GLOBAL_INCREMENT:
+                sequenceHandler = IncrSequenceZKHandler.getInstance();
+                break;
+            default:
+                throw new java.lang.IllegalArgumentException("Invalid sequnce handler type " + seqHandlerType);
+        }
+    }
+
+    /**
+     * 根据原sql获取可执行的sql
+     *
+     * @param sql
+     * @return
+     * @throws UnsupportedEncodingException
+     */
+    public String getExecuteSql(String sql, String charset) throws UnsupportedEncodingException {
+        String executeSql = null;
+        if (null != sql && !"".equals(sql)) {
+            //sql不能转大写，因为sql可能是insert语句会把values也给转换了
+            // 获取表名。
             Matcher matcher = pattern.matcher(sql);
-              if(matcher.find())
-              {
-                  String tableName = matcher.group(2);
-                  long value = sequenceHandler.nextId(tableName.toUpperCase());
+            if (matcher.find()) {
+                String tableName = matcher.group(2);
+                long value = sequenceHandler.nextId(tableName.toUpperCase());
 
-                  // 将MATCHED_FEATURE+表名替换成序列号。
-                  executeSql = sql.replace(matcher.group(1), " "+value);
-              }
+                // 将MATCHED_FEATURE+表名替换成序列号。
+                executeSql = sql.replace(matcher.group(1), " " + value);
+            }
 
-		}
-		return executeSql;
-	}
+        }
+        return executeSql;
+    }
 
 
     //just for test
-	public String getTableName(String sql) {
+    public String getTableName(String sql) {
         Matcher matcher = pattern.matcher(sql);
-        if(matcher.find())
-        {
-          return  matcher.group(2);
+        if (matcher.find()) {
+            return matcher.group(2);
         }
         return null;
-	}
-
+    }
 
 
 }

--- a/src/main/java/io/mycat/route/sequence/handler/IncrSequenceZKHandler.java
+++ b/src/main/java/io/mycat/route/sequence/handler/IncrSequenceZKHandler.java
@@ -59,6 +59,11 @@ public class IncrSequenceZKHandler extends IncrSequenceHandler {
     private final static String PATH = "/mycat/incr_sequence";
     private final static String LOCK = "/lock";
     private final static String SEQ = "/seq";
+    private final static IncrSequenceZKHandler instance = new IncrSequenceZKHandler();
+
+    public static IncrSequenceZKHandler getInstance(){
+        return instance;
+    }
 
     private ThreadLocal<Map<String, Map<String, String>>> tableParaValMapThreadLocal = new ThreadLocal<>();
 
@@ -124,7 +129,7 @@ public class IncrSequenceZKHandler extends IncrSequenceHandler {
                     String val = props.getProperty(table + KEY_MIN_NAME);
                     client.create().creatingParentsIfNeeded().withMode(CreateMode.PERSISTENT).forPath(PATH + "/" + table + SEQ, val.getBytes());
                 } catch (Exception e) {
-                    LOGGER.info("Node exists! Maybe other instance is initializing!");
+                    LOGGER.debug("Node exists! Maybe other instance is initializing!");
                 }
             }
             fetchNextPeriod(table);

--- a/src/test/java/io/mycat/sequence/DistributedSequenceHandlerTest.java
+++ b/src/test/java/io/mycat/sequence/DistributedSequenceHandlerTest.java
@@ -31,7 +31,7 @@ public class DistributedSequenceHandlerTest {
         testingServer = new TestingServer();
         testingServer.start();
         for (int i = 0; i < 16; i++) {
-            distributedSequenceHandler[i] = new DistributedSequenceHandler(mycatConfig);
+            distributedSequenceHandler[i] = new DistributedSequenceHandler(mycatConfig.getSystem());
             distributedSequenceHandler[i].initializeZK(testingServer.getConnectString());
             distributedSequenceHandler[i].nextId("");
         }
@@ -76,7 +76,7 @@ public class DistributedSequenceHandlerTest {
             };
             thread[i].start();
         }
-        for (int i = 0; i < 100 ; i++) {
+        for (int i = 0; i < 100; i++) {
             thread[i].join();
         }
         long end = System.currentTimeMillis();
@@ -95,28 +95,28 @@ public class DistributedSequenceHandlerTest {
         Set<Long> idSet = new HashSet<>();
         try {
             int leader = failLeader(17);
-            System.out.println("断掉一个leader节点后");
+            System.out.println("***断掉一个leader节点后（curator会抛对应的异常断链异常，不用在意）***：");
             for (int i = 0; i < 16; i++) {
                 if (i == leader) {
-                    System.out.println(i + " used to be leader");
+                    System.out.println("Node [" + i + "] used to be leader");
                     continue;
                 }
                 distributedSequenceHandler[i].nextId("");
-                System.out.println(i + "[is leader:" + distributedSequenceHandler[i].getLeaderSelector().hasLeadership() + "]");
+                System.out.println("Node [" + i + "]is leader:" + distributedSequenceHandler[i].getLeaderSelector().hasLeadership() );
                 System.out.println(" InstanceID:" + distributedSequenceHandler[i].getInstanceId());
                 idSet.add(distributedSequenceHandler[i].getInstanceId());
             }
             Assert.assertEquals(idSet.size(), 15);
             idSet = new HashSet<>();
             int leader2 = failLeader(leader);
-            System.out.println("断掉两个leader节点后");
+            System.out.println("***断掉两个leader节点后（curator会抛对应的异常断链异常，不用在意）***：");
             for (int i = 0; i < 16; i++) {
                 if (i == leader || i == leader2) {
-                    System.out.println(i + " used to be leader");
+                    System.out.println("Node ["+i + " used to be leader");
                     continue;
                 }
                 distributedSequenceHandler[i].nextId("");
-                System.out.println(i + "[is leader:" + distributedSequenceHandler[i].getLeaderSelector().hasLeadership() + "]");
+                System.out.println("Node ["+i + "]is leader:" + distributedSequenceHandler[i].getLeaderSelector().hasLeadership());
                 System.out.println(" InstanceID:" + distributedSequenceHandler[i].getInstanceId());
                 idSet.add(distributedSequenceHandler[i].getInstanceId());
             }
@@ -124,15 +124,15 @@ public class DistributedSequenceHandlerTest {
 
             idSet = new HashSet<>();
             MycatConfig mycatConfig = new MycatConfig();
-            distributedSequenceHandler[leader] = new DistributedSequenceHandler(mycatConfig);
+            distributedSequenceHandler[leader] = new DistributedSequenceHandler(mycatConfig.getSystem());
             distributedSequenceHandler[leader].initializeZK(testingServer.getConnectString());
             distributedSequenceHandler[leader].nextId("");
-            distributedSequenceHandler[leader2] = new DistributedSequenceHandler(mycatConfig);
+            distributedSequenceHandler[leader2] = new DistributedSequenceHandler(mycatConfig.getSystem());
             distributedSequenceHandler[leader2].initializeZK(testingServer.getConnectString());
             distributedSequenceHandler[leader2].nextId("");
             System.out.println("新加入两个节点后");
             for (int i = 0; i < 16; i++) {
-                System.out.println(i + "[is leader:" + distributedSequenceHandler[i].getLeaderSelector().hasLeadership() + "]");
+                System.out.println("Node ["+i + "]is leader:" + distributedSequenceHandler[i].getLeaderSelector().hasLeadership() );
                 System.out.println(" InstanceID:" + distributedSequenceHandler[i].getInstanceId());
                 idSet.add(distributedSequenceHandler[i].getInstanceId());
             }
@@ -144,7 +144,7 @@ public class DistributedSequenceHandlerTest {
 
     }
 
-    private int failLeader(int p){
+    private int failLeader(int p) {
         int leader = 0, follower = 0;
         for (int i = 0; i < 16; i++) {
             if (i == p) continue;
@@ -153,7 +153,7 @@ public class DistributedSequenceHandlerTest {
             } else {
                 follower = i;
             }
-            System.out.println(i + "[is leader:" + distributedSequenceHandler[i].getLeaderSelector().hasLeadership() + "]");
+            System.out.println("Node ["+i + "]is leader:" + distributedSequenceHandler[i].getLeaderSelector().hasLeadership() );
             System.out.println(" InstanceID:" + distributedSequenceHandler[i].getInstanceId());
         }
         try {

--- a/src/test/java/io/mycat/sequence/IncrSequenceZKHandlerTest.java
+++ b/src/test/java/io/mycat/sequence/IncrSequenceZKHandlerTest.java
@@ -22,8 +22,8 @@ import java.util.concurrent.ConcurrentSkipListSet;
  * @time 23:35 2016/5/6
  */
 public class IncrSequenceZKHandlerTest {
-    private final static int MAX_CONNECTION = 60;
-    private final static int threadCount = 20;
+    private final static int MAX_CONNECTION = 10;
+    private final static int threadCount = 10;
     private final static int LOOP = 50;
     TestingServer testingServer = null;
     IncrSequenceZKHandler incrSequenceZKHandler[];


### PR DESCRIPTION
1. 改善两种基于ZK的全局ID生成算法单元测试
2. 在MyCat载入配置中正式加入两种基于ZK的全局ID生成算法，配置如下
```
<system>
	<!--分布式ZK ID生成器-->
	<property name="sequnceHandlerType">3</property>
</system>

<system>
	<!--分布式ZK 全局自增ID生成器-->
	<property name="sequnceHandlerType">4</property>
</system>
```