### PR TITLE
fix DDLRouteTest中测试的sql语句的语法问题

### DIFF
--- a/src/test/java/io/mycat/route/DDLRouteTest.java
+++ b/src/test/java/io/mycat/route/DDLRouteTest.java
@@ -43,8 +43,8 @@ public class DDLRouteTest {
 			CacheService cacheService = new CacheService();
 	        RouteService routerService = new RouteService(cacheService);
 	        
-	        // drop table test
-	        String  sql = " ALTER TABLE COMPANY\r\nADD COLUMN TEST  VARCHAR(255) NULL AFTER CREATE_DATE,\r\nDEFAULT CHARACTER SET DEFAULT";
+	        // alter table test
+	        String  sql = " ALTER TABLE COMPANY\r\nADD COLUMN TEST  VARCHAR(255) NULL AFTER CREATE_DATE,\r\n CHARACTER SET = UTF8";
 	        sql = RouterUtil.getFixedSql(sql);
 	        List<String> dataNodes = new ArrayList<>();
 	        String  tablename =  RouterUtil.getTableName(sql, RouterUtil.getAlterTablePos(sql, 0));


### PR DESCRIPTION
测试语句中多了一个 DEFAULT，导致druid解析报错。同时
mysql支持下面的alter：
alter table COMPANY add column test3 varchar(255) null after name, CHARACTER SET DEFAULT;
，但是 druid 不支持，druid要求CHARACTER SET后面必须是等于号：
alter table COMPANY add column test3 varchar(255) null after name, CHARACTER SET = UTF8;