### PR TITLE
mycat1.6 自动化扩容缩容工具，支持任意路由规则

### DIFF
--- a/src/main/assembly/bin/dataMigrate.sh
+++ b/src/main/assembly/bin/dataMigrate.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+#check JAVA_HOME & java
+noJavaHome=false
+if [ -z "$JAVA_HOME" ] ; then
+    noJavaHome=true
+fi
+if [ ! -e "$JAVA_HOME/bin/java" ] ; then
+    noJavaHome=true
+fi
+if $noJavaHome ; then
+    echo
+    echo "Error: JAVA_HOME environment variable is not set."
+    echo
+    exit 1
+fi
+#==============================================================================
+#set JAVA_OPTS
+JAVA_OPTS="-server -Xms2G -Xmx2G -XX:MaxPermSize=64M  -XX:+AggressiveOpts -XX:MaxDirectMemorySize=2G"
+#JAVA_OPTS="-server -Xms4G -Xmx4G -XX:MaxPermSize=64M  -XX:+AggressiveOpts -XX:MaxDirectMemorySize=6G"
+#performance Options
+#JAVA_OPTS="$JAVA_OPTS -Xss256k"
+#JAVA_OPTS="$JAVA_OPTS -XX:+AggressiveOpts"
+#JAVA_OPTS="$JAVA_OPTS -XX:+UseBiasedLocking"
+#JAVA_OPTS="$JAVA_OPTS -XX:+UseFastAccessorMethods"
+#JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
+#JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
+#JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
+#JAVA_OPTS="$JAVA_OPTS -XX:+CMSParallelRemarkEnabled"
+#JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSCompactAtFullCollection"
+#JAVA_OPTS="$JAVA_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
+#JAVA_OPTS="$JAVA_OPTS -XX:CMSInitiatingOccupancyFraction=75"
+#JAVA_OPTS="$JAVA_OPTS -XX:CMSInitiatingOccupancyFraction=75"
+#GC Log Options
+#JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCApplicationStoppedTime"
+#JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCTimeStamps"
+#JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDetails"
+#debug Options
+#JAVA_OPTS="$JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=8065,server=y,suspend=n"
+#==============================================================================
+
+#set HOME
+CURR_DIR=`pwd`
+cd `dirname "$0"`/..
+MYCAT_HOME=`pwd`
+cd $CURR_DIR
+if [ -z "$MYCAT_HOME" ] ; then
+    echo
+    echo "Error: MYCAT_HOME environment variable is not defined correctly."
+    echo
+    exit 1
+fi
+#==============================================================================
+
+#set CLASSPATH
+MYCAT_CLASSPATH="$MYCAT_HOME/conf:$MYCAT_HOME/lib/classes"
+for i in "$MYCAT_HOME"/lib/*.jar
+do
+    MYCAT_CLASSPATH="$MYCAT_CLASSPATH:$i"
+done
+#==============================================================================
+#startup Server
+RUN_CMD="\"$JAVA_HOME/bin/java\""
+RUN_CMD="$RUN_CMD -DMYCAT_HOME=\"$MYCAT_HOME\""
+RUN_CMD="$RUN_CMD -classpath \"$MYCAT_CLASSPATH\""
+RUN_CMD="$RUN_CMD $JAVA_OPTS"
+RUN_CMD="$RUN_CMD io.mycat.util.dataMigrator.DataMigrator "
+#to specify the following main args
+#临时文件路径,目录不存在将自动创建，不指定此目录则默认为mycat根下的temp目录
+RUN_CMD="$RUN_CMD -tempFileDir=/chunk1/haonan/temp"
+#默认true：不论是否发生主备切换，都使用主数据源数据，false：使用当前数据源                  
+RUN_CMD="$RUN_CMD -isAwaysUseMaster=true"
+#mysql bin路径
+RUN_CMD="$RUN_CMD -mysqlBin=/home/iddbs/mysql5.6/bin"
+#mysqldump命令行长度限制字节数 默认110k
+RUN_CMD="$RUN_CMD -cmdLength=110*1024"
+#导入导出数据所用字符集 默认utf8
+RUN_CMD="$RUN_CMD -charset=utf8"
+#完成扩容缩容后是否删除临时文件 默认为true
+RUN_CMD="$RUN_CMD -deleteTempFileDir=true"
+#performance Options
+#并行线程数（涉及生成中间文件和导入导出数据）默认为迁移程序所在主机环境的cpu核数*2
+RUN_CMD="$RUN_CMD -threadCount="
+#每个数据库主机上清理冗余数据的并发线程数，默认为当前脚本程序所在主机cpu核数/2
+RUN_CMD="$RUN_CMD -delThreadCount="
+#读取迁移节点全部数据时一次加载的数据量 默认100000                    
+RUN_CMD="$RUN_CMD -queryPageSize="
+
+echo $RUN_CMD
+eval $RUN_CMD
+#==============================================================================

--- a/src/main/java/io/mycat/util/dataMigrator/ConfigComparer.java
+++ b/src/main/java/io/mycat/util/dataMigrator/ConfigComparer.java
@@ -1,0 +1,261 @@
+package io.mycat.util.dataMigrator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.mycat.config.loader.SchemaLoader;
+import io.mycat.config.loader.xml.XMLSchemaLoader;
+import io.mycat.config.model.DBHostConfig;
+import io.mycat.config.model.DataHostConfig;
+import io.mycat.config.model.DataNodeConfig;
+import io.mycat.config.model.SchemaConfig;
+import io.mycat.config.model.TableConfig;
+import io.mycat.config.model.rule.RuleConfig;
+import io.mycat.config.util.ConfigException;
+import io.mycat.route.function.AbstractPartitionAlgorithm;
+
+/**
+ * 数据迁移新旧配置文件加载、对比
+ * @author haonan108
+ *
+ */
+public class ConfigComparer {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ConfigComparer.class);
+	/*
+	 *指定需要进行数据迁移的表及对应schema
+	 * 配置文件格式
+	 * schema1=tb1,tb2,...
+	 * schema2=all
+	 * ...
+	 */
+	private final static String TABLES_FILE = "/migrateTables.properties";  
+    private final static String NEW_SCHEMA = "/newSchema.xml";
+	private final static String NEW_RULE = "/newRule.xml";
+	private final static String DN_INDEX_FILE = "/dnindex.properties";
+	
+	private SchemaLoader oldLoader;
+	private SchemaLoader newLoader;
+	
+	private  Map<String, DataHostConfig>  oldDataHosts;
+	private  Map<String, DataNodeConfig>  oldDataNodes;
+	private  Map<String, SchemaConfig>  oldSchemas; 
+	
+	private  Map<String, DataHostConfig> newDataHosts;
+	private  Map<String, DataNodeConfig> newDataNodes;
+	private  Map<String, SchemaConfig> newSchemas;
+	
+	//即使发生主备切换也使用主数据源
+	private boolean isAwaysUseMaster;
+	private Properties dnIndexProps;
+	
+	//此类主要目的是通过加载新旧配置文件来获取表迁移信息，migratorTables就是最终要获取的迁移信息集合
+	private List<TableMigrateInfo> migratorTables = new ArrayList<TableMigrateInfo>();
+	
+	public ConfigComparer(boolean isAwaysUseMaster) throws Exception{
+		this.isAwaysUseMaster = isAwaysUseMaster;
+		loadOldConfig();
+		loadNewConfig();
+		loadTablesFile();
+	}
+	
+	public List<TableMigrateInfo> getMigratorTables(){
+		return migratorTables;
+	}
+	
+	private void loadOldConfig(){
+		try{
+			oldLoader = new XMLSchemaLoader();
+			oldDataHosts = oldLoader.getDataHosts();
+			oldDataNodes = oldLoader.getDataNodes();
+			oldSchemas = oldLoader.getSchemas();
+		}catch(Exception e){
+			throw new ConfigException(" old config for migrate read fail!please check schema.xml or  rule.xml  "+e);
+		}
+		
+	}
+	
+	private void loadNewConfig(){
+		try{
+			newLoader = new XMLSchemaLoader(NEW_SCHEMA, NEW_RULE);
+			newDataHosts = newLoader.getDataHosts();
+			newDataNodes = newLoader.getDataNodes();
+			newSchemas = newLoader.getSchemas();
+		}catch(Exception e){
+			throw new ConfigException(" new config for migrate read fail!please check newSchema.xml or  newRule.xml  "+e);
+		}
+		
+	}
+	
+	
+	private void loadTablesFile() throws Exception{
+		Properties pro = new Properties();
+		if(!isAwaysUseMaster){
+			dnIndexProps = loadDnIndexProps();
+		}
+		try{
+			pro.load(ConfigComparer.class.getResourceAsStream(TABLES_FILE));
+		}catch(Exception e){
+			throw new ConfigException("tablesFile.properties read fail!");
+		}
+		Iterator<Entry<Object, Object>> it = pro.entrySet().iterator();
+		while(it.hasNext()){
+			Entry<Object, Object> entry  = it.next();
+			String schemaName = entry.getKey().toString();
+			String tables = entry.getValue().toString();
+			loadMigratorTables(schemaName,getTables(tables));
+		}
+	}
+	
+	private String[] getTables(String tables){
+		if(tables.equalsIgnoreCase("all") || tables.isEmpty()){
+			return new String[]{};
+		}else{
+			return tables.split(",");
+		}
+	}
+	
+	/*
+	 * 加载迁移表信息，tables大小为0表示迁移schema下所有表
+	 */
+	private void loadMigratorTables(String schemaName,String[] tables){
+		if(!DataMigratorUtil.isKeyExistIgnoreCase(oldSchemas, schemaName)){
+			throw new ConfigException("oldSchema:"+schemaName+" is not exists!");
+		}
+		if(!DataMigratorUtil.isKeyExistIgnoreCase(newSchemas,schemaName)){
+			throw new ConfigException("newSchema:"+schemaName+" is not exists!");
+		}
+		Map<String, TableConfig> oldTables =  DataMigratorUtil.getValueIgnoreCase(oldSchemas, schemaName).getTables();
+		Map<String, TableConfig> newTables = DataMigratorUtil.getValueIgnoreCase(newSchemas, schemaName).getTables();
+		if(tables.length>0){
+			//指定schema下的表进行迁移
+			for(int i =0;i<tables.length;i++){
+				TableConfig oldTable =  DataMigratorUtil.getValueIgnoreCase(oldTables,tables[i]);
+				TableConfig newTable = DataMigratorUtil.getValueIgnoreCase(newTables,tables[i]);
+				loadMigratorTable(oldTable, newTable,schemaName,tables[i]);
+			}
+		}else{
+			//迁移schema下所有的表
+			//校验新旧schema中的table配置是否一致
+			Set<String> oldSet = oldTables.keySet();
+			Set<String> newSet = newTables.keySet();
+			if(!oldSet.equals(newSet)){
+				throw new ConfigException("new & old table config is not equal!");
+			}
+			for(String tableName:oldSet){
+				TableConfig oldTable = oldTables.get(tableName);
+				TableConfig newTable = newTables.get(tableName);
+				loadMigratorTable(oldTable, newTable,schemaName,tableName);
+			}
+		}
+		
+	}
+	
+	
+	
+	private void loadMigratorTable(TableConfig oldTable,TableConfig newTable,String schemaName,String tableName){
+		//禁止配置非拆分表
+		if(oldTable == null || newTable == null){
+			throw new ConfigException("please check tableFile.properties,make sure "+schemaName+":"+tableName+" is sharding table ");
+		}
+		//忽略全局表
+		if(oldTable.isGlobalTable()||newTable.isGlobalTable()){
+			String message = "global table: "+schemaName+":"+tableName+" is ignore!";
+			System.out.println("Warn: "+message);
+			LOGGER.warn(message);
+		}else{
+			List<DataNode > oldDN = getDataNodes(oldTable,oldDataNodes,oldDataHosts);
+			List<DataNode > newDN = getDataNodes(newTable,newDataNodes,newDataHosts);
+			//忽略数据节点分布没有发生变化的表
+			if(isNeedMigrate(oldDN,newDN)){
+				checkRuleConfig(oldTable.getRule(), newTable.getRule(),schemaName,tableName);
+				RuleConfig newRC=newTable.getRule();
+				TableMigrateInfo tmi = new TableMigrateInfo(schemaName, tableName, oldDN, newDN, newRC.getRuleAlgorithm(), newRC.getColumn());
+				migratorTables.add(tmi);
+			}else{
+				String message = schemaName+":"+tableName+" is ignore,no need to migrate!";
+				LOGGER.warn(message);
+				System.out.println("Warn: "+message);
+			}
+			
+		}
+	}
+	
+	//对比前后表数据节点分布是否一致
+	private boolean isNeedMigrate(List<DataNode> oldDN,List<DataNode> newDN){
+		if(oldDN.size() != newDN.size()){
+			return true;
+		}
+		return false;
+	}
+	
+	//获取拆分表对应节点列表,具体到实例地址、库
+	private List<DataNode> getDataNodes(TableConfig tableConfig,Map<String, DataNodeConfig> dnConfig,Map<String, DataHostConfig> dhConfig){
+		List<DataNode> dataNodes = new ArrayList<DataNode>();
+		//TO-DO
+		ArrayList<String> dataNodeNames = tableConfig.getDataNodes();
+		int i = 0;
+		for(String name:dataNodeNames){
+			DataNodeConfig config = dnConfig.get(name);
+			String db = config.getDatabase();
+			String dataHost = config.getDataHost();
+			DataHostConfig dh = dhConfig.get(dataHost);
+			String dbType = dh.getDbType();
+			DBHostConfig[]  writeHosts = dh.getWriteHosts();
+			DBHostConfig currentWriteHost;
+			if(isAwaysUseMaster){
+				currentWriteHost = writeHosts[0];
+			}else{
+			    //迁移数据发生在当前切换后的数据源
+				currentWriteHost = writeHosts[Integer.valueOf(dnIndexProps.getProperty(dh.getName()))];
+			}
+			DataNode dn = new DataNode(name,currentWriteHost.getIp(), currentWriteHost.getPort(), currentWriteHost.getUser(), currentWriteHost.getPassword(), db, dbType,i++);
+			dataNodes.add(dn);
+		}
+		
+		return dataNodes;
+	}
+	
+	//校验前后路由规则是否一致
+	private void checkRuleConfig(RuleConfig oldRC,RuleConfig newRC,String schemaName,String tableName){
+		if(!oldRC.getColumn().equalsIgnoreCase(newRC.getColumn())){
+			throw new ConfigException(schemaName+":"+tableName+" old & new partition column is not same!");
+		}
+		AbstractPartitionAlgorithm oldAlg = oldRC.getRuleAlgorithm();
+		AbstractPartitionAlgorithm newAlg = newRC.getRuleAlgorithm();
+		//判断路由算法前后是否一致
+		if(!oldAlg.getClass().isAssignableFrom(newAlg.getClass())){
+			throw new ConfigException(schemaName+":"+tableName+" old & new rule Algorithm is not same!");
+		}
+	}
+	
+	private Properties loadDnIndexProps() {
+		Properties prop = new Properties();
+		InputStream is = null;
+		try {
+			is = ConfigComparer.class.getResourceAsStream(DN_INDEX_FILE);
+			prop.load(is);
+		} catch (Exception e) {
+			throw new ConfigException("please check file \"dnindex.properties\" "+e.getMessage());
+		} finally {
+			try {
+				if(is !=null){
+					is.close();
+				}
+			} catch (IOException e) {
+				throw new ConfigException(e.getMessage());
+			}
+		}
+		return prop;
+	}
+}

--- a/src/main/java/io/mycat/util/dataMigrator/DataClearRunner.java
+++ b/src/main/java/io/mycat/util/dataMigrator/DataClearRunner.java
@@ -1,0 +1,65 @@
+package io.mycat.util.dataMigrator;
+
+import java.io.File;
+import java.sql.Connection;
+import java.util.ArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alibaba.druid.util.JdbcUtils;
+
+/**
+ * 清理数据扩容缩容后的冗余数据
+ * @author haonan108
+ *
+ */
+public class DataClearRunner implements Runnable{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DataClearRunner.class);
+	private DataNode srcDn;
+	private File tempFile;
+	private TableMigrateInfo tableInfo;
+	
+	public DataClearRunner(TableMigrateInfo tableInfo,DataNode srcDn,File tempFile){
+		this.tableInfo = tableInfo;
+		this.srcDn = srcDn;
+		this.tempFile = tempFile;
+	}
+	@Override
+	public void run() {
+		String data = "";
+		int offset = 0;
+		Connection con = null;
+		try {
+			long start = System.currentTimeMillis();
+			con = DataMigratorUtil.getMysqlConnection(srcDn);
+			if(tableInfo.isExpantion()){
+				while((data=DataMigratorUtil.readData(tempFile,offset,DataMigrator.margs.getQueryPageSize())).length()>0){
+					offset += data.getBytes().length;
+					if(data.startsWith(",")){
+						data = data.substring(1, data.length());
+					}
+					if(data.endsWith(",")){
+						data = data.substring(0,data.length()-1);
+					}
+					String sql = "delete from "+tableInfo.getTableName()+" where "+tableInfo.getColumn()+" in ("+data+")";
+					JdbcUtils.execute(con, sql, new ArrayList<>());
+				}
+			}else{
+				String sql = "truncate "+tableInfo.getTableName();
+				JdbcUtils.execute(con, sql, new ArrayList<>());
+			}
+			long end = System.currentTimeMillis();
+			System.out.println(tableInfo.getSchemaAndTableName()+" clean dataNode "+srcDn.getName()+" completed in "+(end-start)+"ms");
+			
+		} catch (Exception e) {
+			String errMessage = srcDn.toString()+":"+"clean data error!";
+			LOGGER.error(errMessage, e);
+			tableInfo.setError(true);
+			tableInfo.getErrMessage().append(errMessage+"\n");
+		} finally{
+			JdbcUtils.close(con);
+		}
+	}
+}

--- a/src/main/java/io/mycat/util/dataMigrator/DataIO.java
+++ b/src/main/java/io/mycat/util/dataMigrator/DataIO.java
@@ -1,0 +1,35 @@
+package io.mycat.util.dataMigrator;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * 数据导入导出接口，mysql、oracle等数据库通过实现此接口提供具体的数据导入导出功能
+ * @author haonan108
+ *
+ */
+public interface DataIO {
+ 
+	/**
+	 * 导入数据
+	 * @param dn 导入到具体的数据库
+	 * @param file 导入的文件
+	 * @throws IOException 
+	 * @throws InterruptedException 
+	 */
+	
+    void importData(TableMigrateInfo table,DataNode dn,String tableName,File file) throws IOException, InterruptedException;
+    
+    /**
+     * 根据条件导出迁移数据
+     * @param dn 导出哪个具体的数据库
+     * @param tableName 导出的表名称
+     * @param export 文件导出到哪里
+     * @param condion 导出文件依赖的具体条件
+     * @return 
+     * @throws IOException 
+     * @throws InterruptedException 
+     */
+    File exportData(TableMigrateInfo table,DataNode dn,String tableName,File exportPath,File condion) throws IOException, InterruptedException;
+	
+}

--- a/src/main/java/io/mycat/util/dataMigrator/DataIOFactory.java
+++ b/src/main/java/io/mycat/util/dataMigrator/DataIOFactory.java
@@ -1,0 +1,19 @@
+package io.mycat.util.dataMigrator;
+
+import io.mycat.util.dataMigrator.dataIOImpl.MysqlDataIO;
+import io.mycat.util.exception.DataMigratorException;
+
+public class DataIOFactory {
+
+	public static final String MYSQL = "mysql";
+	public static final String ORACLE = "oracle";
+	
+	public static DataIO createDataIO(String dbType){
+		switch (dbType) {
+		case MYSQL:
+			return new MysqlDataIO();
+		default:
+			throw new DataMigratorException("dbType:"+dbType+" is not support for the moment!");
+		}
+	}
+}

--- a/src/main/java/io/mycat/util/dataMigrator/DataMigrateRunner.java
+++ b/src/main/java/io/mycat/util/dataMigrator/DataMigrateRunner.java
@@ -1,0 +1,52 @@
+package io.mycat.util.dataMigrator;
+
+import java.io.File;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * 数据迁移过程类
+ * @author haonan108
+ *
+ */
+public  class DataMigrateRunner implements Runnable{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DataMigrateRunner.class);
+	private DataNode src;
+	private DataNode target;
+	private String tableName;
+	private DataIO dataIO;
+	private File conditionFile;
+	private TableMigrateInfo table;
+	
+	
+	
+	public DataMigrateRunner(TableMigrateInfo table, DataNode src,DataNode target,String tableName,File conditionFile){
+		this.tableName = tableName;
+		this.conditionFile= conditionFile;
+		this.src = src;
+		this.target = target;
+		this.table = table;
+		dataIO = DataIOFactory.createDataIO(src.getDbType());
+	}
+
+	@Override
+	public void run() {
+		if(table.isError()) return;
+		try {
+			long start = System.currentTimeMillis();
+			File loadFile = dataIO.exportData(table,src, tableName, conditionFile.getParentFile(), conditionFile);
+			dataIO.importData(table,target,tableName, loadFile);
+			long end = System.currentTimeMillis();
+			System.out.println(table.getSchemaAndTableName()+" "+src.getName()+"->"+target.getName()+" completed in "+(end-start)+"ms");
+		} catch (Exception e) {
+			String errMessage = table.getSchemaAndTableName()+" "+src.getName()+"->"+target.getName()+" migrate err! "+e.getMessage();
+			LOGGER.error(errMessage, e);
+			table.setError(true);
+			table.getErrMessage().append(errMessage);
+		}
+	}
+	
+}

--- a/src/main/java/io/mycat/util/dataMigrator/DataMigrator.java
+++ b/src/main/java/io/mycat/util/dataMigrator/DataMigrator.java
@@ -1,0 +1,282 @@
+package io.mycat.util.dataMigrator;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * 数据迁移统一调度类，支持扩容缩容
+ * 原理：读取需要迁移的数据节点表所有拆分字段数据，按照扩容或缩容后的配置对拆分字段重新计算路由节点，
+ * 将需要迁移的数据导出，然后导入到扩容或缩容后对应的数据节点
+ * @author haonan108
+ *
+ */
+public class DataMigrator {
+ 
+	private static final Logger LOGGER = LoggerFactory.getLogger(DataMigrator.class);
+	
+	public static  DataMigratorArgs margs;
+	
+	private List<TableMigrateInfo> migrateTables;
+	
+	private ExecutorService executor;
+	
+	private List<DataNodeClearGroup> clearGroup = new ArrayList<>();
+	
+	public DataMigrator(String[] args){
+		margs = new DataMigratorArgs(args);
+		executor = new ThreadPoolExecutor(margs.getThreadCount(), margs.getThreadCount(),
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<Runnable>(),new ThreadPoolExecutor.CallerRunsPolicy());
+		
+		
+		try {
+			createTempParentDir(margs.getTempFileDir());
+			ConfigComparer loader = new ConfigComparer(margs.isAwaysUseMaster());
+			migrateTables = loader.getMigratorTables();
+			//建表
+			for(TableMigrateInfo table:migrateTables){
+				table.setTableStructure();
+				table.createTableToNewDataNodes();
+			}
+		} catch (Exception e) {
+			LOGGER.error(e.getMessage(),e);
+			System.out.println(e.getMessage());
+			//配置错误退出迁移程序
+			System.exit(-1);
+		}
+	}
+	
+	public static void main(String[] args) throws SQLException {
+		long start = System.currentTimeMillis();
+		DateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS");
+		System.out.println("\n"+format.format(new Date())+" [1]-> creating migrator schedule and temp files for migrate...");
+		//初始化配置
+		DataMigrator migrator = new DataMigrator(args);
+		
+		//生成中间文件
+		migrator.createTempFiles();
+		migrator.changeSize();
+		migrator.printInfo();
+
+		//迁移数据
+		System.out.println("\n"+format.format(new Date())+" [2]-> start migrate data...");
+		migrator.migrateData();
+		
+		//清除中间临时文件、清除被迁移掉的冗余数据
+		System.out.println("\n"+format.format(new Date())+" [3]-> cleaning redundant data...");
+		migrator.clear();
+		
+		//校验数据是否迁移成功
+		System.out.println("\n"+format.format(new Date())+" [4]-> validating tables migrate result...");
+		migrator.validate();
+		migrator.clearTempFiles();
+		long end = System.currentTimeMillis();
+		System.out.println("\n"+format.format(new Date())+" migrate data complete in "+(end-start)+"ms");
+	}
+	
+	//打印各个表的迁移数据信息
+	private void printInfo() {
+		for(TableMigrateInfo table:migrateTables){
+			table.printMigrateInfo();
+			table.printMigrateSchedule();
+		}
+	}
+
+	//删除临时文件
+	private void clearTempFiles() {
+		File tempFileDir = new File(margs.getTempFileDir());
+		if(tempFileDir.exists() && margs.isDeleteTempDir()){
+			DataMigratorUtil.deleteDir(tempFileDir);
+		}
+	}
+
+	//生成需要进行迁移的数据依赖的拆分字段值文件
+	private void createTempFiles(){
+		for(TableMigrateInfo table:migrateTables){
+			//创建具体拆分表中间临时文件
+			createTableTempFiles(table);
+		}
+		executor.shutdown();
+		while(true){
+			if(executor.isTerminated()){
+				break;
+			}
+			try {
+				Thread.sleep(200);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	private void migrateData() throws SQLException{
+		executor =  new ThreadPoolExecutor(margs.getThreadCount(), margs.getThreadCount(),
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<Runnable>(),new ThreadPoolExecutor.CallerRunsPolicy());
+		for(TableMigrateInfo table:migrateTables){
+			if(!table.isError()){ //忽略已出错的拆分表
+				List<DataNodeMigrateInfo> detailList = table.getDataNodesDetail();
+				for(DataNodeMigrateInfo info:detailList){
+					executor.execute(new DataMigrateRunner(table, info.getSrc(), info.getTarget(), table.getTableName(), info.getTempFile()));
+				}
+			}
+		}
+		executor.shutdown();
+		while(true){
+			if(executor.isTerminated()){
+				break;
+			}
+			try {
+				Thread.sleep(200);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	//缩容需要重新计算表大小
+	private void changeSize() throws SQLException {
+		for(TableMigrateInfo table:migrateTables){
+			if(!table.isExpantion()){
+				List<DataNode> oldDn = table.getOldDataNodes();
+				long size = 0L;
+				for(DataNode dn:oldDn){
+					size+=DataMigratorUtil.querySize(dn, table.getTableName());
+				}
+				table.setSize(size);
+			}
+		}
+	}
+
+	//校验迁移计划中数据迁移情况同数据实际落盘是否一致
+	private void validate() throws SQLException {
+		for(TableMigrateInfo table:migrateTables){
+			if (table.isError()) continue;
+			long size = table.getSize().get();
+			long factSize = 0L;
+			for(DataNode dn:table.getNewDataNodes()){
+				factSize+=DataMigratorUtil.querySize(dn, table.getTableName());
+			}
+			if(factSize != size){
+				String message = "migrate error!after migrate should be:"+size+" but fact is:"+factSize;
+				table.setError(true);
+				table.setErrMessage(message);
+			}
+		}
+		
+		//打印最终迁移结果信息
+		String title = "migrate result";
+		Map<String,String> result = new HashMap<String, String>();
+		for(TableMigrateInfo table:migrateTables){
+			String resultMessage = table.isError()?"fail! reason: "+table.getErrMessage():"success";
+			result.put(table.getSchemaAndTableName(), resultMessage);
+		}
+		String info = DataMigratorUtil.printMigrateInfo(title, result, "->");
+		System.out.println(info);
+	}
+	
+	//清除中间临时文件、导出的迁移数据文件、已被迁移的原始节点冗余数据
+	private void clear(){
+		for(TableMigrateInfo table:migrateTables){
+			makeClearDataGroup(table);
+		}
+		for(DataNodeClearGroup group:clearGroup){
+			clearData(group.getTempFiles(), group.getTableInfo());
+		}
+	}
+	
+	//同一主机上的mysql执行按where条件删除数据并发多了性能反而下降很快
+	//按照主机ip进行分组，每个主机ip分配一个线程池，线程池大小可配置，默认为当前主机环境cpu核数的一半
+	private void makeClearDataGroup(TableMigrateInfo table){
+		List<DataNodeMigrateInfo>  list = table.getDataNodesDetail();
+		 //将数据节点按主机ip分组，每组分配一个线程池
+		for(DataNodeMigrateInfo dnInfo:list){
+			DataNode src = dnInfo.getSrc();
+			String ip  =src.getIp();
+			File f = dnInfo.getTempFile();
+			DataNodeClearGroup group = getDataNodeClearGroup(ip,table);
+			if(group == null){
+				group = new DataNodeClearGroup(ip, table);
+				clearGroup.add(group);
+			}
+			group.getTempFiles().put(f, src);
+		}
+	}
+	
+	private DataNodeClearGroup getDataNodeClearGroup(String ip, TableMigrateInfo table){
+		DataNodeClearGroup result = null;
+		for(DataNodeClearGroup group:clearGroup){
+			if(group.getIp().equals(ip) && group.getTableInfo().equals(table)){
+				result = group;
+			}
+		}
+		return result;
+	}
+	
+	private void clearData(Map<File,DataNode> map,TableMigrateInfo table){
+		if(table.isError()) return;
+		ExecutorService executor  =  new ThreadPoolExecutor(margs.getThreadCount(), margs.getThreadCount(),
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<Runnable>(),new ThreadPoolExecutor.CallerRunsPolicy());
+		Iterator<Entry<File,DataNode>>  it = map.entrySet().iterator();
+		while(it.hasNext()){
+			Entry<File,DataNode> et = it.next();
+			File f =et.getKey();
+			DataNode srcDn  =  et.getValue();
+			executor.execute(new DataClearRunner(table, srcDn, f));
+		}
+		executor.shutdown();
+		while(true){
+			if(executor.isTerminated()){
+				break;
+			}
+			try {
+				Thread.sleep(200);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	private void createTempParentDir(String dir){
+		File outputDir = new File(dir);
+		if(outputDir.exists()){
+			DataMigratorUtil.deleteDir(outputDir);
+		}
+		outputDir.mkdirs();
+		outputDir.setWritable(true);
+	}
+	
+	private void createTableTempFiles(TableMigrateInfo table) {
+		List<DataNode> oldDn = table.getOldDataNodes();
+		if(table.isExpantion()){ //扩容
+			//生成迁移中间文件，并生成迁移执行计划
+			for(DataNode dn:oldDn){
+				executor.execute(new MigratorConditonFilesMaker(table,dn,margs.getTempFileDir(),margs.getQueryPageSize()));
+			}
+		}else{//缩容
+			//找出移除的节点
+			List<DataNode> migrateDn = table.getRemovedDataNodes();
+			for(DataNode dn:migrateDn){
+				executor.execute(new MigratorConditonFilesMaker(table,dn,margs.getTempFileDir(),margs.getQueryPageSize()));
+			}
+		}
+	}
+}

--- a/src/main/java/io/mycat/util/dataMigrator/DataMigratorArgs.java
+++ b/src/main/java/io/mycat/util/dataMigrator/DataMigratorArgs.java
@@ -1,0 +1,140 @@
+package io.mycat.util.dataMigrator;
+
+import io.mycat.config.model.SystemConfig;
+import io.mycat.util.cmd.CmdArgs;
+
+/**
+ * 数据迁移工具依赖参数
+ * @author haonan108
+ *
+ */
+public class DataMigratorArgs {
+
+	/** 并行线程数*/
+	public static final String THREAD_COUNT = "threadCount";
+	
+	/** mysqldump命令所在路径 */
+	public static final String MYSQL_BIN = "mysqlBin";
+	
+	/** 数据迁移生成的中间文件指定存放目录*/
+	public static final String TEMP_FILE_DIR = "tempFileDir";
+	
+	/** 使用主数据源还是当前数据源(如果发生主备切换存在数据源选择问题)*/
+	public static final String IS_AWAYS_USE_MASTER = "isAwaysUseMaster";
+	
+	/**生成中间临时文件一次加载的数据量*/
+	public static final String QUERY_PAGE_SIZE = "queryPageSize";
+	
+	public static final String DEL_THRAD_COUNT = "delThreadCount";
+	
+	/** mysqldump导出中间文件命令操作系统限制长度 */
+	public static final String MYSQL_DUMP_CMD_LENGTH = "cmdLength";
+	
+	public static final String CHARSET = "charset";
+	
+	/**完成扩容缩容后清除临时文件 默认为true*/
+	public static final String DELETE_TEMP_FILE_DIR = "deleteTempFileDir";
+	
+	
+	
+	private static final int DEFAULT_THREAD_COUNT = Runtime.getRuntime().availableProcessors()*2;
+	
+	private static final int DEFAULT_DEL_THRAD_COUNT  = Runtime.getRuntime().availableProcessors()/2;
+	
+	private static final int DEFAULT_CMD_LENGTH = 110*1024;//操作系统命令行限制长度 110KB
+	
+	private static final int DEFAULT_PAGE_SIZE = 100000;//默认一次读取10w条数据
+	
+	private static final String DEFAULT_CHARSET = "utf8";
+	
+	private CmdArgs cmdArgs;
+	
+	public DataMigratorArgs(String[] args){
+		cmdArgs = CmdArgs.getInstance(args);
+	}
+	
+	public String getString(String name){
+		return cmdArgs.getString(name);
+	}
+	
+	public String getMysqlBin(){
+		String result = getString(MYSQL_BIN);
+		if(result ==null) return "";
+		if(!result.isEmpty() &&!result.endsWith("/")){
+			result +="/";
+		}
+		return result;
+	}
+	
+	public String getTempFileDir(){
+		String path = getString(TEMP_FILE_DIR);
+		if(null == path || path.trim().isEmpty()){
+			return SystemConfig.getHomePath()+"/temp";
+		}
+		return path;
+	}
+	
+	public int getThreadCount(){
+		String count =getString(THREAD_COUNT);
+		if(null == count||count.isEmpty()|| count.equals("0") ){
+			return DEFAULT_THREAD_COUNT;
+		}
+		return Integer.valueOf(count);
+	}
+	
+	public int getDelThreadCount(){
+		String count =getString(DEL_THRAD_COUNT);
+		if(null == count||count.isEmpty()|| count.equals("0") ){
+			return DEFAULT_DEL_THRAD_COUNT;
+		}
+		return Integer.valueOf(count);
+	}
+	
+	public boolean isAwaysUseMaster(){
+		String result = getString(IS_AWAYS_USE_MASTER);
+		if(null == result||result.isEmpty()||result.equals("true")){
+			return true;
+		}
+	    return false;
+	}
+	
+	public int getCmdLength(){
+		String result = getString(MYSQL_DUMP_CMD_LENGTH);
+		if(null  == result||result.isEmpty()){
+			return DEFAULT_CMD_LENGTH;
+		}
+		if(result.contains("*")){
+			String[] arr = result.split("\\*");
+			int j = 1;
+			for (int i = 0; i < arr.length; i++) {
+				j *= Integer.valueOf(arr[i]);
+			}
+			return j;
+		}
+		return Integer.valueOf(result);
+	}
+	
+	public int getQueryPageSize(){
+		String result = getString(QUERY_PAGE_SIZE);
+		if(null == result||result.isEmpty()){
+			return DEFAULT_PAGE_SIZE;
+		}
+		return Integer.valueOf(result);
+	}
+	
+	public String getCharSet(){
+		String result = getString(CHARSET);
+		if(null == result||result.isEmpty()){
+			return DEFAULT_CHARSET;
+		}
+		return result;
+	}
+	
+	public boolean isDeleteTempDir(){
+		String result = getString(DELETE_TEMP_FILE_DIR);
+		if(null == result||result.isEmpty()||result.equals("true")){
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/main/java/io/mycat/util/dataMigrator/DataMigratorUtil.java
+++ b/src/main/java/io/mycat/util/dataMigrator/DataMigratorUtil.java
@@ -1,0 +1,384 @@
+package io.mycat.util.dataMigrator;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alibaba.druid.util.JdbcUtils;
+
+public class DataMigratorUtil {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(DataMigratorUtil.class);
+	
+	static{
+		try {
+			Class.forName("com.mysql.jdbc.Driver");
+		} catch (ClassNotFoundException e) {
+			LOGGER.error("",e);
+		}
+	}
+	
+	/**
+	 * 添加数据到文件末尾
+	 * @param file
+	 * @param content
+	 * @throws IOException
+	 */
+	public static void appendDataToFile(File file, String content) throws IOException {   
+		RandomAccessFile randomFile = null;  
+		try {     
+			// 打开一个随机访问文件流，按读写方式     
+			randomFile = new RandomAccessFile(file, "rw");     
+			// 文件长度，字节数     
+			long fileLength = randomFile.length();     
+			// 将写文件指针移到文件尾。     
+			randomFile.seek(fileLength);     
+			randomFile.writeBytes(content);
+			content = null;
+		} catch (IOException e) {     
+			LOGGER.error("appendDataToFile is error!",e);
+		} finally{  
+			if(randomFile != null){  
+				try {  
+					randomFile.close();  
+				} catch (IOException e) {  
+					e.printStackTrace();  
+				}  
+			}  
+		}  
+	}
+	
+	public static String readDataFromFile(File file,int offset,int length) throws IOException{
+		RandomAccessFile randomFile = null;  
+		try {     
+			// 打开一个随机访问文件流，按读写方式     
+			randomFile = new RandomAccessFile(file, "rw");     
+			randomFile.seek(offset);
+			byte[] buffer = new byte[length];
+			randomFile.read(buffer);
+			return new String(buffer).trim();
+		} catch (IOException e) {     
+			throw e;   
+		} finally{  
+			if(randomFile != null){  
+				try {  
+					randomFile.close();  
+				} catch (IOException e) {  
+					e.printStackTrace();  
+				}  
+			}  
+		}  
+	}
+	
+	/**
+	 * 读取逗号分隔的文件数据
+	 * @param file 
+	 * @param start 文件起始位置
+	 * @param length 读取字节数
+	 * @return
+	 * @throws IOException
+	 */
+	public static  String readData(File file,int start,int length) throws IOException{
+		String data = readDataFromFile(file, start, length);
+		if((start+length)<=file.length()){
+			data = data.substring(0, data.lastIndexOf(","));
+		}
+
+		return data;
+	}
+	
+	public static final int BUFSIZE = 1024 * 8; 
+	
+	public static void mergeFiles(File outFile, File f) throws IOException {  
+        FileChannel outChannel = null;
+        FileOutputStream fos = null;
+        FileInputStream fis = null;
+        try {  
+        	fos = new FileOutputStream(outFile,true);
+        	fis = new FileInputStream(f);
+            outChannel = fos.getChannel();  
+            FileChannel fc = fis.getChannel();   
+            ByteBuffer bb = ByteBuffer.allocate(BUFSIZE);  
+            while(fc.read(bb) != -1){  
+            	bb.flip();  
+            	outChannel.write(bb);  
+            	bb.clear();  
+            }  
+            fc.close();  
+        } catch (IOException e) {  
+        	throw e;
+        } finally {  
+            try {
+            	if(fos != null){
+            		fos.close();
+            	}
+            	if(fis != null){
+            		fis.close();
+            	}
+            	if (outChannel != null){
+            		outChannel.close();
+            	}
+            } 
+            catch (IOException e) {
+            	e.printStackTrace();
+            }  
+        }  
+    }
+	
+	/**
+	 * 统计文件有多少行
+	 * @param file
+	 * @return
+	 */
+	public static long countLine(File file) throws IOException{
+		long count = 0L;
+		RandomAccessFile randomFile = null;  
+		
+		// 打开一个随机访问文件流，按读写方式     
+		try {
+			randomFile = new RandomAccessFile(file, "rw");
+			String s ="";
+			while((s=randomFile.readLine())!=null && !s.trim().isEmpty()){
+				count++;
+			}
+		} catch (FileNotFoundException e) {
+			throw e;
+		}finally{
+			if(randomFile != null){  
+				try {  
+					randomFile.close();  
+				} catch (IOException e) {  
+					e.printStackTrace();  
+				}  
+			}  
+		}
+		
+		return count;
+	}
+	
+	/**
+     * 递归删除目录下的所有文件及子目录下所有文件
+     * @param dir 将要删除的文件目录
+     * @return boolean Returns "true" if all deletions were successful.
+     *                 If a deletion fails, the method stops attempting to
+     *                 delete and returns "false".
+     */
+    public static boolean deleteDir(File dir) {
+        if (dir.isDirectory()) {
+            String[] children = dir.list();
+            for (int i=0; i<children.length; i++) {
+                boolean success = deleteDir(new File(dir, children[i]));
+                if (!success) {
+                    return false;
+                }
+            }
+        }
+        // 目录此时为空，可以删除
+        return dir.delete();
+    }
+    
+    //将命令行中的？替换为具体参数
+    public static  String paramsAssignment(String cmd,Object... params){
+		List<Object> paramList= Arrays.asList(params);
+		for(Object param:paramList){
+			cmd = cmd.replaceFirst("\\?", param.toString());
+		}
+		return cmd;
+	}
+    
+    public static Connection getMysqlConnection(DataNode dn) throws SQLException{
+    	Connection con = null;
+		con = DriverManager.getConnection(dn.getUrl(), dn.getUserName(), dn.getPwd());
+    	return con;
+    }
+    
+    public static List<Map<String, Object>> executeQuery(Connection conn, String sql,Object... parameters) throws SQLException{
+    	return JdbcUtils.executeQuery(conn, sql, Arrays.asList(parameters));
+    }
+    
+    //查询表数据量
+  	public static long querySize(DataNode dn,String tableName) throws SQLException{
+  		List<Map<String, Object>> list=null;
+  		long size = 0L;
+  		Connection con = null;
+  		try {
+  			con =  getMysqlConnection(dn);
+  			list = executeQuery(con, "select count(1) size from "+tableName);
+  			size = (long) list.get(0).get("size");
+  		} catch (SQLException e) {
+  			throw e;
+  		}finally{
+  			JdbcUtils.close(con);
+  		}
+  		return size;
+  	}
+  	
+  	public static void createTable(DataNode dn,String table) throws SQLException{
+  		Connection con = null;
+  		try {
+  			con =  getMysqlConnection(dn);
+  			JdbcUtils.execute(con, table, new ArrayList<>());
+  		} catch (SQLException e) {
+  			throw e;
+  		}finally{
+  			JdbcUtils.close(con);
+  		}
+  	}
+  	
+  	/**
+  	 * 格式化数据迁移信息
+  	 *  +---------title-------+
+  	 *  |key1 = value1     |
+  	 *  |key2 = value2     |
+  	 *  |...                        |
+  	 *  +---------------------+
+  	 * @param title
+  	 * @param map
+  	 * @param mark
+  	 * @return
+  	 */
+  	public static  String printMigrateInfo(String title,Map<String,String> map,String mark){
+  		StringBuilder result = new StringBuilder(" ");
+  		List<String> mergeList = new ArrayList<>();
+  		
+  		Iterator<Entry<String, String>> itor = map.entrySet().iterator();
+  		
+  		int maxKeyLength = 0;
+  		int maxValueLength = 0;
+  		while(itor.hasNext()){
+  			Entry<String, String> entry = itor.next();
+  			String key = entry.getKey();
+  			String value = entry.getValue();
+  			maxKeyLength = (key.length()>maxKeyLength)?key.length():maxKeyLength;
+  			maxValueLength =  (value.length()>maxValueLength)?value.length():maxValueLength;
+  		}
+  		
+  		int maxLength=maxKeyLength+maxValueLength+2+mark.length();
+  		if(maxLength<= title.length()){
+  			maxLength = title.length()+8;
+  		}
+  		itor = map.entrySet().iterator();
+  		//合并key和value，并找出长度最大的字符串
+  		while(itor.hasNext()){
+  			Entry<String, String> entry = itor.next();
+  			String key = entry.getKey();
+  			String value = entry.getValue();
+  			int keyLength = maxKeyLength-key.length();
+  			StringBuilder keySb = new StringBuilder(key);
+  			for(int i=0;i<keyLength;i++){
+  				keySb.append(" ");
+  			}
+  			key = keySb.toString();
+  			
+  			String merge = key+" "+mark+" "+value;
+  			mergeList.add(merge);
+  		}
+  		int maxLineLength = 300;//一行显示最大字符数
+  		if(maxLength > maxLineLength){
+  			maxLength = maxLineLength;
+  		}
+  		//拼第一行title
+  		StringBuilder titleSb = new StringBuilder("+");
+  		int halfLength = (maxLength-title.length())/2;
+  		for(int i=0;i<halfLength;i++){
+  			titleSb.append("-");
+  		}
+  		titleSb.append(title);
+  		for(int i=0;i<(maxLength-halfLength-title.length());i++){
+  			titleSb.append("-");
+  		}
+  		titleSb.append("+\n");
+  		result.append(titleSb);
+  		
+  		List<String> changeList = new ArrayList<>();
+  		//调整内容
+  		for(int i=0;i<mergeList.size();i++){
+  			String content = mergeList.get(i);
+  		    if(content.trim().length()>=maxLength){
+  		    	String[] str = content.split(mark);
+  		    	String key = str[0];
+  		    	String value =str[1];
+  		    	String[] values = getValues(value,maxLength-maxKeyLength-1-mark.length());
+  		    	for(int j=0;j<values.length;j++){
+  		    		String s = "";
+  		    		if(j > 0){
+  		    			StringBuilder keySb = new StringBuilder();
+  		    			for(int k=0;k<key.length()+1;k++){
+  		    				keySb.append(" ");
+  		    			}
+  		    			s = keySb.toString()+values[j];
+  		    		}else{
+  		    			s = key+mark+values[j];
+  		    		}
+  		    		
+  		    		changeList.add(s);
+  		    	}
+  		    }else{
+  		    	changeList.add(content);
+  		    }
+  		}
+  		
+  		//拼接内容
+  		for(int i=0;i<changeList.size();i++){
+  			StringBuilder contentSb = new StringBuilder(" |");
+  			String content = changeList.get(i);
+  			contentSb.append(content);
+  			int length = maxLength-content.length();
+  			for(int j=0;j<length;j++){
+  				contentSb.append(" ");
+  			}
+  			contentSb.append("|\n");
+  			result.append(contentSb);
+  		}
+  		StringBuilder endSb = new StringBuilder(" +");
+  		for(int i=0;i<maxLength;i++){
+  			endSb.append("-");
+  		}
+  		endSb.append("+\n");
+  		result.append(endSb);
+  		return result.toString();
+  		
+  	}
+  	
+  	public static  <T> boolean isKeyExistIgnoreCase(Map<String,T> map,String key){
+		return map.containsKey(key.toLowerCase()) || map.containsKey(key.toUpperCase());
+	}
+	
+	public static <T> T getValueIgnoreCase(Map<String,T> map,String key){
+		T result = map.get(key.toLowerCase());
+		return  result==null?map.get(key.toUpperCase()):result;
+	}
+  	
+  	private static String[] getValues(String value, int maxValueLength) {
+  		int length = value.length()/maxValueLength;
+  		if(value.length()%maxValueLength>0){
+  			length+=1;
+  		}
+  		String[] result = new String[length];
+  		for(int i=0;i<length-1;i++){
+  			String str = value.substring(i*maxValueLength,i*maxValueLength+maxValueLength);
+  			result[i] = str;
+  		}
+  		String str = value.substring((length-1)*maxValueLength,value.length());
+  		result[length-1] = str;
+		return result;
+	}
+
+}

--- a/src/main/java/io/mycat/util/dataMigrator/DataNode.java
+++ b/src/main/java/io/mycat/util/dataMigrator/DataNode.java
@@ -1,0 +1,124 @@
+package io.mycat.util.dataMigrator;
+
+/**
+ * 数据节点，精确到库名称
+ * @author haonan108
+ *
+ */
+public class DataNode{
+
+	private String name;
+	private String ip;
+	private int port;
+	private String userName;
+	private String pwd;
+	private String db;
+	private String dbType;
+	private int index;
+	
+	public DataNode(String name,String ip, int port, String userName, String pwd, String db,String dbType,int index) {
+		super();
+		this.name = name;
+		this.ip = ip;
+		this.port = port;
+		this.userName = userName;
+		this.pwd = pwd;
+		this.db = db;
+		this.index = index;
+		this.dbType = dbType;
+	}
+
+	public String getIp() {
+		return ip;
+	}
+
+	public void setIp(String ip) {
+		this.ip = ip;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public String getUserName() {
+		return userName;
+	}
+
+	public void setUserName(String userName) {
+		this.userName = userName;
+	}
+
+	public String getPwd() {
+		return pwd;
+	}
+
+	public void setPwd(String pwd) {
+		this.pwd = pwd;
+	}
+
+	public String getDb() {
+		return db;
+	}
+
+	public void setDb(String db) {
+		this.db = db;
+	}
+
+	public String getDbType() {
+		return dbType;
+	}
+
+	public void setDbType(String dbType) {
+		this.dbType = dbType;
+	}
+	
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+	
+	//暂时只提供mysql驱动
+	public String getUrl(){
+		return "jdbc:mysql://"+ip+":"+port+"/"+db;
+	}
+	
+	public int getIndex() {
+		return index;
+	}
+
+	public void setIndex(int index) {
+		this.index = index;
+	}
+
+	@Override
+	public String toString(){
+		return this.name;
+	}
+
+	@Override
+	public boolean equals(Object o){
+		if(o == null) return false;
+		if (this == o) return true;
+		
+		if(o instanceof DataNode){
+			DataNode other = (DataNode)o;
+			if (other.toString().equals(this.toString())){
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	@Override
+	public int hashCode(){
+		return this.toString().hashCode();
+	}
+	
+}

--- a/src/main/java/io/mycat/util/dataMigrator/DataNodeClearGroup.java
+++ b/src/main/java/io/mycat/util/dataMigrator/DataNodeClearGroup.java
@@ -1,0 +1,42 @@
+package io.mycat.util.dataMigrator;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 数据节点按照主机ip进行分组
+ * @author haonan108
+ *
+ */
+public class DataNodeClearGroup {
+
+	private String ip;
+	private Map<File,DataNode>  tempFiles = new HashMap<>();
+	private TableMigrateInfo tableInfo;
+	
+	public DataNodeClearGroup(String ip, TableMigrateInfo tableInfo) {
+		super();
+		this.ip = ip;
+		this.tableInfo = tableInfo;
+	}
+	public String getIp() {
+		return ip;
+	}
+	public void setIp(String ip) {
+		this.ip = ip;
+	}
+	public Map<File,DataNode> getTempFiles() {
+		return tempFiles;
+	}
+	public void setTempFiles(Map<File,DataNode> tempFiles) {
+		this.tempFiles = tempFiles;
+	}
+	public TableMigrateInfo getTableInfo() {
+		return tableInfo;
+	}
+	public void setTableInfo(TableMigrateInfo tableInfo) {
+		this.tableInfo = tableInfo;
+	}
+	
+}

--- a/src/main/java/io/mycat/util/dataMigrator/DataNodeMigrateInfo.java
+++ b/src/main/java/io/mycat/util/dataMigrator/DataNodeMigrateInfo.java
@@ -1,0 +1,60 @@
+package io.mycat.util.dataMigrator;
+
+import java.io.File;
+
+/**
+ * 数据迁移时数据节点间迁移信息
+ * @author haonan108
+ *
+ */
+public class DataNodeMigrateInfo {
+
+	private DataNode src;
+	private DataNode target;
+	private File tempFile;
+	private long size;
+	private TableMigrateInfo table;
+	
+	public DataNodeMigrateInfo(TableMigrateInfo table, DataNode src, DataNode target, File tempFile, long size) {
+		super();
+		this.table = table;
+		this.src = src;
+		this.target = target;
+		this.tempFile = tempFile;
+		this.size = size;
+	}
+	
+	public TableMigrateInfo getTable() {
+		return table;
+	}
+
+	public void setTable(TableMigrateInfo table) {
+		this.table = table;
+	}
+
+	public DataNode getSrc() {
+		return src;
+	}
+	public void setSrc(DataNode src) {
+		this.src = src;
+	}
+	public DataNode getTarget() {
+		return target;
+	}
+	public void setTarget(DataNode target) {
+		this.target = target;
+	}
+	public File getTempFile() {
+		return tempFile;
+	}
+	public void setTempFile(File tempFile) {
+		this.tempFile = tempFile;
+	}
+	public long getSize() {
+		return size;
+	}
+	public void setSize(long size) {
+		this.size = size;
+	}
+	
+}

--- a/src/main/java/io/mycat/util/dataMigrator/MigratorConditonFilesMaker.java
+++ b/src/main/java/io/mycat/util/dataMigrator/MigratorConditonFilesMaker.java
@@ -1,0 +1,178 @@
+package io.mycat.util.dataMigrator;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alibaba.druid.util.JdbcUtils;
+
+import io.mycat.route.function.AbstractPartitionAlgorithm;
+import io.mycat.util.CollectionUtil;
+
+/**
+ * 对具体某个节点重新路由 生成导出数据所依赖的中间文件
+ * @author haonan108
+ */
+public class MigratorConditonFilesMaker implements Runnable{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MigratorConditonFilesMaker.class);
+	private DataNode srcDn;
+	private List<DataNode> newDn;
+	private String column;
+	private String tableName;
+	private AbstractPartitionAlgorithm alg;
+	private int index;
+	private String tempFileDir;
+	private TableMigrateInfo tableInfo;
+	private int newDnSize;
+	private int pageSize;
+	private boolean isExpantion;
+	
+	private Map<DataNode,File> files = new HashMap<>();
+	
+	Map<Integer,StringBuilder> map = new HashMap<>();//存放节点发生变化的拆分字段字符串数据 key:dn索引 value 拆分字段值,以逗号分隔
+	
+	public MigratorConditonFilesMaker(TableMigrateInfo tableInfo,DataNode srcDn,String tempFileDir, int pageSize){
+		this.tableInfo = tableInfo;
+		this.tempFileDir = tempFileDir;
+		this.srcDn = srcDn;
+		this.newDn = tableInfo.getNewDataNodes();
+		this.column = tableInfo.getColumn();
+		this.tableName = tableInfo.getTableName();
+		this.alg = tableInfo.getNewRuleAlgorithm();
+		this.newDnSize = newDn.size();
+		this.pageSize = pageSize;
+		this.isExpantion = tableInfo.isExpantion();
+		this.index = srcDn.getIndex();
+	}
+	
+	@Override
+	public void run() {
+		if(tableInfo.isError()) return;
+		
+		long[] count = new long[newDnSize];
+    	int page=0;
+    	List<Map<String, Object>> list=null;
+		
+    	Connection con = null;
+		try {
+			con = DataMigratorUtil.getMysqlConnection(srcDn);
+			//创建空的中间临时文件
+			createTempFiles();
+			
+			//暂时只实现mysql的分页查询
+			list = DataMigratorUtil.executeQuery(con, "select " 
+			        + column+ " from " + tableName + " limit ?,?", page++ * pageSize,
+			        pageSize);
+			int total = 0; //该节点表总数据量
+			
+			while (!CollectionUtil.isEmpty(list)) {
+				if(tableInfo.isError()) return;
+				flushData(map,false);
+    			for(int i=0,l=list.size();i<l;i++){
+    				Map<String, Object> sf=list.get(i);
+    				String filedVal = sf.get(column).toString();
+    				Integer newIndex=alg.calculate(filedVal);
+    				total++;
+    				if(!srcDn.equals(newDn.get(newIndex))){
+    					count[newIndex]++;
+    					map.get(newIndex).append(filedVal+",");
+    				}
+    			}
+    			list = DataMigratorUtil.executeQuery(con, "select "
+                        + column + " from " + tableName + " limit ?,?", page++ * pageSize,
+                        pageSize);
+    		}
+			flushData(map,true);
+			statisticalData(total,count);
+		} catch (Exception e) {
+			//发生错误，终止此拆分表所有节点线程任务，记录错误信息，退出此拆分表迁移任务
+			String message = "["+tableInfo.getSchemaName()+":"+tableName+"]  src dataNode: "+srcDn.getUrl()+
+					" prepare temp files is failed! this table's migrator will exit! "+e.getMessage();
+			tableInfo.setError(true);
+			tableInfo.setErrMessage(message);
+			System.out.println(message);
+			LOGGER.error(message, e);
+		}finally{
+			JdbcUtils.close(con);
+		}
+	}
+	
+	//创建中间临时文件
+	private void createTempFiles() throws IOException{
+		File parentFile = createDirIfNotExist();
+		for(int i= 0;i<newDnSize;i++){
+			if(i == index && isExpantion) continue;
+			map.put(i, new StringBuilder());
+			createTempFile(parentFile,i);
+		}
+	}
+	
+	
+	//中间临时文件 格式: srcDnName-targetDnName.txt   中间文件存在的话会被清除
+	private void createTempFile(File parentFile, int i) throws IOException {
+		File f = new File(parentFile,srcDn.getName()+"(old)"+"-"+newDn.get(i).getName()+"(new).txt");
+		if(f.exists()){
+			f.delete();
+		}
+		f.createNewFile();
+		files.put(newDn.get(i), f);
+	}
+	
+	//统计各节点数据迁移信息,并移除空文件
+	private void statisticalData(int total, long[] count){
+		tableInfo.getSize().addAndGet(total);
+		List<DataNodeMigrateInfo> list = tableInfo.getDataNodesDetail();
+		List<Long> sizeList = new ArrayList<>();
+		for(int i=0;i<count.length;i++){
+			long c = count[i];
+			sizeList.add(c);
+			DataNode targetDn = newDn.get(i);
+			if(count[i]>0){
+				DataNodeMigrateInfo info  =new DataNodeMigrateInfo(tableInfo,srcDn, targetDn, files.get(targetDn), c);
+				list.add(info);
+			}else{
+				File f = files.get(targetDn);
+				if(f != null && f.exists()){
+					f.delete();
+				}
+				files.remove(targetDn);
+			}
+		}
+		Map<String, String> map = tableInfo.getDnMigrateSize();
+		map.put(srcDn.getName()+"["+total+"]", sizeList.toString());
+	}
+	
+	//将迁移字段值写入中间文件,数据超过1024或者要求强制才写入，避免重复打开关闭写入文件
+	private void flushData(Map<Integer, StringBuilder> map,boolean isForce) throws IOException {
+		for(int i= 0;i<newDnSize;i++){
+			if(i == index && isExpantion) continue;  //扩容的话不需要考虑当前节点
+			StringBuilder sb = map.get(i);
+			if((isForce || sb.toString().getBytes().length>1024) && sb.length()>0){
+				String s = sb.toString();
+				if(isForce){//最后一次将末尾的','截掉
+					s = s.substring(0, s.length()-1);
+				}
+				DataMigratorUtil.appendDataToFile(files.get(newDn.get(i)),s);
+				sb = new StringBuilder();
+				map.put(i, sb);
+			}
+		}
+	}
+	
+	//创建中间临时文件父目录
+	private File createDirIfNotExist() {
+		File f = new File(tempFileDir,tableInfo.getSchemaName()+"-"+tableName);
+		if(!f.exists()){
+			f.mkdirs();
+		}
+		return f;
+	}
+}

--- a/src/main/java/io/mycat/util/dataMigrator/TableMigrateInfo.java
+++ b/src/main/java/io/mycat/util/dataMigrator/TableMigrateInfo.java
@@ -1,0 +1,243 @@
+package io.mycat.util.dataMigrator;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.alibaba.druid.util.JdbcUtils;
+
+import io.mycat.route.function.AbstractPartitionAlgorithm;
+
+
+/**
+ * 表迁移信息，包括:
+ * 表名、迁移前后的数据节点、表数据量、迁移前后数据分布对比
+ * @author haonan108
+ *
+ */
+
+public class TableMigrateInfo {
+
+	private String schemaName;
+	private String tableName;
+	private List<DataNode> oldDataNodes;
+	private List<DataNode> newDataNodes;
+	private AtomicLong size = new AtomicLong();
+	
+	private List<DataNodeMigrateInfo> dataNodesDetail = new ArrayList<>();//节点间数据迁移详细信息
+	
+	private AbstractPartitionAlgorithm newRuleAlgorithm;
+	private String column;
+	
+	private boolean isExpantion; //true:扩容 false：缩容
+	
+	private volatile boolean isError; 
+	
+    private StringBuffer errMessage = new StringBuffer();
+    
+    private String tableStructure = ""; //记录建表信息，迁移后的节点表不存在的话自动建表
+    
+    private Map<String,String> dnMigrateSize;
+	
+	public TableMigrateInfo(String schemaName, String tableName, List<DataNode> oldDataNodes,
+			List<DataNode> newDataNodes, AbstractPartitionAlgorithm newRuleAlgorithm, String column) {
+		super();
+		this.schemaName = schemaName;
+		this.tableName = tableName;
+		this.oldDataNodes = oldDataNodes;
+		this.newDataNodes = newDataNodes;
+		this.newRuleAlgorithm = newRuleAlgorithm;
+		this.column = column;
+		if(newDataNodes.size()>oldDataNodes.size()){
+			isExpantion = true;
+		}else{
+			isExpantion = false;
+		}
+		dnMigrateSize = new TreeMap<>(new Comparator<String>() {
+			@Override
+			public int compare(String o1, String o2) {
+				return o1.compareTo(o2);
+			}
+		});
+	}
+	
+	//读取表结构
+	public  void setTableStructure() throws SQLException{
+		DataNode dn = this.getOldDataNodes().get(0);
+		Connection con = null;
+		try {
+			con = DataMigratorUtil.getMysqlConnection(dn);
+			List<Map<String, Object>> list = DataMigratorUtil.executeQuery(con, "show create table "+tableName);
+			Map<String, Object> m  = list.get(0);
+			String str = m.get("Create Table").toString();
+			str = str.replaceAll("CREATE TABLE", "Create Table if not exists");
+			setTableStructure(str);
+		} catch (SQLException e) {
+			throw e;
+		}finally {
+			JdbcUtils.close(con);
+		}
+	}
+	
+	//缩容后，找出被移除的节点
+	public List<DataNode> getRemovedDataNodes(){
+		List<DataNode> list = new ArrayList<>();
+		list.addAll(oldDataNodes);
+		list.removeAll(newDataNodes);
+		return list;
+	}
+	
+	//扩容后，找出除旧节点以外新增加的节点
+	public List<DataNode> getNewAddDataNodes(){
+		List<DataNode> list = new ArrayList<>();
+		list.addAll(newDataNodes);
+		list.removeAll(oldDataNodes);
+		return list;
+	}
+	
+	//对新增的节点创建表：create table if not exists 
+	public void createTableToNewDataNodes() throws SQLException{
+		if(this.isExpantion){
+			List<DataNode> newDataNodes = getNewAddDataNodes();
+			for(DataNode dn:newDataNodes){
+				DataMigratorUtil.createTable(dn, this.tableStructure);
+			}
+		}
+	}
+	
+	//打印迁移信息
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void printMigrateInfo(){
+		Map<String,String> map = new LinkedHashMap();
+		map.put("tableSize", size.get()+"");
+		map.put("migrate before", oldDataNodes.toString());
+		map.put("migrate after", newDataNodes.toString());
+		map.put("rule function", newRuleAlgorithm.getClass().getSimpleName());
+		String title = getSchemaAndTableName()+" migrate info";
+		System.out.println(DataMigratorUtil.printMigrateInfo(title, map, "="));
+	}
+	
+	public void printMigrateSchedule(){
+		String title = getSchemaAndTableName()+" migrate schedule";
+		System.out.println(DataMigratorUtil.printMigrateInfo(title, dnMigrateSize, "->"));
+	}
+	
+	/**
+	 * 是否为扩容，true：扩容，false：缩容
+	 * @return
+	 */
+	public boolean isExpantion(){
+		return isExpantion;
+	}
+
+	public List<DataNodeMigrateInfo> getDataNodesDetail() {
+		return dataNodesDetail;
+	}
+
+	public void setDataNodesDetail(List<DataNodeMigrateInfo> dataNodesDetail) {
+		this.dataNodesDetail = dataNodesDetail;
+	}
+
+	public String getSchemaName() {
+		return schemaName;
+	}
+
+	public void setSchemaName(String schemaName) {
+		this.schemaName = schemaName;
+	}
+
+	public String getTableName() {
+		return tableName;
+	}
+
+	public void setTableName(String tableName) {
+		this.tableName = tableName;
+	}
+
+	public List<DataNode> getOldDataNodes() {
+		return oldDataNodes;
+	}
+
+	public void setOldDataNodes(List<DataNode> oldDataNodes) {
+		this.oldDataNodes = oldDataNodes;
+	}
+
+	public List<DataNode> getNewDataNodes() {
+		return newDataNodes;
+	}
+
+	public void setNewDataNodes(List<DataNode> newDataNodes) {
+		this.newDataNodes = newDataNodes;
+	}
+
+	public AbstractPartitionAlgorithm getNewRuleAlgorithm() {
+		return newRuleAlgorithm;
+	}
+
+	public void setNewRuleAlgorithm(AbstractPartitionAlgorithm newRuleAlgorithm) {
+		this.newRuleAlgorithm = newRuleAlgorithm;
+	}
+
+	public String getColumn() {
+		return column;
+	}
+
+	public void setColumn(String column) {
+		this.column = column;
+	}
+	
+	public String getSchemaAndTableName(){
+		return "["+schemaName+":"+tableName+"]";
+	}
+
+	public StringBuffer getErrMessage() {
+		return errMessage;
+	}
+
+	public void setErrMessage(String errMessage) {
+		this.errMessage = new StringBuffer(errMessage);
+	}
+
+	public AtomicLong getSize() {
+		return size;
+	}
+	
+	public void setSize(long size){
+		this.size = new AtomicLong(size);
+	}
+
+	public boolean isError() {
+		return isError;
+	}
+
+	public void setError(boolean isError) {
+		this.isError = isError;
+	}
+
+	public String getTableStructure() {
+		return tableStructure;
+	}
+
+	public void setTableStructure(String tableStructure) {
+		this.tableStructure = tableStructure;
+	}
+
+	public void setSize(AtomicLong size) {
+		this.size = size;
+	}
+
+	public Map<String, String> getDnMigrateSize() {
+		return dnMigrateSize;
+	}
+
+	public void setDnMigrateSize(Map<String, String> dnMigrateSize) {
+		this.dnMigrateSize = dnMigrateSize;
+	}
+	
+}

--- a/src/main/java/io/mycat/util/dataMigrator/dataIOImpl/MysqlDataIO.java
+++ b/src/main/java/io/mycat/util/dataMigrator/dataIOImpl/MysqlDataIO.java
@@ -1,0 +1,130 @@
+package io.mycat.util.dataMigrator.dataIOImpl;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.mycat.util.dataMigrator.DataIO;
+import io.mycat.util.dataMigrator.DataMigrator;
+import io.mycat.util.dataMigrator.DataMigratorUtil;
+import io.mycat.util.dataMigrator.DataNode;
+import io.mycat.util.dataMigrator.TableMigrateInfo;
+import io.mycat.util.exception.DataMigratorException;
+
+/**
+ * mysql导入导出实现类
+ * @author haonan108
+ *
+ */
+public class MysqlDataIO implements DataIO{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MysqlDataIO.class); 
+	
+	private String mysqlBin;
+	private int cmdLength;
+	private String charset;
+	
+	private Runtime runtime = Runtime.getRuntime();
+	
+	public MysqlDataIO(){
+		cmdLength = DataMigrator.margs.getCmdLength();
+		charset = DataMigrator.margs.getCharSet();
+		mysqlBin  = DataMigrator.margs.getMysqlBin();
+	}
+	
+	@Override
+	public void importData(TableMigrateInfo table,DataNode dn,String tableName, File file) throws IOException, InterruptedException {
+		String ip = dn.getIp();
+		int port = dn.getPort();
+		String user = dn.getUserName();
+		String pwd = dn.getPwd();
+		String db = dn.getDb();
+		
+		String loadData ="?mysql -h? -P? -u? -p? -D? --local-infile=1 -e \"load data local infile '?' replace into table ? CHARACTER SET '?' FIELDS TERMINATED BY ','  LINES TERMINATED BY '\\r\\n'\"";
+		loadData = DataMigratorUtil.paramsAssignment(loadData,mysqlBin,ip,port,user,pwd,db,file.getAbsolutePath(),tableName,charset);
+		LOGGER.debug(table.getSchemaAndTableName()+" "+loadData);
+		Process process = runtime.exec((new String[]{"sh","-c",loadData}));
+		
+		//获取错误信息
+		InputStreamReader in = new InputStreamReader(process.getErrorStream());
+		BufferedReader br = new BufferedReader(in);
+		String errMessage = null;  
+        while ((errMessage = br.readLine()) != null) {  
+            if(!errMessage.startsWith("Warning")){
+            	System.out.println(errMessage+" -> "+loadData);
+            }
+        }
+        
+		process.waitFor();
+	}
+
+	@Override
+	public File exportData(TableMigrateInfo table,DataNode dn, String tableName, File export, File condition) throws IOException, InterruptedException {
+		String ip = dn.getIp();
+		int port = dn.getPort();
+		String user = dn.getUserName();
+		String pwd = dn.getPwd();
+		String db = dn.getDb();
+		
+		String mysqlDump = "?mysqldump -h? -P? -u? -p? ? ?  --no-create-info --default-character-set=? "
+				+ "--add-locks=false --tab='?' --fields-terminated-by=',' --lines-terminated-by='\\r\\n' --where='? in(?)'";
+		String fileName = condition.getName();
+		File exportPath = new File(export,fileName.substring(0, fileName.indexOf(".txt")));
+		if(!exportPath.exists()){
+			exportPath.mkdirs();
+		}
+		//拼接mysqldump命令，不拼接where条件：--where=id in(?)
+		mysqlDump = DataMigratorUtil.paramsAssignment(mysqlDump,mysqlBin,ip,port,user,pwd,db,tableName,charset,exportPath,table.getColumn());
+
+		String data = "";
+		//由于操作系统对命令行长度的限制，导出过程被拆分成多次，最后需要将导出的数据文件合并
+		File mergedFile = new File(exportPath,tableName.toLowerCase()+".sql");
+		if(!mergedFile.exists()){
+			mergedFile.createNewFile();
+		}
+		int offset = 0;
+		while((data=DataMigratorUtil.readData(condition,offset,cmdLength)).length()>0){
+			offset += data.getBytes().length;
+			if(data.startsWith(",")){
+				data = data.substring(1, data.length());
+			}
+			if(data.endsWith(",")){
+				data = data.substring(0,data.length()-1);
+			}
+			String mysqlDumpCmd = DataMigratorUtil.paramsAssignment(mysqlDump,data);
+			Process process = runtime.exec((new String[]{"sh","-c",mysqlDumpCmd}));
+			//获取错误信息
+			InputStreamReader in = new InputStreamReader(process.getErrorStream());
+			BufferedReader br = new BufferedReader(in);
+			String errMessage = null;  
+	        while ((errMessage = br.readLine()) != null) {  
+	            if(!errMessage.startsWith("Warning")){
+	            	LOGGER.error("err data->"+data);
+	            	System.out.println(errMessage+" -> "+mysqlDump);
+	            }
+	        }
+			process.waitFor();
+			//查找导出的文件
+			File[] files = exportPath.listFiles();
+			File exportFile = null;
+			for(int i=0;i<files.length;i++){
+				if(!files[i].getName().equals(mergedFile.getName())){
+					exportFile = files[i];
+					break;
+				}
+			}
+			if(exportFile == null){
+				 errMessage = "can not find dump file -------> "+mysqlDumpCmd;
+				 throw new DataMigratorException(errMessage);
+			}
+			//合并文件
+			DataMigratorUtil.mergeFiles(mergedFile, exportFile);
+			
+		}
+		return mergedFile;
+	}
+}

--- a/src/main/java/io/mycat/util/exception/DataMigratorException.java
+++ b/src/main/java/io/mycat/util/exception/DataMigratorException.java
@@ -1,0 +1,36 @@
+package io.mycat.util.exception;
+/**
+ * 
+ * @author haonan108
+ *
+ */
+public class DataMigratorException  extends RuntimeException{
+
+	private static final long serialVersionUID = -6706826479467595980L;
+
+	public DataMigratorException() {
+		super();
+		
+	}
+
+	public DataMigratorException(String message, Throwable cause,
+			boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+		
+	}
+
+	public DataMigratorException(String message, Throwable cause) {
+		super(message, cause);
+		
+	}
+
+	public DataMigratorException(String message) {
+		super(message);
+		
+	}
+
+	public DataMigratorException(Throwable cause) {
+		super(cause);
+		
+	}
+}

--- a/src/main/resources/migrateTables.properties
+++ b/src/main/resources/migrateTables.properties
@@ -1,0 +1,6 @@
+#schema1=tb1,tb2,...
+#schema2=all（写all或者不写将对此schema下拆分节点变化的拆分表全部进行重新路由）
+#...
+
+#sample
+#TESTDB=travelrecord,company,goods


### PR DESCRIPTION
**原理：**读取要迁移的节点数据表拆分字段值，根据迁移后的配置进行路由，将需要迁移的数据id字段值记录在文件中，然后通过mysqldump将id字段值所有数据dump到sql文件中，再将sql文件导入到迁移后的节点上，最后将要迁移的节点数据上已迁移的数据删除。

一个拆分表数据的迁移过程：
{
   old dn1->重新路由->中间文件->导出数据->导入数据->new dn1
   old dn2->重新路由->中间文件->导出数据->导入数据->new dn2
   ...
}

异常处理：（一个拆分表数据迁移出错，不影响其他拆分表的迁移，拆分表迁移过程中任何环节出错，停止整个拆分表的迁移任务，迁移程序执行完成后，提供迁移成功和失败拆分表信息列表，及失败原因，维护人员根据失败原因进行故障排查后，重新迁移失败的拆分表）
读取配置文件->抛出错误，终止程序
生成中间文件，数据导出，导入->抛出错误，终止出错节点所属拆分表的所有节点线程任务，不影响其他拆分表线程任务

**扩容缩容步骤：**
1、复制schema.xml、rule.xml并重命名为newSchema.xml、newRule.xml放于conf目录下
2、修改newSchema.xml和newRule.xml配置文件为扩容缩容后的mycat配置参数（表的节点数、数据源、路由规则）
3、修改conf目录下的migrateTables.properties配置文件，告诉工具哪些表需要进行扩容或缩容,没有出现在此配置文件的schema表不会进行数据迁移
4、修改bin目录下的dataMigrate.sh脚本文件，具体参数含义参考bin/dataMigrate.sh中的注释
5、停止mycat服务（如果可以确保扩容缩容过程中只有读操作，也可以不停止mycat服务）
6、执行bin/ dataMigrate.sh脚本，开始扩容/缩容过程
7、扩容缩容成功后，将newSchema.xml和newRule.xml重命名为schema.xml和rule.xml并替换掉原文件，重启mycat服务，整个扩容缩容过程完成。

