### PR TITLE
修复bug #938 当分库字段为uuid时，使用sharding-by-murmur规则配置主子表关系，导致主子表关联数据无法插入到同一个库中 

### DIFF
--- a/src/main/java/io/mycat/route/util/RouterUtil.java
+++ b/src/main/java/io/mycat/route/util/RouterUtil.java
@@ -1339,12 +1339,16 @@ public class RouterUtil {
 			}
 			//取得joinkey的值
 			String joinKeyVal = insertStmt.getValues().getValues().get(joinKeyIndex).toString();
+			String realVal = joinKeyVal;
+			if (joinKeyVal.startsWith("'") && joinKeyVal.endsWith("'")) {
+				realVal = joinKeyVal.substring(1, joinKeyVal.length() - 1);
+			}
 
 			String sql = insertStmt.toString();
 
 			// try to route by ER parent partion key
 			//如果是二级子表（父表不再有父表）,并且分片字段正好是joinkey字段，调用routeByERParentKey
-			RouteResultset theRrs = RouterUtil.routeByERParentKey(sc, schema, ServerParse.INSERT, sql, rrs, tc, joinKeyVal);
+			RouteResultset theRrs = RouterUtil.routeByERParentKey(sc, schema, ServerParse.INSERT, sql, rrs, tc, realVal);
 			if (theRrs != null) {
 				boolean processedInsert=false;
 				//判断是否需要全局序列号

--- a/src/main/java/io/mycat/route/util/RouterUtil.java
+++ b/src/main/java/io/mycat/route/util/RouterUtil.java
@@ -1339,11 +1339,12 @@ public class RouterUtil {
 			}
 			//取得joinkey的值
 			String joinKeyVal = insertStmt.getValues().getValues().get(joinKeyIndex).toString();
+			//解决bug #938，当关联字段的值为char类型时，去掉前后"'"
 			String realVal = joinKeyVal;
-			if (joinKeyVal.startsWith("'") && joinKeyVal.endsWith("'")) {
+			if (joinKeyVal.startsWith("'") && joinKeyVal.endsWith("'") && joinKeyVal.length() > 2) {
 				realVal = joinKeyVal.substring(1, joinKeyVal.length() - 1);
 			}
-
+			
 			String sql = insertStmt.toString();
 
 			// try to route by ER parent partion key


### PR DESCRIPTION
修复bug #938 当分库字段为uuid时，使用sharding-by-murmur规则配置主子表关系，导致主子表关联数据无法插入到同一个库中 