### PR TITLE
修改分布式事务校验开关

### DIFF
--- a/src/main/java/io/mycat/config/model/SystemConfig.java
+++ b/src/main/java/io/mycat/config/model/SystemConfig.java
@@ -152,7 +152,8 @@ public final class SystemConfig {
 	private int useCompression =0;	
 	private int useSqlStat = 1;
 
-	private boolean enableDistributedTransactions = true;
+	//处理分布式事务开关，默认为不过滤分布式事务
+	private int handleDistributedTransactions = 0;
 
 	private int checkTableConsistency = 0;
 	private long checkTableConsistencyPeriod = CHECKTABLECONSISTENCYPERIOD;
@@ -210,13 +211,7 @@ public final class SystemConfig {
 	 * 写入到临时目录
 	 */
 	private String dataNodeSortedTempDir;
-	public boolean isEnableDistributedTransactions() {
-		return enableDistributedTransactions;
-	}
 
-	public void setEnableDistributedTransactions(boolean enableDistributedTransactions) {
-		this.enableDistributedTransactions = enableDistributedTransactions;
-	}
 
 
 
@@ -881,5 +876,13 @@ public final class SystemConfig {
 
 	public void setProcessorBufferPoolType(int processorBufferPoolType) {
 		this.processorBufferPoolType = processorBufferPoolType;
+	}
+
+	public int getHandleDistributedTransactions() {
+		return handleDistributedTransactions;
+	}
+
+	public void setHandleDistributedTransactions(int handleDistributedTransactions) {
+		this.handleDistributedTransactions = handleDistributedTransactions;
 	}
 }

--- a/src/main/java/io/mycat/route/RouteResultsetNode.java
+++ b/src/main/java/io/mycat/route/RouteResultsetNode.java
@@ -50,6 +50,7 @@ public final class RouteResultsetNode implements Serializable , Comparable<Route
 	private int totalNodeSize =0; //方便后续jdbc批量获取扩展
    private Procedure procedure;
 	private LoadData loadData;
+	private RouteResultset source;
 	
 	// 强制走 master，可以通过 RouteResultset的属性canRunInReadDB(false)
 	// 传给 RouteResultsetNode 来实现，但是 强制走 slave需要增加一个属性来实现:
@@ -277,5 +278,13 @@ public final class RouteResultsetNode implements Serializable , Comparable<Route
 	
 	public boolean isHasBlanceFlag() {
 		return hasBlanceFlag;
+	}
+
+	public RouteResultset getSource() {
+		return source;
+	}
+
+	public void setSource(RouteResultset source) {
+		this.source = source;
 	}
 }

--- a/src/main/java/io/mycat/route/parser/druid/impl/DruidInsertParser.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/DruidInsertParser.java
@@ -263,8 +263,9 @@ public class DruidInsertParser extends DefaultDruidParser {
 					Integer nodeIndex = node.getKey();
 					List<ValuesClause> valuesList = node.getValue();
 					insertStmt.setValuesList(valuesList);
-					nodes[count++] = new RouteResultsetNode(tableConfig.getDataNodes().get(nodeIndex),
+					nodes[count] = new RouteResultsetNode(tableConfig.getDataNodes().get(nodeIndex),
 							rrs.getSqlType(),insertStmt.toString());
+					nodes[count++].setSource(rrs);
 				}
 				rrs.setNodes(nodes);
 				rrs.setFinishedRoute(true);

--- a/src/main/java/io/mycat/route/util/RouterUtil.java
+++ b/src/main/java/io/mycat/route/util/RouterUtil.java
@@ -108,6 +108,7 @@ public class RouterUtil {
 		}
 		RouteResultsetNode[] nodes = new RouteResultsetNode[1];
 		nodes[0] = new RouteResultsetNode(dataNode, rrs.getSqlType(), stmt);//rrs.getStatement()
+		nodes[0].setSource(rrs);
 		rrs.setNodes(nodes);
 		rrs.setFinishedRoute(true);
 		if (rrs.getCanRunInReadDB() != null) {
@@ -166,6 +167,7 @@ public class RouterUtil {
 				for(int i=0;i<nodeSize;i++){
 					String name = iterator1.next();
 					nodes[i] = new RouteResultsetNode(name, sqlType, stmt);
+					nodes[i].setSource(rrs);
 				}
 				rrs.setNodes(nodes);
 			}
@@ -173,6 +175,7 @@ public class RouterUtil {
 		}else if(schema.getDataNode()!=null){		//默认节点ddl
 			RouteResultsetNode[] nodes = new RouteResultsetNode[1];
 			nodes[0] = new RouteResultsetNode(schema.getDataNode(), sqlType, stmt);
+			nodes[0].setSource(rrs);
 			rrs.setNodes(nodes);
 			return rrs;
 		}
@@ -640,6 +643,7 @@ public class RouterUtil {
 		RouteResultsetNode node;
 		for (String dataNode : dataNodes) {
 			node = new RouteResultsetNode(dataNode, rrs.getSqlType(), stmt);
+			node.setSource(rrs);
 			if (rrs.getCanRunInReadDB() != null) {
 				node.setCanRunInReadDB(rrs.getCanRunInReadDB());
 			}
@@ -672,6 +676,7 @@ public class RouterUtil {
 
 		RouteResultsetNode[] nodes = new RouteResultsetNode[1];
 		nodes[0] = new RouteResultsetNode(dataNode, rrs.getSqlType(), sql);
+		nodes[0].setSource(rrs);
 		if (rrs.getCanRunInReadDB() != null) {
 			nodes[0].setCanRunInReadDB(rrs.getCanRunInReadDB());
 		}
@@ -1092,7 +1097,7 @@ public class RouterUtil {
 			String changeSql = orgSql;
 			nodes[i] = new RouteResultsetNode(dataNode, rrs.getSqlType(), changeSql);//rrs.getStatement()
 			nodes[i].setSubTableName(String.valueOf(subTables[i]));
-			
+			nodes[i].setSource(rrs);
 			if (rrs.getCanRunInReadDB() != null) {
 				nodes[i].setCanRunInReadDB(rrs.getCanRunInReadDB());
 			}

--- a/src/main/java/io/mycat/server/handler/Explain2Handler.java
+++ b/src/main/java/io/mycat/server/handler/Explain2Handler.java
@@ -74,6 +74,7 @@ public class Explain2Handler {
 			
 			RouteResultsetNode node = new RouteResultsetNode(dataNode, ServerParse.SELECT, sql);
 			RouteResultset	rrs =  new RouteResultset(sql, ServerParse.SELECT);
+			node.setSource(rrs);
 			EMPTY_ARRAY[0] = node; 
 			rrs.setNodes(EMPTY_ARRAY);
 			SingleNodeHandler singleNodeHandler = new SingleNodeHandler(rrs, c.getSession2());

--- a/src/main/java/io/mycat/server/handler/ServerLoadDataInfileHandler.java
+++ b/src/main/java/io/mycat/server/handler/ServerLoadDataInfileHandler.java
@@ -316,6 +316,7 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler
         {
             //走默认节点
             RouteResultsetNode rrNode = new RouteResultsetNode(schema.getDataNode(), ServerParse.INSERT, sql);
+            rrNode.setSource(rrs);
             rrs.setNodes(new RouteResultsetNode[]{rrNode});
             return rrs;
         }
@@ -328,6 +329,7 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler
                 String dataNode = dataNodes.get(i);
                 RouteResultsetNode rrNode = new RouteResultsetNode(dataNode, ServerParse.INSERT, sql);
                 rrsNodes[i]=rrNode;
+                rrsNodes[i].setSource(rrs);
             }
 
             rrs.setNodes(rrsNodes);
@@ -530,6 +532,7 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler
         for (String dn : routeMap.keySet())
         {
             RouteResultsetNode rrNode = new RouteResultsetNode(dn, ServerParse.LOAD_DATA_INFILE_SQL, srcStatement);
+            rrNode.setSource(rrs);
             rrNode.setTotalNodeSize(size);
             rrNode.setStatement(srcStatement);
             LoadData newLoadData = new LoadData();

--- a/src/main/java/io/mycat/server/interceptor/impl/GlobalTableUtil.java
+++ b/src/main/java/io/mycat/server/interceptor/impl/GlobalTableUtil.java
@@ -169,7 +169,7 @@ public class GlobalTableUtil{
 	static String addColumnIfCreate(String sql, SQLStatement statement) {
 		if (isCreate(statement) && sql.trim().toUpperCase().startsWith("CREATE TABLE ") && !hasGlobalColumn(statement)) {
 			SQLColumnDefinition column = new SQLColumnDefinition();
-			column.setDataType(new SQLCharacterDataType("int"));
+			column.setDataType(new SQLCharacterDataType("bigint"));
 			column.setName(new SQLIdentifierExpr(GLOBAL_TABLE_MYCAT_COLUMN));
 			column.setComment(new SQLCharExpr("全局表保存修改时间戳的字段名"));
 			((SQLCreateTableStatement)statement).getTableElementList().add(column);

--- a/src/main/resources/server.xml
+++ b/src/main/resources/server.xml
@@ -36,7 +36,8 @@
 			<property name="serverPort">8066</property> <property name="managerPort">9066</property> 
 			<property name="idleTimeout">300000</property> <property name="bindIp">0.0.0.0</property> 
 			<property name="frontWriteQueueSize">4096</property> <property name="processors">32</property> -->
-		<property name="enableDistributedTransactions">false</property>
+		<!--分布式事务开关，0为不过滤分布式事务，1为过滤分布式事务（如果分布式事务内只涉及全局表，则不过滤），2为不过滤分布式事务,但是记录分布式事务日志-->
+		<property name="handleDistributedTransactions">2</property>
 		
 			<!--
 			off heap for merge/order/group/limit


### PR DESCRIPTION
**配置方法：**
在server.xml的system标签中添加：
`<property name="handleDistributedTransactions">0</property>`
值可以为0,1,2
0 - 不检查分布式事务，执行所有分布式事务
1 - 过滤掉所有分布式事务，不执行，直接报错
2 - 检查分布式事务，但执行，只是打日志
**实现说明：**
Nonblockingsession类处理事务还有请求，在这个类中过滤掉分布式事务。
一个地方是execute方法中，添加如果是更新语句（insert，update，delete），并且不是全局表更新，那么检查是否为分布式事务。
另一个地方是在commit方法中，做相似的检查。
举例：
如下两种分布式事务：
`1. insert into hotnews(id) values(1),(2);`
`2. set autocommit = 0;insert into hotnews(id) values(3),(4);commit;`
如果handleDistributedTransactions配置为0，则顺利执行。
如果handleDistributedTransactions配置为1，则：
对于事务1：
```
mysql>insert into hotnews(id) values(1),(2);
1148 - Distributed transaction is disabled!
```
对于事务2:
```
mysql> set autocommit = 0;
Query OK, 0 rows affected
mysql> insert into hotnews(id) values(3),(4);
Query OK, 2 rows affected
mysql> commit;
1148 - Distributed transaction is disabled!
```

如果handleDistributedTransactions配置为2，则后台日志：
对于事务1：
```
07-21 08:50:41.835   WARN [$_NIOREACTOR-3-RW] (NonBlockingSession.java:150) -Distributed transaction detected! RRS:insert into hotnews(id) values(1),(2), route={
   1 -> dn2{INSERT INTO hotnews (id)
VALUES (1)}
   2 -> dn3{INSERT INTO hotnews (id)
VALUES (2)}
}
```
对于事务2：
```
07-21 08:51:22.578   WARN [$_NIOREACTOR-3-RW] (NonBlockingSession.java:194) -Distributed transaction detected! Targets:{dn1{INSERT INTO hotnews (id)
VALUES (3)}=MySQLConnection [id=8, lastTime=1469062279566, user=root, schema=db1, old shema=db1, borrowed=true, fromSlaveDB=false, threadId=481613, charset=utf8, txIsolation=3, autocommit=false, attachment=dn1{INSERT INTO hotnews (id)
VALUES (3)}, respHandler=org.opencloudb.mysql.nio.handler.MultiNodeCoordinator@70f3863, host=10.202.4.39, port=3306, statusSync=null, writeQueue=0, modifiedSQLExecuted=true], dn2{INSERT INTO hotnews (id)
VALUES (4)}=MySQLConnection [id=3, lastTime=1469062279566, user=root, schema=db2, old shema=db2, borrowed=true, fromSlaveDB=false, threadId=481617, charset=utf8, txIsolation=3, autocommit=false, attachment=dn2{INSERT INTO hotnews (id)
VALUES (4)}, respHandler=org.opencloudb.mysql.nio.handler.MultiNodeCoordinator@70f3863, host=10.202.4.39, port=3306, statusSync=null, writeQueue=0, modifiedSQLExecuted=true]}
```
