### PR TITLE
1.5版本-修复循环使用分片节点时，在跨头尾节点查询时出现的空指针异常

### DIFF
--- a/src/main/java/org/opencloudb/route/function/AbstractPartitionAlgorithm.java
+++ b/src/main/java/org/opencloudb/route/function/AbstractPartitionAlgorithm.java
@@ -51,7 +51,7 @@ public abstract class AbstractPartitionAlgorithm implements RuleAlgorithm {
 			
 			return re;
 		}else{
-			return null;
+			return new Integer[0];
 		}
 	}
 	


### PR DESCRIPTION
异常出现的场景：
1.按日期分片，10天一个分片，10个分片节点
2.跨第一个分片和第十个分片查询时会出现 ERROR 1064 (HY000): NullPointerException

源代码分析：
/**
* 对于存储数据按顺序存放的字段做范围路由，可以使用这个函数
* @param algorithm
* @param beginValue
* @param endValue
* @return
*/
public static Integer[] calculateSequenceRange(AbstractPartitionAlgorithm algorithm, String beginValue, String endValue) {
Integer begin = 0, end = 0;
begin = algorithm.calculate(beginValue);
end = algorithm.calculate(endValue);

    if(begin == null || end == null){
        return new Integer[0];
    }

    if (end >= begin) {     //该判断在以上场景时   end为0   begin为9  ，导致判断不通过返回了null
        int len = end-begin+1;
        Integer [] re = new Integer[len];

        for(int i =0;i<len;i++){
            re[i]=begin+i;
        }

        return re;
    }else{
        return null;
    }
}