### PR TITLE
将缓冲池抽象化为接口BufferPool，并且让ByteBufferArena和DirectByteBufferPool实现它。将MyCat的缓冲池修改为BufferPool类型，实现还是DirectByteBufferPool。（测试ByteBufferArena中）

### DIFF
--- a/src/main/java/io/mycat/MycatServer.java
+++ b/src/main/java/io/mycat/MycatServer.java
@@ -37,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.mycat.buffer.BufferPool;
+import io.mycat.buffer.ByteBufferArena;
 import io.mycat.config.model.SchemaConfig;
 import io.mycat.config.model.TableConfig;
 import io.mycat.config.table.structure.MySQLTableStructureDetector;
@@ -97,7 +99,7 @@ public class MycatServer {
 	private final SQLInterceptor sqlInterceptor;
 	private volatile int nextProcessor;
 	// System Buffer Pool Instance
-	private DirectByteBufferPool bufferPool;
+	private BufferPool bufferPool;
 	private boolean aio = false;
 
 	//XA事务全局ID生成
@@ -153,7 +155,7 @@ public class MycatServer {
 		this.startupTime = TimeUtil.currentTimeMillis();
 	}
 
-	public DirectByteBufferPool getBufferPool() {
+	public BufferPool getBufferPool() {
 		return bufferPool;
 	}
 
@@ -261,6 +263,7 @@ public class MycatServer {
 		int socketBufferLocalPercent = system.getProcessorBufferLocalPercent();
 		bufferPool = new DirectByteBufferPool(bufferPoolPageSize,bufferPoolChunkSize,
 				bufferPoolPageNumber,system.getFrontSocketSoRcvbuf());
+//		bufferPool = new ByteBufferArena(bufferPoolPageSize,bufferPoolChunkSize,bufferPoolPageNumber,system.getFrontSocketSoRcvbuf());
 		businessExecutor = ExecutorUtil.create("BusinessExecutor",
 				threadPoolSize);
 		timerExecutor = ExecutorUtil.create("Timer", system.getTimerExecutor());

--- a/src/main/java/io/mycat/buffer/BufferArray.java
+++ b/src/main/java/io/mycat/buffer/BufferArray.java
@@ -16,11 +16,11 @@ import java.util.List;
  * @author zagnix
  */
 public class BufferArray {
-	private final DirectByteBufferPool bufferPool;
+	private final BufferPool bufferPool;
 	private ByteBuffer curWritingBlock;
 	private List<ByteBuffer> writedBlockLst = Collections.emptyList();
 
-	public BufferArray(DirectByteBufferPool bufferPool) {
+	public BufferArray(BufferPool bufferPool) {
 		super();
 		this.bufferPool = bufferPool;
 		curWritingBlock = bufferPool.allocate(bufferPool.getChunkSize());

--- a/src/main/java/io/mycat/buffer/BufferPool.java
+++ b/src/main/java/io/mycat/buffer/BufferPool.java
@@ -1,0 +1,21 @@
+package io.mycat.buffer;
+
+import java.nio.ByteBuffer;
+
+/**
+ * 缓冲池
+ *
+ * @author Hash Zhang
+ * @version 1.0
+ * @time 12:19 2016/5/23
+ */
+public interface BufferPool {
+    public ByteBuffer allocate(int size);
+    public void recycle(ByteBuffer theBuf);
+    public int capacity();
+    public int size();
+    public int getConReadBuferChunk();
+    public  int getSharedOptsCount();
+    public int getChunkSize();
+    public BufferArray allocateArray();
+}

--- a/src/main/java/io/mycat/buffer/ByteBufferArena.java
+++ b/src/main/java/io/mycat/buffer/ByteBufferArena.java
@@ -4,6 +4,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -15,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @time 17:19 2016/5/17
  * @see @https://github.com/netty/netty
  */
-public class ByteBufferArena {
+public class ByteBufferArena implements BufferPool {
     private static final Logger LOGGER = LoggerFactory.getLogger(ByteBufferChunkList.class);
     private final ByteBufferChunkList q[];
 
@@ -26,12 +28,20 @@ public class ByteBufferArena {
     private final int pageSize;
     private final int chunkSize;
 
+    private final AtomicInteger capacity;
+    private final AtomicInteger size;
 
-    public ByteBufferArena(int chunkSize, int pageSize, int chunkCount) {
+    private final ConcurrentHashMap<Thread, Integer> sharedOptsCount;
+
+    private final int conReadBuferChunk;
+
+    public ByteBufferArena(int chunkSize, int pageSize, int chunkCount, int conReadBuferChunk) {
         try {
             this.chunkSize = chunkSize;
             this.pageSize = pageSize;
             this.chunkCount.set(chunkCount);
+            this.conReadBuferChunk = conReadBuferChunk;
+
             q = new ByteBufferChunkList[6];
             q[5] = new ByteBufferChunkList(100, Integer.MAX_VALUE, chunkSize, pageSize, 0);
             q[4] = new ByteBufferChunkList(75, 100, chunkSize, pageSize, 0);
@@ -53,10 +63,15 @@ public class ByteBufferArena {
             q[2].prevList = q[1];
             q[1].prevList = q[0];
             q[0].prevList = null;
+
+            capacity = new AtomicInteger(6 * chunkCount * chunkSize);
+            size = new AtomicInteger(6 * chunkCount * chunkSize);
+            sharedOptsCount = new ConcurrentHashMap<>();
         } finally {
         }
     }
 
+    @Override
     public ByteBuffer allocate(int reqCapacity) {
         try {
             ByteBuffer byteBuffer = null;
@@ -80,6 +95,15 @@ public class ByteBufferArena {
 //                System.out.println(failCount.get());
 //            }
 //            printList();
+            capacity.addAndGet(-reqCapacity);
+            final Thread thread =  Thread.currentThread();
+            if (sharedOptsCount.contains(thread)) {
+                int currentCount = sharedOptsCount.get(thread);
+                currentCount++;
+                sharedOptsCount.put(thread,currentCount);
+            } else{
+                sharedOptsCount.put(thread,0);
+            }
             return byteBuffer;
         } finally {
         }
@@ -92,7 +116,8 @@ public class ByteBufferArena {
         failCount.set(0);
     }
 
-    public boolean recycle(ByteBuffer byteBuffer) {
+    @Override
+    public void recycle(ByteBuffer byteBuffer) {
         try {
             int i;
             for (i = 0; i < 6; i++) {
@@ -102,9 +127,18 @@ public class ByteBufferArena {
             }
             if (i > 5) {
                 LOGGER.warn("This ByteBuffer is not maintained in ByteBufferArena!");
-                return false;
+                return;
             }
-            return true;
+            final Thread thread =  Thread.currentThread();
+            if (sharedOptsCount.contains(thread)) {
+                int currentCount = sharedOptsCount.get(thread);
+                currentCount--;
+                sharedOptsCount.put(thread,currentCount);
+            } else{
+                sharedOptsCount.put(thread,0);
+            }
+            capacity.addAndGet(byteBuffer.capacity());
+            return;
         } finally {
         }
     }
@@ -113,5 +147,44 @@ public class ByteBufferArena {
         for (int i = 0; i < 6; i++) {
             System.out.println(i + ":" + q[i].byteBufferChunks.toString());
         }
+    }
+
+    @Override
+    public int capacity() {
+        return capacity.get();
+    }
+
+    @Override
+    public int size() {
+        return size.get();
+    }
+
+    @Override
+    public int getConReadBuferChunk() {
+        return conReadBuferChunk;
+    }
+
+    @Override
+    public int getSharedOptsCount() {
+        final Set<Integer> integers = (Set<Integer>) sharedOptsCount.values();
+        int count = 0;
+        for(int i : integers){
+            count += i;
+        }
+        return count;
+    }
+
+    /**
+     * 这里pageSize就是DirectByteBuffer的chunksize
+     * @return
+     */
+    @Override
+    public int getChunkSize() {
+        return pageSize;
+    }
+
+    @Override
+    public BufferArray allocateArray() {
+        return new BufferArray(this);
     }
 }

--- a/src/main/java/io/mycat/buffer/DirectByteBufferPool.java
+++ b/src/main/java/io/mycat/buffer/DirectByteBufferPool.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author zagnix
  */
 @SuppressWarnings("restriction")
-public class DirectByteBufferPool {
+public class DirectByteBufferPool implements BufferPool{
     private static final Logger LOGGER = LoggerFactory.getLogger("DirectByteBufferPool");
     public static final String LOCAL_BUF_THREAD_PREX = "$_";
     private ByteBufferPage[] allPages;

--- a/src/main/java/io/mycat/config/model/SystemConfig.java
+++ b/src/main/java/io/mycat/config/model/SystemConfig.java
@@ -42,8 +42,8 @@ public final class SystemConfig {
 
 	private static final String DEFAULT_SQL_PARSER = "druidparser";// fdbparser, druidparser
 	private static final short DEFAULT_BUFFER_CHUNK_SIZE = 4096;
-	private static final int DEFAULT_BUFFER_POOL_PAGE_SIZE = 512*1024*10;
-	private static final short DEFAULT_BUFFER_POOL_PAGE_NUMBER = 8;
+	private static final int DEFAULT_BUFFER_POOL_PAGE_SIZE = 512*1024*4;
+	private static final short DEFAULT_BUFFER_POOL_PAGE_NUMBER = 64;
 	private int processorBufferLocalPercent;
 	private static final int DEFAULT_PROCESSORS = Runtime.getRuntime().availableProcessors();
 	private int frontSocketSoRcvbuf = 1024 * 1024;
@@ -158,7 +158,9 @@ public final class SystemConfig {
 		this.processors = DEFAULT_PROCESSORS;
 		this.bufferPoolPageSize = DEFAULT_BUFFER_POOL_PAGE_SIZE;
 		this.bufferPoolChunkSize = DEFAULT_BUFFER_CHUNK_SIZE;
-		this.bufferPoolPageNumber = (short) (DEFAULT_PROCESSORS*2);
+//		this.bufferPoolPageNumber = (short) (DEFAULT_PROCESSORS*2);
+		this.bufferPoolPageNumber = (short) (DEFAULT_BUFFER_POOL_PAGE_NUMBER);
+
 		this.processorExecutor = (DEFAULT_PROCESSORS != 1) ? DEFAULT_PROCESSORS * 2 : 4;
 		this.managerExecutor = 2;
 

--- a/src/main/java/io/mycat/manager/response/ShowProcessor.java
+++ b/src/main/java/io/mycat/manager/response/ShowProcessor.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 
 import io.mycat.MycatServer;
 import io.mycat.backend.mysql.PacketUtil;
+import io.mycat.buffer.BufferPool;
 import io.mycat.buffer.DirectByteBufferPool;
 import io.mycat.config.Fields;
 import io.mycat.manager.ManagerConnection;
@@ -126,7 +127,7 @@ public final class ShowProcessor {
     }
 
     private static RowDataPacket getRow(NIOProcessor processor, String charset) {
-    	DirectByteBufferPool bufferPool=processor.getBufferPool();
+    	BufferPool bufferPool=processor.getBufferPool();
     	long bufferSize=bufferPool.size();
     	long bufferCapacity=bufferPool.capacity();
     	long bufferSharedOpts=bufferPool.getSharedOptsCount();

--- a/src/main/java/io/mycat/net/NIOProcessor.java
+++ b/src/main/java/io/mycat/net/NIOProcessor.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.mycat.buffer.BufferPool;
 import io.mycat.buffer.DirectByteBufferPool;
 import org.slf4j.Logger; import org.slf4j.LoggerFactory;
 
@@ -45,7 +46,7 @@ import io.mycat.util.TimeUtil;
 public final class NIOProcessor {
 	private static final Logger LOGGER = LoggerFactory.getLogger("NIOProcessor");
 	private final String name;
-	private final DirectByteBufferPool bufferPool;
+	private final BufferPool bufferPool;
 	private final NameableExecutor executor;
 	private final ConcurrentMap<Long, FrontendConnection> frontends;
 	private final ConcurrentMap<Long, BackendConnection> backends;
@@ -56,7 +57,7 @@ public final class NIOProcessor {
 	//前端已连接数
 	private AtomicInteger frontendsLength = new AtomicInteger(0);
 
-	public NIOProcessor(String name, DirectByteBufferPool bufferPool,
+	public NIOProcessor(String name, BufferPool bufferPool,
 			NameableExecutor executor) throws IOException {
 		this.name = name;
 		this.bufferPool = bufferPool;
@@ -70,7 +71,7 @@ public final class NIOProcessor {
 		return name;
 	}
 
-	public DirectByteBufferPool getBufferPool() {
+	public BufferPool getBufferPool() {
 		return bufferPool;
 	}
 

--- a/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
@@ -116,6 +116,10 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 		rrs.setNodes(nodes);		
 		
 		//分表
+		/**
+		 *  subTables="t_order$1-2,t_order3"
+		 *目前分表 1.6 开始支持 幵丏 dataNode 在分表条件下只能配置一个，分表条件下不支持join。
+		 */
 		if(rrs.isDistTable()){
 			return this.routeDisTable(statement,rrs);
 		}

--- a/src/main/java/io/mycat/route/util/RouterUtil.java
+++ b/src/main/java/io/mycat/route/util/RouterUtil.java
@@ -430,7 +430,7 @@ public class RouterUtil {
 	 * 获取开始位置后的 LIKE、WHERE 位置 如果不含 LIKE、WHERE 则返回执行语句的长度
 	 *
 	 * @param upStmt   执行sql
-	 * @param start    开发位置
+	 * @param start    开始位置
 	 * @return int
 	 * @author mycat
 	 */

--- a/src/test/java/io/mycat/buffer/TestByteBufferArena.java
+++ b/src/test/java/io/mycat/buffer/TestByteBufferArena.java
@@ -26,7 +26,7 @@ public class TestByteBufferArena {
     @Test
     public void testAllocate() {
         int allocTimes =  1024*100 ;
-        ByteBufferArena byteBufferArena = new ByteBufferArena(chunkSize,pageSize,chunkCount);
+        ByteBufferArena byteBufferArena = new ByteBufferArena(chunkSize,pageSize,chunkCount,8);
         long start = System.currentTimeMillis();
         for (int i = 0; i < allocTimes; i++) {
 //            System.out.println("allocate "+i);
@@ -70,7 +70,7 @@ public class TestByteBufferArena {
 
     @Test
     public void testExpansion(){
-        ByteBufferArena byteBufferArena = new ByteBufferArena(1024,8,1);
+        ByteBufferArena byteBufferArena = new ByteBufferArena(1024,8,1,8);
         for (int i = 0; i < 1 ; i++) {
             ByteBuffer byteBufer = byteBufferArena.allocate(256);
             ByteBuffer byteBufer2 = byteBufferArena.allocate(256);
@@ -85,7 +85,7 @@ public class TestByteBufferArena {
         int size = 256;
         int pageSize = size * 4;
         int allocTimes = 8;
-        ByteBufferArena byteBufferArena = new ByteBufferArena(256*4,256,2);
+        ByteBufferArena byteBufferArena = new ByteBufferArena(256*4,256,2,8);
         Map<Long, ByteBuffer> buffs = new HashMap<Long, ByteBuffer>(8);
         ByteBuffer byteBuffer = null;
         DirectBuffer directBuffer = null;
@@ -122,7 +122,7 @@ public class TestByteBufferArena {
         int size = 256;
         int pageSize = size * 4;
         int allocTimes = 9;
-        ByteBufferArena pool = new ByteBufferArena(256*4,256,2);;
+        ByteBufferArena pool = new ByteBufferArena(256*4,256,2,8);;
         long start = System.currentTimeMillis();
         ByteBuffer byteBuffer = null;
         List<ByteBuffer> buffs = new ArrayList<ByteBuffer>();


### PR DESCRIPTION
初步测试结果：
**DirectByteBufferPool吞吐量：**
第一次测试：
![5 1](https://cloud.githubusercontent.com/assets/15627489/15459201/8d5ebfb2-20d5-11e6-9c35-e7d720f94a25.PNG)
第二次测试：
![5 2](https://cloud.githubusercontent.com/assets/15627489/15459176/5ea6a946-20d5-11e6-97bd-fd1e0a5dadea.PNG)
第三次测试：
![5 3](https://cloud.githubusercontent.com/assets/15627489/15459177/5eaaf550-20d5-11e6-9975-2a7cffee7a83.PNG)
第四次测试：
![5 4](https://cloud.githubusercontent.com/assets/15627489/15459206/942f4abe-20d5-11e6-89dc-6f1a64f7d1c9.PNG)
第五次测试：
![5 5](https://cloud.githubusercontent.com/assets/15627489/15459207/9839dfde-20d5-11e6-8511-b3ea498590dd.PNG)

**ByteBufferArena吞吐量：**

第一次测试：
![4](https://cloud.githubusercontent.com/assets/15627489/15459221/b84eb45c-20d5-11e6-8ac8-49386496f725.PNG)

第二次测试：
![4 2](https://cloud.githubusercontent.com/assets/15627489/15459225/bc6ee124-20d5-11e6-904b-2af28646cc54.PNG)

第三次测试：
![4 3](https://cloud.githubusercontent.com/assets/15627489/15459227/beb3f622-20d5-11e6-9f15-53ed0c93cfdf.PNG)

第四次测试：
![4 4](https://cloud.githubusercontent.com/assets/15627489/15459231/c12a5a72-20d5-11e6-810d-fa0ce004c3e6.PNG)

第五次测试：
![4 5](https://cloud.githubusercontent.com/assets/15627489/15459232/c523e53a-20d5-11e6-88df-f61abc79371d.PNG)

