### PR TITLE
1.5

### DIFF
--- a/src/main/java/org/opencloudb/buffer/BufferPool.java
+++ b/src/main/java/org/opencloudb/buffer/BufferPool.java
@@ -177,6 +177,10 @@ public final class BufferPool {
 			return createTempBuffer(size);
 		}
 	}
+	
+	public int getNewCreated(){
+		return this.newCreated.get();
+	}
 
 	public static void main(String[] args) {
 		BufferPool pool = new BufferPool(3276800000L, 1024, 2);

--- a/src/main/java/org/opencloudb/buffer/BufferPool.java
+++ b/src/main/java/org/opencloudb/buffer/BufferPool.java
@@ -183,7 +183,7 @@ public final class BufferPool {
 	}
 
 	public static void main(String[] args) {
-		BufferPool pool = new BufferPool(327680L, 1024, 2);
+		BufferPool pool = new BufferPool(3276800000L, 1024, 2);
 		long i = pool.capacity();
 		List<ByteBuffer> all = new ArrayList<ByteBuffer>();
 		for (int j = 0; j <= i; j++) {
@@ -193,9 +193,5 @@ public final class BufferPool {
 			pool.recycle(buf);
 		}
 		LOGGER.info(pool.size());
-	}
-	
-	public int getNewCreated(){
-		return this.newCreated.get();
 	}
 }

--- a/src/main/java/org/opencloudb/response/ShowProcessor.java
+++ b/src/main/java/org/opencloudb/response/ShowProcessor.java
@@ -129,7 +129,7 @@ public final class ShowProcessor {
     	BufferPool bufferPool=processor.getBufferPool();
     	long bufferSize=bufferPool.size();
     	long bufferCapacity=bufferPool.capacity();
-    	long bufferSharedOpts=bufferPool.getSharedOptsCount();
+    	long newCreated = bufferPool.getNewCreated();
     	long bufferUsagePercent=(bufferCapacity-bufferSize)*100/bufferCapacity;
         RowDataPacket row = new RowDataPacket(FIELD_COUNT);
         row.add(processor.getName().getBytes());
@@ -141,7 +141,7 @@ public final class ShowProcessor {
         row.add(LongUtil.toBytes(bufferSize));
         row.add(LongUtil.toBytes(bufferCapacity));
         row.add(LongUtil.toBytes(bufferUsagePercent));
-        row.add(LongUtil.toBytes(bufferSharedOpts));
+        row.add(LongUtil.toBytes(newCreated));
         row.add(IntegerUtil.toBytes(processor.getFrontends().size()));
         row.add(IntegerUtil.toBytes(processor.getBackends().size()));
         return row;


### PR DESCRIPTION
 Mycat 性能调优指南中文档中提到：
管理命令show @@processor中显示的BU_WARNS为Socket Buffer Pool不够时，临时创新的新的BUFFER的次数。
看了一下源代码，BU_WARNS取值为BufferPool对象属性sharedOptsCount的值，这个属性值是缓存池回收缓存区时操作共享缓存区域的次数，不是创建新的buffer的次数。
如果显示创建buffer次数个人认为应该取属性newCreated，并按此逻辑进行了修改。