### PR TITLE
1、迁移1.6版本注释注解处理‘db_type=master/slave’场景

### DIFF
--- a/src/main/java/org/opencloudb/backend/PhysicalDBNode.java
+++ b/src/main/java/org/opencloudb/backend/PhysicalDBNode.java
@@ -94,7 +94,10 @@ public class PhysicalDBNode {
 		if (dbPool.isInitSuccess()) {
 			LOGGER.debug("rrs.getRunOnSlave() " + rrs.getRunOnSlave());
 			if (rrs.getRunOnSlave() != null) { // 带有 /*db_type=master/slave*/ 注解
-				if (rrs.getRunOnSlave()) { // 强制走 slave
+				// 强制走 slave
+                // 当autoCommit=false场景下，有可能一个查询需要依赖同一个事物内
+                //之前的插入操作，此时即使用户指定db_type=slave,也要强制查询走主节点，保证数据准确性
+				if (rrs.getRunOnSlave()&&autoCommit) { 
 					LOGGER.debug("rrs.isHasBlanceFlag() "
 							+ rrs.isHasBlanceFlag());
 					if (rrs.isHasBlanceFlag()) { // 带有 /*balance*/

--- a/src/main/java/org/opencloudb/backend/PhysicalDBNode.java
+++ b/src/main/java/org/opencloudb/backend/PhysicalDBNode.java
@@ -86,8 +86,58 @@ public class PhysicalDBNode {
 			dbPool.init(dbPool.activedIndex);
 		}
 	}
+	
+	public void getConnection(String schema, boolean autoCommit,
+			RouteResultsetNode rrs, ResponseHandler handler, Object attachment)
+			throws Exception {
+		checkRequest(schema);
+		if (dbPool.isInitSuccess()) {
+			LOGGER.debug("rrs.getRunOnSlave() " + rrs.getRunOnSlave());
+			if (rrs.getRunOnSlave() != null) { // 带有 /*db_type=master/slave*/ 注解
+				if (rrs.getRunOnSlave()) { // 强制走 slave
+					LOGGER.debug("rrs.isHasBlanceFlag() "
+							+ rrs.isHasBlanceFlag());
+					if (rrs.isHasBlanceFlag()) { // 带有 /*balance*/
+													// 注解(目前好像只支持一个注解...)
+						dbPool.getReadBanlanceCon(schema, autoCommit, handler,
+								attachment, this.database);
+					} else { // 没有 /*balance*/ 注解
+						LOGGER.debug("rrs.isHasBlanceFlag()"
+								+ rrs.isHasBlanceFlag());
+						if (!dbPool.getReadCon(schema, autoCommit, handler,
+								attachment, this.database)) {
+							LOGGER.warn("Do not have slave connection to use, use master connection instead.");
+							dbPool.getSource().getConnection(schema,
+									autoCommit, handler, attachment);
+							rrs.setRunOnSlave(false);
+							rrs.setCanRunInReadDB(false);
+						}
+					}
+				} else { // 强制走 master
+					// 默认获得的是 writeSource，也就是 走master
+					LOGGER.debug("rrs.getRunOnSlave() " + rrs.getRunOnSlave());
+					dbPool.getSource().getConnection(schema, autoCommit,
+							handler, attachment);
+					rrs.setCanRunInReadDB(false);
+				}
+			} else { // 没有 /*db_type=master/slave*/ 注解，按照原来的处理方式
+				LOGGER.debug("rrs.getRunOnSlave() " + rrs.getRunOnSlave()); // null
+				if (rrs.canRunnINReadDB(autoCommit)) {
+					dbPool.getRWBanlanceCon(schema, autoCommit, handler,
+							attachment, this.database);
+				} else {
+					dbPool.getSource().getConnection(schema, autoCommit,
+							handler, attachment);
+				}
+			}
 
-	public void getConnection(String schema,boolean autoCommit, RouteResultsetNode rrs,
+		} else {
+			throw new IllegalArgumentException("Invalid DataSource:"
+					+ dbPool.getActivedIndex());
+		}
+	}
+
+	/*public void getConnection(String schema,boolean autoCommit, RouteResultsetNode rrs,
 			ResponseHandler handler, Object attachment) throws Exception {
 		checkRequest(schema);
 		if (dbPool.isInitSuccess()) {
@@ -102,5 +152,5 @@ public class PhysicalDBNode {
 			throw new IllegalArgumentException("Invalid DataSource:"
 					+ dbPool.getActivedIndex());
 		}
-	}
+	}*/
 }

--- a/src/main/java/org/opencloudb/mysql/nio/handler/SingleNodeHandler.java
+++ b/src/main/java/org/opencloudb/mysql/nio/handler/SingleNodeHandler.java
@@ -150,6 +150,10 @@ public class SingleNodeHandler implements ResponseHandler, Terminatable,
 		this.isRunning = true;
 		this.packetId = 0;
 		final BackendConnection conn = session.getTarget(node);
+		LOGGER.debug("rrs.getRunOnSlave() " + rrs.getRunOnSlave());
+		node.setRunOnSlave(rrs.getRunOnSlave());	// 实现 master/slave注解
+		LOGGER.debug("node.getRunOnSlave() " + node.getRunOnSlave());
+
 		//之前是否获取过Connection并且Connection有效
 		if (session.tryExistsCon(conn, node)) {
 			_execute(conn);

--- a/src/main/java/org/opencloudb/route/RouteResultset.java
+++ b/src/main/java/org/opencloudb/route/RouteResultset.java
@@ -67,6 +67,18 @@ public final class RouteResultset implements Serializable {
 
     //是否可以在从库运行,此属性主要供RouteResultsetNode获取
     private Boolean canRunInReadDB;
+    
+    // 强制走 master，可以通过 RouteResultset的属性canRunInReadDB=false
+    // 传给 RouteResultsetNode 来实现，但是 强制走 slave需要增加一个属性来实现:
+    private Boolean runOnSlave = null;	// 默认null表示不施加影响
+    
+    public Boolean getRunOnSlave() {
+		return runOnSlave;
+	}
+
+	public void setRunOnSlave(Boolean runOnSlave) {
+		this.runOnSlave = runOnSlave;
+	}
 
     private Procedure procedure;
 

--- a/src/main/java/org/opencloudb/route/RouteResultsetNode.java
+++ b/src/main/java/org/opencloudb/route/RouteResultsetNode.java
@@ -47,8 +47,12 @@ public final class RouteResultsetNode implements Serializable , Comparable<Route
 	private int limitStart;
 	private int limitSize;
 	private int totalNodeSize =0; //方便后续jdbc批量获取扩展
-   private Procedure procedure;
+    private Procedure procedure;
 	private LoadData loadData;
+	
+	// 强制走 master，可以通过 RouteResultset的属性canRunInReadDB(false)
+	// 传给 RouteResultsetNode 来实现，但是 强制走 slave需要增加一个属性来实现:
+	private Boolean runOnSlave = null;	// 默认null表示不施加影响, true走slave,false走master
 
 	public RouteResultsetNode(String name, int sqlType, String srcStatement) {
 		this.name = name;
@@ -72,6 +76,14 @@ public final class RouteResultsetNode implements Serializable , Comparable<Route
     {
         this.hintMap = hintMap;
     }
+    
+    public Boolean getRunOnSlave() {
+		return runOnSlave;
+	}
+
+	public void setRunOnSlave(Boolean runOnSlave) {
+		this.runOnSlave = runOnSlave;
+	}
 
 	public void setStatement(String statement) {
 		this.statement = statement;
@@ -215,5 +227,9 @@ public final class RouteResultsetNode implements Serializable , Comparable<Route
 			return 1;
 		}
 		return this.name.compareTo(obj.name);
+	}
+	
+	public boolean isHasBlanceFlag() {
+		return hasBlanceFlag;
 	}
 }

--- a/src/main/java/org/opencloudb/route/handler/HintHandlerFactory.java
+++ b/src/main/java/org/opencloudb/route/handler/HintHandlerFactory.java
@@ -18,6 +18,11 @@ public class HintHandlerFactory {
         hintHandlerMap.put("schema",new HintSchemaHandler());
         hintHandlerMap.put("datanode",new HintDataNodeHandler());
         hintHandlerMap.put("catlet",new HintCatletHandler());
+        
+        // 新增sql hint（注解）/*#mycat:db_type=master*/ 和 /*#mycat:db_type=slave*/
+        // 该hint可以和 /*balance*/ 一起使用
+        // 实现强制走 master 和 强制走 slave
+        hintHandlerMap.put("db_type", new HintMasterDBHandler());
         isInit = true;	// 修复多次初始化的bug
     }
     

--- a/src/main/java/org/opencloudb/route/handler/HintMasterDBHandler.java
+++ b/src/main/java/org/opencloudb/route/handler/HintMasterDBHandler.java
@@ -1,0 +1,88 @@
+package org.opencloudb.route.handler;
+
+
+
+import java.sql.SQLNonTransientException;
+import java.util.Map;
+
+import org.opencloudb.cache.LayerCachePool;
+import org.opencloudb.config.model.SchemaConfig;
+import org.opencloudb.config.model.SystemConfig;
+import org.opencloudb.route.RouteResultset;
+import org.opencloudb.route.factory.RouteStrategyFactory;
+import org.opencloudb.server.ServerConnection;
+import org.opencloudb.server.parser.ServerParse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 处理情况 sql hint: mycat:db_type=master/slave<br/>
+ * 后期可能会考虑增加 mycat:db_type=slave_newest，实现走延迟最小的slave
+ * @author digdeep@126.com
+ */
+// /*#mycat:db_type=master*/
+// /*#mycat:db_type=slave*/
+// /*#mycat:db_type=slave_newest*/
+// 强制走 master 和 强制走 slave
+public class HintMasterDBHandler implements HintHandler {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(HintMasterDBHandler.class);
+
+	@Override
+	public RouteResultset route(SystemConfig sysConfig, SchemaConfig schema, int sqlType, 
+			String realSQL, String charset,
+			ServerConnection sc, LayerCachePool cachePool, String hintSQLValue, int hintSqlType, Map hintMap)
+					throws SQLNonTransientException {
+		
+//		LOGGER.debug("realSQL: " + realSQL); // select * from travelrecord limit 1
+//		LOGGER.debug("sqlType: " + sqlType); // 7
+//		LOGGER.debug("schema.getName(): " + schema.getName()); // TESTDB
+//		LOGGER.debug("schema.getName(): " + schema.getDataNode()); // null
+//		LOGGER.debug("hintSQLValue: " + hintSQLValue); // master/slave
+		
+		RouteResultset rrs = RouteStrategyFactory.getRouteStrategy()
+									.route(sysConfig, schema, sqlType, 
+										realSQL, charset, sc, cachePool);
+		
+		LOGGER.debug("schema.rrs(): " + rrs); // master
+		Boolean isRouteToMaster = null;	// 默认不施加任何影响
+		
+		LOGGER.debug("hintSQLValue:::::::::" + hintSQLValue); // slave
+		
+		if(hintSQLValue != null && !hintSQLValue.trim().equals("")){
+			if(hintSQLValue.trim().equalsIgnoreCase("master"))
+				isRouteToMaster = true;
+			if(hintSQLValue.trim().equalsIgnoreCase("slave")){
+//				if(rrs.getCanRunInReadDB() != null && !rrs.getCanRunInReadDB()){
+//					isRouteToMaster = null;
+//					LOGGER.warn(realSQL + " can not run in slave.");
+//				}else{
+//					isRouteToMaster = false;
+//				}
+				if(sqlType == ServerParse.DELETE || sqlType == ServerParse.INSERT
+						||sqlType == ServerParse.REPLACE || sqlType == ServerParse.UPDATE
+						|| sqlType == ServerParse.DDL){
+					LOGGER.error("should not use hint 'db_type' to route 'delete', 'insert', 'replace', 'update', 'ddl' to a slave db.");
+					isRouteToMaster = null;	// 不施加任何影响
+				}else{
+					isRouteToMaster = false;
+				}
+			}
+		}
+		
+		if(isRouteToMaster == null){	// 默认不施加任何影响
+			LOGGER.warn(" sql hint 'db_type' error, ignore this hint.");
+			return rrs;
+		}
+		
+		if(isRouteToMaster)	// 强制走 master 
+			rrs.setRunOnSlave(false);
+		
+		if(!isRouteToMaster)// 强制走slave
+			rrs.setRunOnSlave(true);
+		
+		LOGGER.debug("rrs.getRunOnSlave():" + rrs.getRunOnSlave());
+		return rrs;
+	}
+
+}


### PR DESCRIPTION
2、重构hint sql标志逻辑：
注解支持的'!'不被mysql单库兼容，
注解支持的'#'不被mybatis兼容
考虑支持mycat字符前缀标志Hintsql:"/** mycat: */"