### PR TITLE
修复UpDate解析验证是否修改分片字段代码缺陷导致，没有考虑别名

### DIFF
--- a/src/main/java/io/mycat/route/parser/druid/impl/DruidUpdateParser.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/DruidUpdateParser.java
@@ -1,67 +1,51 @@
 package io.mycat.route.parser.druid.impl;
 
-import java.sql.SQLNonTransientException;
-import java.util.List;
-
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLUpdateSetItem;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlUpdateStatement;
-
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlSchemaStatVisitor;
 import io.mycat.config.model.SchemaConfig;
 import io.mycat.config.model.TableConfig;
 import io.mycat.route.RouteResultset;
 import io.mycat.route.util.RouterUtil;
 import io.mycat.util.StringUtil;
 
+import java.sql.SQLNonTransientException;
+import java.util.List;
+
 public class DruidUpdateParser extends DefaultDruidParser {
-	@Override
-	public void statementParse(SchemaConfig schema, RouteResultset rrs, SQLStatement stmt) throws SQLNonTransientException {
-		if(ctx.getTables() != null && ctx.getTables().size() > 1 && !schema.isNoSharding()) {
-			String msg = "multi table related update not supported,tables:" + ctx.getTables();
-			LOGGER.warn(msg);
-			throw new SQLNonTransientException(msg);
-		}
-		MySqlUpdateStatement update = (MySqlUpdateStatement)stmt;
-		String tableName = StringUtil.removeBackquote(update.getTableName().getSimpleName().toUpperCase());
-		
-		List<SQLUpdateSetItem> updateSetItem = update.getItems();
-		TableConfig tc = schema.getTables().get(tableName);
+    @Override
+    public void statementParse(SchemaConfig schema, RouteResultset rrs, SQLStatement stmt) throws SQLNonTransientException {
+        //这里限制了update分片表的个数只能有一个
+        if (ctx.getTables() != null && ctx.getTables().size() > 1 && !schema.isNoSharding()) {
+            String msg = "multi table related update not supported,tables:" + ctx.getTables();
+            LOGGER.warn(msg);
+            throw new SQLNonTransientException(msg);
+        }
+        MySqlUpdateStatement update = (MySqlUpdateStatement) stmt;
+        String tableName = StringUtil.removeBackquote(update.getTableName().getSimpleName().toUpperCase());
 
-		if(RouterUtil.isNoSharding(schema,tableName)) {//整个schema都不分库或者该表不拆分
-			RouterUtil.routeForTableMeta(rrs, schema, tableName, rrs.getStatement());
-			rrs.setFinishedRoute(true);
-			return;
-		}
+        List<SQLUpdateSetItem> updateSetItem = update.getItems();
+        TableConfig tc = schema.getTables().get(tableName);
 
-		String partitionColumn = tc.getPartitionColumn();
-		String joinKey = tc.getJoinKey();
-		if(tc.isGlobalTable() || (partitionColumn == null && joinKey == null)) {
-			//修改全局表 update 受影响的行数
-			RouterUtil.routeToMultiNode(false, rrs, tc.getDataNodes(), rrs.getStatement(),tc.isGlobalTable());
-			rrs.setFinishedRoute(true);
-			return;
-		}
-		
-		if(updateSetItem != null && updateSetItem.size() > 0) {
-			boolean hasParent = (schema.getTables().get(tableName).getParentTC() != null);
-			for(SQLUpdateSetItem item : updateSetItem) {
-				String column = StringUtil.removeBackquote(item.getColumn().toString().toUpperCase());
-				if(partitionColumn != null && partitionColumn.equals(column)) {
-					String msg = "partion key can't be updated " + tableName + "->" + partitionColumn;
-					LOGGER.warn(msg);
-					throw new SQLNonTransientException(msg);
-				}
-				if(hasParent) {
-					if(column.equals(joinKey)) {
-						String msg = "parent relation column can't be updated " + tableName + "->" + joinKey;
-						LOGGER.warn(msg);
-						throw new SQLNonTransientException(msg);
-					}
-					rrs.setCacheAble(true);
-				}
-			}
-		}
-		
+        if (RouterUtil.isNoSharding(schema, tableName)) {//整个schema都不分库或者该表不拆分
+            RouterUtil.routeForTableMeta(rrs, schema, tableName, rrs.getStatement());
+            rrs.setFinishedRoute(true);
+            return;
+        }
+
+        String partitionColumn = tc.getPartitionColumn();
+        String joinKey = tc.getJoinKey();
+        if (tc.isGlobalTable() || (partitionColumn == null && joinKey == null)) {
+            //修改全局表 update 受影响的行数
+            RouterUtil.routeToMultiNode(false, rrs, tc.getDataNodes(), rrs.getStatement(), tc.isGlobalTable());
+            rrs.setFinishedRoute(true);
+            return;
+        }
+
+
+        confirmShardColumnNotUpdated(updateSetItem, schema, tableName, partitionColumn, joinKey, rrs);
+
 //		if(ctx.getTablesAndConditions().size() > 0) {
 //			Map<String, Set<ColumnRoutePair>> map = ctx.getTablesAndConditions().get(tableName);
 //			if(map != null) {
@@ -74,9 +58,35 @@ public class DruidUpdateParser extends DefaultDruidParser {
 //			
 //		}
 //		System.out.println();
-		
-		if(schema.getTables().get(tableName).isGlobalTable() && ctx.getRouteCalculateUnit().getTablesAndConditions().size() > 1) {
-			throw new SQLNonTransientException("global table not supported multi table related update "+ tableName);
-		}
-	}
+
+        if (schema.getTables().get(tableName).isGlobalTable() && ctx.getRouteCalculateUnit().getTablesAndConditions().size() > 1) {
+            throw new SQLNonTransientException("global table not supported multi table related update " + tableName);
+        }
+    }
+
+    private void confirmShardColumnNotUpdated(List<SQLUpdateSetItem> updateSetItem,SchemaConfig schema,String tableName,String partitionColumn,String joinKey,RouteResultset rrs) throws SQLNonTransientException {
+        if (updateSetItem != null && updateSetItem.size() > 0) {
+            boolean hasParent = (schema.getTables().get(tableName).getParentTC() != null);
+            for (SQLUpdateSetItem item : updateSetItem) {
+                String column = StringUtil.removeBackquote(item.getColumn().toString().toUpperCase());
+                //考虑别名，前面已经限制了update分片表的个数只能有一个，所以这里别名只能是分片表的
+                if (column.contains(StringUtil.TABLE_COLUMN_SEPARATOR)) {
+                    column = column.substring(column.indexOf(".") + 1).trim().toUpperCase();
+                }
+                if (partitionColumn != null && partitionColumn.equals(column)) {
+                    String msg = "partion key can't be updated " + tableName + "->" + partitionColumn;
+                    LOGGER.warn(msg);
+                    throw new SQLNonTransientException(msg);
+                }
+                if (hasParent) {
+                    if (column.equals(joinKey)) {
+                        String msg = "parent relation column can't be updated " + tableName + "->" + joinKey;
+                        LOGGER.warn(msg);
+                        throw new SQLNonTransientException(msg);
+                    }
+                    rrs.setCacheAble(true);
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/io/mycat/util/StringUtil.java
+++ b/src/main/java/io/mycat/util/StringUtil.java
@@ -36,6 +36,8 @@ import java.util.Random;
  * @author mycat
  */
 public class StringUtil {
+	public static final String TABLE_COLUMN_SEPARATOR = ".";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(StringUtil.class);
 	private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 	private static final Random RANDOM = new Random();

--- a/src/test/java/io/mycat/parser/druid/DruidUpdateParserTest.java
+++ b/src/test/java/io/mycat/parser/druid/DruidUpdateParserTest.java
@@ -1,0 +1,55 @@
+package io.mycat.parser.druid;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlUpdateStatement;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import io.mycat.config.model.SchemaConfig;
+import io.mycat.config.model.TableConfig;
+import io.mycat.route.RouteResultset;
+import io.mycat.route.parser.druid.impl.DruidUpdateParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.SQLNonTransientException;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Hash Zhang
+ * @version 1.0.0
+ * @date 2016/7/7
+ */
+
+public class DruidUpdateParserTest {
+    @Test
+    public void testAliasUpdate() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+        MySqlStatementParser parser = new MySqlStatementParser("update hotnews h set h.id = 1 where h.name = 234;");
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement sqlStatement = statementList.get(0);
+        MySqlUpdateStatement update = (MySqlUpdateStatement) sqlStatement;
+        SchemaConfig schemaConfig = mock(SchemaConfig.class);
+        Map<String, TableConfig> tables = mock(Map.class);
+        TableConfig tableConfig = mock(TableConfig.class);
+        String tableName = "hotnews";
+        when((schemaConfig).getTables()).thenReturn(tables);
+        when(tables.get(tableName)).thenReturn(tableConfig);
+        when(tableConfig.getParentTC()).thenReturn(null);
+        RouteResultset routeResultset = new RouteResultset("update hotnews h set h.id = 1 where h.name = 234;", 11);
+        Class c = DruidUpdateParser.class;
+        Method method = c.getDeclaredMethod("confirmShardColumnNotUpdated", new Class[]{List.class, SchemaConfig.class, String.class, String.class, String.class, RouteResultset.class});
+        method.setAccessible(true);
+        try {
+            method.invoke(c.newInstance(), update.getItems(), schemaConfig, tableName, "ID", "", routeResultset);
+            System.out.println("未抛异常，解析通过则不对！");
+            Assert.assertTrue(false);
+        }catch (Exception e){
+            System.out.println("抛异常原因为SQLNonTransientException则正确");
+            Assert.assertTrue(e.getCause() instanceof SQLNonTransientException);
+        }
+    }
+}


### PR DESCRIPTION
update hotnews set id = 1 where name = 234;这个语句会报错，因为分片字段不能修改。
但是：update hotnews h set h.id = 1 where h.name = 234;加上别名的语句则不会报错并且能修改成功。
这是由于UpDate解析验证是否修改分片字段代码缺陷导致，没有考虑别名。作了修改并添加单元测试