### PR TITLE
server.xml添加一个配置项用来设置mycat要模拟的mysql的版本

### DIFF
--- a/src/main/java/org/opencloudb/config/Versions.java
+++ b/src/main/java/org/opencloudb/config/Versions.java
@@ -26,19 +26,15 @@ package org.opencloudb.config;
 /**
  * @author mycat
  */
-public final class Versions {
+public abstract class Versions {
 
     /**协议版本**/
     public static final byte PROTOCOL_VERSION = 10;
 
-    /**服务器版**/
-    private static byte[] SERVER_VERSION = "5.5.8-mycat-1.5.1-RELEASE-20160524231026".getBytes();
+    /**服务器版本**/
+    public static byte[] SERVER_VERSION = "5.5.8-mycat-1.5.1-RELEASE-20160525102622".getBytes();
 
-    private static Versions instance = new Versions();
-
-    private Versions() {}
-
-    public void setServerVersion(String version) {
+    public static void setServerVersion(String version) {
         byte[] mysqlVersionPart = version.getBytes();
         int startIndex;
         for (startIndex = 0; startIndex < SERVER_VERSION.length; startIndex++) {
@@ -53,8 +49,4 @@ public final class Versions {
                 SERVER_VERSION.length - startIndex);
         SERVER_VERSION = newMycatVersion;
     }
-
-    public byte[] getServerVersion() { return SERVER_VERSION; }
-
-    public static Versions getInstance() { return instance; }
 }

--- a/src/main/java/org/opencloudb/config/Versions.java
+++ b/src/main/java/org/opencloudb/config/Versions.java
@@ -26,12 +26,35 @@ package org.opencloudb.config;
 /**
  * @author mycat
  */
-public interface Versions {
+public final class Versions {
 
     /**协议版本**/
     public static final byte PROTOCOL_VERSION = 10;
 
     /**服务器版**/
-    public static final byte[] SERVER_VERSION = "5.6.29-mycat-1.5-GA-20160201172658".getBytes();
+    private static byte[] SERVER_VERSION = "5.5.8-mycat-1.5.1-RELEASE-20160524231026".getBytes();
 
+    private static Versions instance = new Versions();
+
+    private Versions() {}
+
+    public void setServerVersion(String version) {
+        byte[] mysqlVersionPart = version.getBytes();
+        int startIndex;
+        for (startIndex = 0; startIndex < SERVER_VERSION.length; startIndex++) {
+            if (SERVER_VERSION[startIndex] == '-')
+                break;
+        }
+
+        // 重新拼接mycat version字节数组
+        byte[] newMycatVersion = new byte[mysqlVersionPart.length + SERVER_VERSION.length - startIndex];
+        System.arraycopy(mysqlVersionPart, 0, newMycatVersion, 0, mysqlVersionPart.length);
+        System.arraycopy(SERVER_VERSION, startIndex, newMycatVersion, mysqlVersionPart.length,
+                SERVER_VERSION.length - startIndex);
+        SERVER_VERSION = newMycatVersion;
+    }
+
+    public byte[] getServerVersion() { return SERVER_VERSION; }
+
+    public static Versions getInstance() { return instance; }
 }

--- a/src/main/java/org/opencloudb/config/Versions.template
+++ b/src/main/java/org/opencloudb/config/Versions.template
@@ -26,12 +26,35 @@ package org.opencloudb.config;
 /**
  * @author mycat
  */
-public interface Versions {
+public final class Versions {
 
     /**协议版本**/
     public static final byte PROTOCOL_VERSION = 10;
 
     /**服务器版**/
-    public static final byte[] SERVER_VERSION = "@server-version@".getBytes();
+    private static byte[] SERVER_VERSION = "@server-version@".getBytes();
 
+    private static Versions instance = new Versions();
+
+    private Versions() {}
+
+    public void setServerVersion(String version) {
+        byte[] mysqlVersionPart = version.getBytes();
+        int startIndex;
+        for (startIndex = 0; startIndex < SERVER_VERSION.length; startIndex++) {
+            if (SERVER_VERSION[startIndex] == '-')
+                break;
+        }
+
+        // 重新拼接mycat version字节数组
+        byte[] newMycatVersion = new byte[mysqlVersionPart.length + SERVER_VERSION.length - startIndex];
+        System.arraycopy(mysqlVersionPart, 0, newMycatVersion, 0, mysqlVersionPart.length);
+        System.arraycopy(SERVER_VERSION, startIndex, newMycatVersion, mysqlVersionPart.length,
+                SERVER_VERSION.length - startIndex);
+        SERVER_VERSION = newMycatVersion;
+    }
+
+    public byte[] getServerVersion() { return SERVER_VERSION; }
+
+    public static Versions getInstance() { return instance; }
 }

--- a/src/main/java/org/opencloudb/config/Versions.template
+++ b/src/main/java/org/opencloudb/config/Versions.template
@@ -26,19 +26,15 @@ package org.opencloudb.config;
 /**
  * @author mycat
  */
-public final class Versions {
+public abstract class Versions {
 
     /**协议版本**/
     public static final byte PROTOCOL_VERSION = 10;
 
-    /**服务器版**/
-    private static byte[] SERVER_VERSION = "@server-version@".getBytes();
+    /**服务器版本**/
+    public static byte[] SERVER_VERSION = "@server-version@".getBytes();
 
-    private static Versions instance = new Versions();
-
-    private Versions() {}
-
-    public void setServerVersion(String version) {
+    public static void setServerVersion(String version) {
         byte[] mysqlVersionPart = version.getBytes();
         int startIndex;
         for (startIndex = 0; startIndex < SERVER_VERSION.length; startIndex++) {
@@ -53,8 +49,4 @@ public final class Versions {
                 SERVER_VERSION.length - startIndex);
         SERVER_VERSION = newMycatVersion;
     }
-
-    public byte[] getServerVersion() { return SERVER_VERSION; }
-
-    public static Versions getInstance() { return instance; }
 }

--- a/src/main/java/org/opencloudb/config/loader/xml/XMLServerLoader.java
+++ b/src/main/java/org/opencloudb/config/loader/xml/XMLServerLoader.java
@@ -37,6 +37,7 @@ import java.util.Map;
 
 import org.opencloudb.MycatConfig;
 import org.opencloudb.MycatServer;
+import org.opencloudb.config.Versions;
 import org.opencloudb.config.model.ClusterConfig;
 import org.opencloudb.config.model.QuarantineConfig;
 import org.opencloudb.config.model.SystemConfig;
@@ -216,6 +217,29 @@ public class XMLServerLoader {
             if (node instanceof Element) {
                 Map<String, Object> props = ConfigUtil.loadElements((Element) node);
                 ParameterMapping.mapping(system, props);
+            }
+        }
+
+        if (system.getFakeMySQLVersion() != null) {
+            boolean validVersion = false;
+            String majorMySQLVersion = system.getFakeMySQLVersion();
+            /*
+             * 注意！！！ 目前MySQL官方主版本号仍然是5.x, 以后万一前面的大版本号变成2位数字，
+             * 比如 10.x...,下面获取主版本的代码要做修改
+             */
+            majorMySQLVersion = majorMySQLVersion.substring(0, majorMySQLVersion.indexOf(".", 2));
+            for (String ver : SystemConfig.MySQLVersions) {
+                // 这里只是比较mysql前面的大版本号
+                if (majorMySQLVersion.equals(ver)) {
+                    validVersion = true;
+                }
+            }
+
+            if (validVersion) {
+                Versions.getInstance().setServerVersion(system.getFakeMySQLVersion());
+            } else {
+                throw new ConfigException("The specified MySQL Version (" + system.getFakeMySQLVersion()
+                        + ") is not valid.");
             }
         }
     }

--- a/src/main/java/org/opencloudb/config/loader/xml/XMLServerLoader.java
+++ b/src/main/java/org/opencloudb/config/loader/xml/XMLServerLoader.java
@@ -236,7 +236,7 @@ public class XMLServerLoader {
             }
 
             if (validVersion) {
-                Versions.getInstance().setServerVersion(system.getFakeMySQLVersion());
+                Versions.setServerVersion(system.getFakeMySQLVersion());
             } else {
                 throw new ConfigException("The specified MySQL Version (" + system.getFakeMySQLVersion()
                         + ") is not valid.");

--- a/src/main/java/org/opencloudb/config/model/SystemConfig.java
+++ b/src/main/java/org/opencloudb/config/model/SystemConfig.java
@@ -69,6 +69,7 @@ public final class SystemConfig {
 	private int maxStringLiteralLength = 65535;
 	private int frontWriteQueueSize = 2048;
 	private String bindIp = "0.0.0.0";
+	private String fakeMySQLVersion = null;
 	private int serverPort;
 	private int managerPort;
 	private String charset;
@@ -97,6 +98,11 @@ public final class SystemConfig {
 	public static final int SEQUENCEHANDLER_LOCALFILE = 0;
 	public static final int SEQUENCEHANDLER_MYSQLDB = 1;
 	public static final int SEQUENCEHANDLER_LOCAL_TIME = 2;
+	/*
+	 * 注意！！！ 目前mycat支持的MySQL版本，如果后续有新的MySQL版本,请添加到此数组， 对于MySQL的其他分支，
+	 * 比如MariaDB目前版本号已经到10.1.x，但是其驱动程序仍然兼容官方的MySQL,因此这里版本号只需要MySQL官方的版本号即可。
+	 */
+	public static final String[] MySQLVersions = { "5.5", "5.6", "5.7" };
 	private int sequnceHandlerType = SEQUENCEHANDLER_LOCALFILE;
 	private String sqlInterceptor = "org.opencloudb.interceptor.impl.DefaultSqlInterceptor";
 	private String sqlInterceptorType = "select";
@@ -276,6 +282,14 @@ public final class SystemConfig {
 
 	public void setCharset(String charset) {
 		this.charset = charset;
+	}
+
+	public String getFakeMySQLVersion() {
+		return fakeMySQLVersion;
+	}
+
+	public void setFakeMySQLVersion(String mysqlVersion) {
+		this.fakeMySQLVersion = mysqlVersion;
 	}
 
 	public int getServerPort() {

--- a/src/main/java/org/opencloudb/net/FrontendConnection.java
+++ b/src/main/java/org/opencloudb/net/FrontendConnection.java
@@ -389,7 +389,7 @@ public abstract class FrontendConnection extends AbstractConnection {
 			HandshakePacket hs = new HandshakePacket();
 			hs.packetId = 0;
 			hs.protocolVersion = Versions.PROTOCOL_VERSION;
-			hs.serverVersion = Versions.getInstance().getServerVersion();
+			hs.serverVersion = Versions.SERVER_VERSION;
 			hs.threadId = id;
 			hs.seed = rand1;
 			hs.serverCapabilities = getServerCapabilities();

--- a/src/main/java/org/opencloudb/net/FrontendConnection.java
+++ b/src/main/java/org/opencloudb/net/FrontendConnection.java
@@ -389,7 +389,7 @@ public abstract class FrontendConnection extends AbstractConnection {
 			HandshakePacket hs = new HandshakePacket();
 			hs.packetId = 0;
 			hs.protocolVersion = Versions.PROTOCOL_VERSION;
-			hs.serverVersion = Versions.SERVER_VERSION;
+			hs.serverVersion = Versions.getInstance().getServerVersion();
 			hs.threadId = id;
 			hs.seed = rand1;
 			hs.serverCapabilities = getServerCapabilities();

--- a/src/main/java/org/opencloudb/response/ShowVersion.java
+++ b/src/main/java/org/opencloudb/response/ShowVersion.java
@@ -73,7 +73,7 @@ public final class ShowVersion {
         // write rows
         byte packetId = eof.packetId;
         RowDataPacket row = new RowDataPacket(FIELD_COUNT);
-        row.add(Versions.SERVER_VERSION);
+        row.add(Versions.getInstance().getServerVersion());
         row.packetId = ++packetId;
         buffer = row.write(buffer, c,true);
 

--- a/src/main/java/org/opencloudb/response/ShowVersion.java
+++ b/src/main/java/org/opencloudb/response/ShowVersion.java
@@ -73,7 +73,7 @@ public final class ShowVersion {
         // write rows
         byte packetId = eof.packetId;
         RowDataPacket row = new RowDataPacket(FIELD_COUNT);
-        row.add(Versions.getInstance().getServerVersion());
+        row.add(Versions.SERVER_VERSION);
         row.packetId = ++packetId;
         buffer = row.write(buffer, c,true);
 

--- a/src/main/java/org/opencloudb/server/response/SelectVersion.java
+++ b/src/main/java/org/opencloudb/server/response/SelectVersion.java
@@ -61,7 +61,7 @@ public class SelectVersion {
         buffer = eof.write(buffer, c,true);
         byte packetId = eof.packetId;
         RowDataPacket row = new RowDataPacket(FIELD_COUNT);
-        row.add(Versions.getInstance().getServerVersion());
+        row.add(Versions.SERVER_VERSION);
         row.packetId = ++packetId;
         buffer = row.write(buffer, c,true);
         EOFPacket lastEof = new EOFPacket();

--- a/src/main/java/org/opencloudb/server/response/SelectVersion.java
+++ b/src/main/java/org/opencloudb/server/response/SelectVersion.java
@@ -61,7 +61,7 @@ public class SelectVersion {
         buffer = eof.write(buffer, c,true);
         byte packetId = eof.packetId;
         RowDataPacket row = new RowDataPacket(FIELD_COUNT);
-        row.add(Versions.SERVER_VERSION);
+        row.add(Versions.getInstance().getServerVersion());
         row.packetId = ++packetId;
         buffer = row.write(buffer, c,true);
         EOFPacket lastEof = new EOFPacket();


### PR DESCRIPTION
server.xml的 system下，添加 fakeMySQLVersion 设置项，用来设置mycat与客户端交互时伪装的MySQL的具体版本，之前一直是5.5.8，这对于后端mysql版本较新时，使用mycat会丢失一些新特性。

代码的修改思路就是把之前的接口Versions改为抽象类，在load server.xml的时候，可以根据fakeMySQLVersion的值来配置SERVER_VERSION，如果没有设置fakeMySQLVersion，则使用默认值。

测试
在server.xml中，添加
<system>
...
<property name="fakeMySQLVersion">5.6.3</property>
...
</system>

下面是分别设置为 5.6.4， 5.6.3， 5.7.4， 5.5.8，不设置时候的输出
测试1 简单的select version

Server version: 5.6.4-mycat-1.5.1-RELEASE-20160524231026 MyCat Server (OpenCloundDB)

Copyright (c) 2000, 2015, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
MySQL [TESTDB]> select version();
+------------------------------------------+
| VERSION()                                |
+------------------------------------------+
| 5.6.4-mycat-1.5.1-RELEASE-20160524231026 |
+------------------------------------------+
1 row in set (0.00 sec)

Server version: 5.6.4-mycat-1.5.1-RELEASE-20160524231026 MyCat Server (monitor)

Copyright (c) 2000, 2015, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MySQL [TESTDB]> show @@version;
+------------------------------------------+
| VERSION                                  |
+------------------------------------------+
| 5.6.4-mycat-1.5.1-RELEASE-20160524231026 |
+------------------------------------------+
1 row in set (0.01 sec)

测试2 观察对毫秒的支持
这里测试一张表mytab 在这几种设置下，向其中插入数据，观察毫秒部分是否被截断的情况，因为根据
mysql的官方文档
http://dev.mysql.com/doc/refman/5.6/en/date-and-time-type-overview.html
As of MySQL 5.6.4, an optional fsp value in the range from 0 to 6 may be given to specify fractional seconds precision. A value of 0 signifies that there is no fractional part. If omitted, the default precision is 0.
可以知道，MySQL从5.6.4之后timestamp和datetime开始支持毫秒精度

+-------+--------------+------+-----+----------------------+-------+
| Field | Type         | Null | Key | Default              | Extra |
+-------+--------------+------+-----+----------------------+-------+
| id    | int(11)      | YES  |     | NULL                 |       |
| ts    | timestamp(6) | YES  |     | CURRENT_TIMESTAMP(6) |       |
| date  | datetime(6)  | YES  |     | CURRENT_TIMESTAMP(6) |       |
+-------+--------------+------+-----+----------------------+-------+

Class name: MySQL Connector Java, mysql-connector-java-5.1.38 ( Revision: fe541c166cec739c74cc727c5da96c1028b4834a )

TS: 2016-05-25 09:36:36.882
Server name: MySQL
Server version: 5.6.4-mycat-1.5.1-RELEASE-20160524231026
Database info: 5.6


TS: 2016-05-25 09:39:38.338
Server name: MySQL
Server version: 5.6.3-mycat-1.5.1-RELEASE-20160524231026
Database info: 5.6

TS: 2016-05-25 09:40:53.641
Wed May 25 09:40:54 GMT+08:00 2016 WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.
Server name: MySQL
Server version: 5.7.3-mycat-1.5.1-RELEASE-20160524231026
Database info: 5.7

TS: 2016-05-25 09:43:23.05
Server name: MySQL
Server version: 5.5.8-mycat-1.5.1-RELEASE-20160524231026
Database info: 5.5

TS: 2016-05-25 09:44:31.666
Server name: MySQL
Server version: 5.5.8-mycat-1.5.1-RELEASE-20160524231026
Database info: 5.5

我们可以看到最后的插入结果， id的取值就是mysql版本号对应的数字
5580是server.xml里不设置时候的情况

MySQL [TESTDB]> select * from mytab;
+------+----------------------------+----------------------------+
| id   | ts                         | date                       |
+------+----------------------------+----------------------------+
|  564 | 2016-05-25 09:36:36.882000 | 2016-05-25 09:36:36.882000 |
|  563 | 2016-05-25 09:39:38.000000 | 2016-05-25 09:39:38.000000 |
|  573 | 2016-05-25 09:40:53.641000 | 2016-05-25 09:40:53.641000 |
|  558 | 2016-05-25 09:43:23.000000 | 2016-05-25 09:43:23.000000 |
| 5580 | 2016-05-25 09:44:31.000000 | 2016-05-25 09:44:31.000000 |
+------+----------------------------+----------------------------+
5 rows in set (0.04 sec)


测试3 fakeMySQLVersion设置一个非法值
只允许设置官方目前的MySQL的版本号（从5.5.x开始）
5.5.x， 5.6.x  5.7.x

这里设置成5.8.3，可以看到启动后异常
Exception in thread "main" java.lang.ExceptionInInitializerError
	at org.opencloudb.MycatStartup.main(MycatStartup.java:50)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:144)
Caused by: org.opencloudb.config.util.ConfigException: The specified MySQL Version (5.8.3) is not valid.
	at org.opencloudb.config.loader.xml.XMLServerLoader.loadSystem(XMLServerLoader.java:241)
	at org.opencloudb.config.loader.xml.XMLServerLoader.load(XMLServerLoader.java:96)
	at org.opencloudb.config.loader.xml.XMLServerLoader.<init>(XMLServerLoader.java:70)
	at org.opencloudb.config.loader.xml.XMLConfigLoader.<init>(XMLConfigLoader.java:56)
	at org.opencloudb.ConfigInitializer.<init>(ConfigInitializer.java:64)
	at org.opencloudb.MycatConfig.<init>(MycatConfig.java:69)
	at org.opencloudb.MycatServer.<init>(MycatServer.java:105)
	at org.opencloudb.MycatServer.<clinit>(MycatServer.java:73)
