### PR TITLE
Port pull request 942 from 1.6 to 1.5, manager端口支持select @@session.tx_read_only

### DIFF
--- a/src/main/java/org/opencloudb/handler/SelectHandler.java
+++ b/src/main/java/org/opencloudb/handler/SelectHandler.java
@@ -25,11 +25,13 @@ package org.opencloudb.handler;
 
 import static org.opencloudb.parser.ManagerParseSelect.SESSION_AUTO_INCREMENT;
 import static org.opencloudb.parser.ManagerParseSelect.VERSION_COMMENT;
+import static org.opencloudb.parser.ManagerParseSelect.SESSION_TX_READ_ONLY;
 
 import org.opencloudb.config.ErrorCode;
 import org.opencloudb.manager.ManagerConnection;
 import org.opencloudb.parser.ManagerParseSelect;
 import org.opencloudb.response.SelectSessionAutoIncrement;
+import org.opencloudb.response.SelectTxReadOnly;
 import org.opencloudb.response.SelectVersionComment;
 
 /**
@@ -44,6 +46,9 @@ public final class SelectHandler {
             break;
         case SESSION_AUTO_INCREMENT:
             SelectSessionAutoIncrement.execute(c);
+            break;
+        case SESSION_TX_READ_ONLY:
+            SelectTxReadOnly.response(c);
             break;
         default:
             c.writeErrMessage(ErrorCode.ER_YES, "Unsupported statement");

--- a/src/main/java/org/opencloudb/parser/ManagerParseSelect.java
+++ b/src/main/java/org/opencloudb/parser/ManagerParseSelect.java
@@ -33,9 +33,11 @@ public final class ManagerParseSelect {
     public static final int OTHER = -1;
     public static final int VERSION_COMMENT = 1;
     public static final int SESSION_AUTO_INCREMENT = 2;
+    public static final int SESSION_TX_READ_ONLY = 3;
 
     private static final char[] _VERSION_COMMENT = "VERSION_COMMENT".toCharArray();
     private static final char[] _SESSION_AUTO_INCREMENT = "SESSION.AUTO_INCREMENT_INCREMENT".toCharArray();
+    private static final char[] _SESSION_TX_READ_ONLY = "SESSION.TX_READ_ONLY".toCharArray();
 
     public static int parse(String stmt, int offset) {
         int i = offset;
@@ -88,17 +90,24 @@ public final class ManagerParseSelect {
         return OTHER;
     }
 
-    // SESSION.AUTO_INCREMENT_INCREMENT
+    // SESSION.AUTO_INCREMENT_INCREMENT  or SESSION.TX_READ_ONLY
     static int select2SCheck(String stmt, int offset) {
         int length = offset + _SESSION_AUTO_INCREMENT.length;
-        if (stmt.length() >= length) {
-            if (ParseUtil.compare(stmt, offset, _SESSION_AUTO_INCREMENT)) {
+        int length_tx_read_only = offset + _SESSION_TX_READ_ONLY.length;
+        if ((stmt.length() >= length)
+                && (ParseUtil.compare(stmt, offset, _SESSION_AUTO_INCREMENT))) {
                 if (stmt.length() > length && stmt.charAt(length) != ' ') {
                     return OTHER;
                 }
                 return SESSION_AUTO_INCREMENT;
+        } else if ((stmt.length() >= length_tx_read_only)
+                && ParseUtil.compare(stmt, offset, _SESSION_TX_READ_ONLY)) {
+            if (stmt.length() > length_tx_read_only && stmt.charAt(length_tx_read_only) != ' ') {
+                return OTHER;
             }
+            return SESSION_TX_READ_ONLY;
         }
+
         return OTHER;
     }
 

--- a/src/main/java/org/opencloudb/response/SelectTxReadOnly.java
+++ b/src/main/java/org/opencloudb/response/SelectTxReadOnly.java
@@ -27,6 +27,7 @@ package org.opencloudb.response;
 
 import org.opencloudb.config.Fields;
 import org.opencloudb.mysql.PacketUtil;
+import org.opencloudb.net.FrontendConnection;
 import org.opencloudb.net.mysql.EOFPacket;
 import org.opencloudb.net.mysql.FieldPacket;
 import org.opencloudb.net.mysql.ResultSetHeaderPacket;
@@ -55,7 +56,7 @@ public class SelectTxReadOnly {
 
     }
 
-    public static void response(ServerConnection c) {
+    public static void response(FrontendConnection c) {
         ByteBuffer buffer = c.allocate();
         buffer = header.write(buffer, c,true);
         for (FieldPacket field : fields) {


### PR DESCRIPTION
具体修改请参考 pull request 942
https://github.com/MyCATApache/Mycat-Server/pull/942
有部分代码已经在https://github.com/MyCATApache/Mycat-Server/pull/930 中完成，
因此做部分的移植即可。

下面是测试结果， 在mycat-eye中也可以成功添加监控。

连接manager端口(9066)， mycat配置模拟MySQL的版本为 5.6.20

Server version: 5.6.20-mycat-1.5.1-RELEASE-20160614153228 MyCat Server (monitor)

Copyright (c) 2000, 2015, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MySQL [(none)]> select @@session.tx_read_only;
+------------------------+
| @@session.tx_read_only |
+------------------------+
|                      0 |
+------------------------+
1 row in set (0.00 sec)

MySQL [(none)]> select @@tx_read_only;
ERROR 1003 (HY000): Unsupported statement
MySQL [(none)]> select @@global.tx_read_only;
ERROR 1003 (HY000): Unsupported statement