### PR TITLE
(移植1.5branch上的pull request916) server.xml中添加配置项让mycat可以设置要模拟的mysql的版本号

### DIFF
--- a/src/main/java/io/mycat/config/Versions.java
+++ b/src/main/java/io/mycat/config/Versions.java
@@ -26,12 +26,27 @@ package io.mycat.config;
 /**
  * @author mycat
  */
-public interface Versions {
+public abstract class Versions {
 
     /**协议版本**/
     public static final byte PROTOCOL_VERSION = 10;
 
-    /**服务器版**/
-    public static final byte[] SERVER_VERSION = "5.6.29-mycat-1.6-DEV-20160509113407".getBytes();
+    /**服务器版本**/
+    public static byte[] SERVER_VERSION = "5.6.29-mycat-1.6-DEV-20160526215755".getBytes();
 
+    public static void setServerVersion(String version) {
+        byte[] mysqlVersionPart = version.getBytes();
+        int startIndex;
+        for (startIndex = 0; startIndex < SERVER_VERSION.length; startIndex++) {
+            if (SERVER_VERSION[startIndex] == '-')
+                break;
+        }
+
+        // 重新拼接mycat version字节数组
+        byte[] newMycatVersion = new byte[mysqlVersionPart.length + SERVER_VERSION.length - startIndex];
+        System.arraycopy(mysqlVersionPart, 0, newMycatVersion, 0, mysqlVersionPart.length);
+        System.arraycopy(SERVER_VERSION, startIndex, newMycatVersion, mysqlVersionPart.length,
+                SERVER_VERSION.length - startIndex);
+        SERVER_VERSION = newMycatVersion;
+    }
 }

--- a/src/main/java/io/mycat/config/Versions.template
+++ b/src/main/java/io/mycat/config/Versions.template
@@ -26,12 +26,27 @@ package io.mycat.config;
 /**
  * @author mycat
  */
-public interface Versions {
+public abstract class Versions {
 
     /**协议版本**/
     public static final byte PROTOCOL_VERSION = 10;
 
-    /**服务器版**/
-    public static final byte[] SERVER_VERSION = "@server-version@".getBytes();
+    /**服务器版本**/
+    public static byte[] SERVER_VERSION = "@server-version@".getBytes();
 
+    public static void setServerVersion(String version) {
+        byte[] mysqlVersionPart = version.getBytes();
+        int startIndex;
+        for (startIndex = 0; startIndex < SERVER_VERSION.length; startIndex++) {
+            if (SERVER_VERSION[startIndex] == '-')
+                break;
+        }
+
+        // 重新拼接mycat version字节数组
+        byte[] newMycatVersion = new byte[mysqlVersionPart.length + SERVER_VERSION.length - startIndex];
+        System.arraycopy(mysqlVersionPart, 0, newMycatVersion, 0, mysqlVersionPart.length);
+        System.arraycopy(SERVER_VERSION, startIndex, newMycatVersion, mysqlVersionPart.length,
+                SERVER_VERSION.length - startIndex);
+        SERVER_VERSION = newMycatVersion;
+    }
 }

--- a/src/main/java/io/mycat/config/loader/xml/XMLServerLoader.java
+++ b/src/main/java/io/mycat/config/loader/xml/XMLServerLoader.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import io.mycat.config.Versions;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -219,6 +220,29 @@ public class XMLServerLoader {
             if (node instanceof Element) {
                 Map<String, Object> props = ConfigUtil.loadElements((Element) node);
                 ParameterMapping.mapping(system, props);
+            }
+        }
+
+        if (system.getFakeMySQLVersion() != null) {
+            boolean validVersion = false;
+            String majorMySQLVersion = system.getFakeMySQLVersion();
+            /*
+             * 注意！！！ 目前MySQL官方主版本号仍然是5.x, 以后万一前面的大版本号变成2位数字，
+             * 比如 10.x...,下面获取主版本的代码要做修改
+             */
+            majorMySQLVersion = majorMySQLVersion.substring(0, majorMySQLVersion.indexOf(".", 2));
+            for (String ver : SystemConfig.MySQLVersions) {
+                // 这里只是比较mysql前面的大版本号
+                if (majorMySQLVersion.equals(ver)) {
+                    validVersion = true;
+                }
+            }
+
+            if (validVersion) {
+                Versions.setServerVersion(system.getFakeMySQLVersion());
+            } else {
+                throw new ConfigException("The specified MySQL Version (" + system.getFakeMySQLVersion()
+                        + ") is not valid.");
             }
         }
     }

--- a/src/main/java/io/mycat/config/model/SystemConfig.java
+++ b/src/main/java/io/mycat/config/model/SystemConfig.java
@@ -70,6 +70,7 @@ public final class SystemConfig {
 	private int maxStringLiteralLength = 65535;
 	private int frontWriteQueueSize = 2048;
 	private String bindIp = "0.0.0.0";
+	private String fakeMySQLVersion = null;
 	private int serverPort;
 	private int managerPort;
 	private String charset;
@@ -108,6 +109,11 @@ public final class SystemConfig {
 	public static final int SEQUENCEHANDLER_LOCAL_TIME = 2;
 	public static final int SEQUENCEHANDLER_ZK_DISTRIBUTED = 3;
 	public static final int SEQUENCEHANDLER_ZK_GLOBAL_INCREMENT = 4;
+	/*
+	 * 注意！！！ 目前mycat支持的MySQL版本，如果后续有新的MySQL版本,请添加到此数组， 对于MySQL的其他分支，
+	 * 比如MariaDB目前版本号已经到10.1.x，但是其驱动程序仍然兼容官方的MySQL,因此这里版本号只需要MySQL官方的版本号即可。
+	 */
+	public static final String[] MySQLVersions = { "5.5", "5.6", "5.7" };
 	private int sequnceHandlerType = SEQUENCEHANDLER_LOCALFILE;
 	private String sqlInterceptor = "io.mycat.server.interceptor.impl.DefaultSqlInterceptor";
 	private String sqlInterceptorType = "select";
@@ -308,6 +314,14 @@ public final class SystemConfig {
 
 	public void setCharset(String charset) {
 		this.charset = charset;
+	}
+
+	public String getFakeMySQLVersion() {
+		return fakeMySQLVersion;
+	}
+
+	public void setFakeMySQLVersion(String mysqlVersion) {
+		this.fakeMySQLVersion = mysqlVersion;
 	}
 
 	public int getServerPort() {

--- a/src/main/resources/server.xml
+++ b/src/main/resources/server.xml
@@ -14,6 +14,7 @@
 	<property name="defaultSqlParser">druidparser</property>
 		<property name="sequnceHandlerType">3</property>
       <!--  <property name="useCompression">1</property>--> <!--1为开启mysql压缩协议-->
+        <!--  <property name="fakeMySQLVersion">5.6.20</property>--> <!--设置模拟的MySQL版本号-->
 	<!-- <property name="processorBufferChunk">40960</property> -->
 	<!-- 
 	<property name="processors">1</property> 


### PR DESCRIPTION
具体的改动参考下面，这里额外修改了server.xml，注释中添加了 fakeMySQLVersion的配置
https://github.com/MyCATApache/Mycat-Server/pull/916