### PR TITLE
Allow % in user name, which is used in some cloud MySQL DB.

### DIFF
--- a/src/main/resources/schema.dtd
+++ b/src/main/resources/schema.dtd
@@ -69,7 +69,7 @@
   url CDATA #REQUIRED
   host NMTOKEN #REQUIRED
   password CDATA #REQUIRED
-  user NMTOKEN #REQUIRED
+  user CDATA #REQUIRED
   usingDecrypt CDATA #IMPLIED>
 
 <!ELEMENT heartbeat (#PCDATA)>


### PR DESCRIPTION
微软Azure MySQL DB的用户名里面会包含一个%字符。由于当前的schema.dtd里面user配置是NMTOKEN，%是不允许的。