### PR TITLE
增加支持/**mycat:*/注释注解头

### DIFF
--- a/src/main/java/io/mycat/backend/datasource/PhysicalDBNode.java
+++ b/src/main/java/io/mycat/backend/datasource/PhysicalDBNode.java
@@ -95,7 +95,10 @@ public class PhysicalDBNode {
 		if (dbPool.isInitSuccess()) {
 			LOGGER.debug("rrs.getRunOnSlave() " + rrs.getRunOnSlave());
 			if(rrs.getRunOnSlave() != null){		// 带有 /*db_type=master/slave*/ 注解
-				if(rrs.getRunOnSlave()){			// 强制走 slave
+				// 强制走 slave
+				// 当autoCommit=false场景下，有可能一个查询需要依赖同一个事物内
+                //之前的插入操作，此时即使用户指定db_type=slave,也要强制查询走主节点，保证数据准确性
+				if(rrs.getRunOnSlave()&&autoCommit){			
 					LOGGER.debug("rrs.isHasBlanceFlag() " + rrs.isHasBlanceFlag());
 					if (rrs.isHasBlanceFlag()) {		// 带有 /*balance*/ 注解(目前好像只支持一个注解...)
 						dbPool.getReadBanlanceCon(schema,autoCommit,handler, attachment, this.database);

--- a/src/main/java/io/mycat/backend/datasource/PhysicalDBNode.java
+++ b/src/main/java/io/mycat/backend/datasource/PhysicalDBNode.java
@@ -96,9 +96,7 @@ public class PhysicalDBNode {
 			LOGGER.debug("rrs.getRunOnSlave() " + rrs.getRunOnSlave());
 			if(rrs.getRunOnSlave() != null){		// 带有 /*db_type=master/slave*/ 注解
 				// 强制走 slave
-				// 当autoCommit=false场景下，有可能一个查询需要依赖同一个事物内
-                //之前的插入操作，此时即使用户指定db_type=slave,也要强制查询走主节点，保证数据准确性
-				if(rrs.getRunOnSlave()&&autoCommit){			
+				if(rrs.getRunOnSlave()){			
 					LOGGER.debug("rrs.isHasBlanceFlag() " + rrs.isHasBlanceFlag());
 					if (rrs.isHasBlanceFlag()) {		// 带有 /*balance*/ 注解(目前好像只支持一个注解...)
 						dbPool.getReadBanlanceCon(schema,autoCommit,handler, attachment, this.database);

--- a/src/main/java/io/mycat/route/RouteService.java
+++ b/src/main/java/io/mycat/route/RouteService.java
@@ -100,8 +100,8 @@ public class RouteService {
                 	String hintType = (String) hintMap.get(MYCAT_HINT_TYPE);
                     String hintSql = (String) hintMap.get(hintType);
                     if( hintSql.length() == 0 ) {
-                    	LOGGER.warn("comment int sql must meet :/*!mycat:type=value*/ or /*#mycat:type=value*/: "+stmt);
-                    	throw new SQLSyntaxErrorException("comment int sql must meet :/*!mycat:type=value*/ or /*#mycat:type=value*/: "+stmt);
+                    	LOGGER.warn("comment int sql must meet :/*!mycat:type=value*/ or /*#mycat:type=value*/ or /*mycat:type=value*/: "+stmt);
+                    	throw new SQLSyntaxErrorException("comment int sql must meet :/*!mycat:type=value*/ or /*#mycat:type=value*/ or /*mycat:type=value*/: "+stmt);
                     }
                     String realSQL = stmt.substring(endPos + "*/".length()).trim();
 
@@ -125,8 +125,8 @@ public class RouteService {
                     }
                     
                 }else{//fixed by runfriends@126.com
-                	LOGGER.warn("comment in sql must meet :/*!mycat:type=value*/ or /*#mycat:type=value*/: "+stmt);
-                	throw new SQLSyntaxErrorException("comment in sql must meet :/*!mcat:type=value*/ or /*#mycat:type=value*/: "+stmt);
+                	LOGGER.warn("comment in sql must meet :/*!mycat:type=value*/ or /*#mycat:type=value*/ or /*mycat:type=value*/: "+stmt);
+                	throw new SQLSyntaxErrorException("comment in sql must meet :/*!mcat:type=value*/ or /*#mycat:type=value*/ or /*mycat:type=value*/: "+stmt);
                 }
 			}
 		} else {

--- a/src/main/java/io/mycat/route/RouteService.java
+++ b/src/main/java/io/mycat/route/RouteService.java
@@ -150,6 +150,12 @@ public class RouteService {
 			while(j < len && c != '!' && c != '#' && (c == ' ' || c == '*')){
 				c = sql.charAt(++j);
 			}
+			//注解支持的'!'不被mysql单库兼容，
+			//注解支持的'#'不被mybatis兼容
+			//考虑用mycat字符前缀标志Hintsql:"/** mycat: */"
+			if(sql.charAt(j)=='m'){
+				j--;
+			}
 			if(j + 6 >= len)	// prevent the following sql.charAt overflow
 				return -1;		// false
 			if(sql.charAt(++j) == 'm' && sql.charAt(++j) == 'y' && sql.charAt(++j) == 'c'

--- a/src/main/java/io/mycat/route/handler/HintHandlerFactory.java
+++ b/src/main/java/io/mycat/route/handler/HintHandlerFactory.java
@@ -19,7 +19,7 @@ public class HintHandlerFactory {
         hintHandlerMap.put("datanode",new HintDataNodeHandler());
         hintHandlerMap.put("catlet",new HintCatletHandler());
         
-        // 新增sql hint（注解）/*#mycat:db_type=master*/ 和 /*#mycat:db_type=slave*/
+        // 新增sql hint（注解）/*#mycat:db_type=master*/ 和 /*#mycat:db_type=slave*/  和 /*mycat:db_type=slave*/
         // 该hint可以和 /*balance*/ 一起使用
         // 实现强制走 master 和 强制走 slave
         hintHandlerMap.put("db_type", new HintMasterDBHandler());

--- a/src/main/java/io/mycat/server/parser/ServerParse.java
+++ b/src/main/java/io/mycat/server/parser/ServerParse.java
@@ -658,7 +658,7 @@ public final class ServerParse {
 //  /*!mycat: sql=SELECT * FROM test where id=99 */set @pin=1;
 //                    call p_test(@pin,@pout);
 //                    select @pout;
-                    if(stmt.startsWith("/*!mycat:")||stmt.startsWith("/*#mycat:"))
+                    if(stmt.startsWith("/*!mycat:")||stmt.startsWith("/*#mycat:")||stmt.startsWith("/*mycat:"))
                     {
                         Matcher matcher = callPattern.matcher(stmt);
                         if (matcher.find()) return CALL;


### PR DESCRIPTION
注解支持的'#'不被mybatis兼容
添加hint sql支持的格式/** mycat: */
2、修改当事务提交模式为手动提交场景下，如果指定db_type=slave会强制走从节点的问题，原则是在事务内无论是否指定注解都应该走主节点。