### PR TITLE
将一些初始化连接时hard code的mysql系统参数转化为可通过MyCAT配置文件修改的参数

### DIFF
--- a/src/main/java/org/opencloudb/config/Isolations.java
+++ b/src/main/java/org/opencloudb/config/Isolations.java
@@ -23,6 +23,8 @@
  */
 package org.opencloudb.config;
 
+import com.alibaba.druid.sql.dialect.db2.ast.stmt.DB2SelectQueryBlock;
+
 /**
  * 事务隔离级别定义
  * 
@@ -35,4 +37,16 @@ public interface Isolations {
     public static final int REPEATED_READ = 3;
     public static final int SERIALIZABLE = 4;
 
+    /**
+     * 通用的RDBMS事务隔离级别的数值应该为 0，1，2，3，由于mycat历史遗留问题，目前
+     * 仍然使用从1开始表示各个级别。对应的MYSQL的tx_isolation变量取值参考
+     * http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html
+     */
+    public static final String[] IsolationLevel = {
+            "READ-UNCOMMITTED", // 0 占位
+            "READ-UNCOMMITTED", // 1 也叫 DIRTY READ
+            "READ-COMMITTED",   // 2 缩写 RC
+            "REPEATABLE-READ",  // 3 缩写 RR
+            "SERIALIZABLE"      // 4 缩写 SR
+    };
 }

--- a/src/main/java/org/opencloudb/config/loader/xml/XMLServerLoader.java
+++ b/src/main/java/org/opencloudb/config/loader/xml/XMLServerLoader.java
@@ -242,6 +242,13 @@ public class XMLServerLoader {
                         + ") is not valid.");
             }
         }
+
+        if (system.getMaxPacketSize() > SystemConfig.MYCAT_MAX_PACKET_SIZE) {
+            throw new ConfigException("The specified maxPacketSize (" + system.getMaxPacketSize()
+                    + ") is over limit, now the max supported value in MyCAT is "
+                    + SystemConfig.MYCAT_MAX_PACKET_SIZE);
+        }
+        system.setMysqlVariables();
     }
 
 }

--- a/src/main/java/org/opencloudb/parser/druid/impl/DruidInsertParser.java
+++ b/src/main/java/org/opencloudb/parser/druid/impl/DruidInsertParser.java
@@ -193,7 +193,7 @@ public class DruidInsertParser extends DefaultDruidParser {
 				SQLBinaryOpExpr opExpr = (SQLBinaryOpExpr)expr;
 				String column = StringUtil.removeBackquote(opExpr.getLeft().toString().toUpperCase());
 				if(column.equals(partitionColumn)) {
-					String msg = "partion key can't be updated: " + tableName + " -> " + partitionColumn;
+					String msg = "Sharding column can't be updated: " + tableName + " -> " + partitionColumn;
 					LOGGER.warn(msg);
 					throw new SQLNonTransientException(msg);
 				}

--- a/src/main/java/org/opencloudb/server/response/SelectVariables.java
+++ b/src/main/java/org/opencloudb/server/response/SelectVariables.java
@@ -25,6 +25,7 @@ package org.opencloudb.server.response;
 
 import com.google.common.base.Splitter;
 import org.apache.log4j.Logger;
+import org.opencloudb.MycatServer;
 import org.opencloudb.backend.BackendConnection;
 import org.opencloudb.config.Fields;
 import org.opencloudb.mysql.PacketUtil;
@@ -92,6 +93,7 @@ public final class SelectVariables
         // write rows
         //byte packetId = eof.packetId;
 
+        HashMap<String, String> variables = MycatServer.getInstance().getConfig().getSystem().getMysqlVariables();
         RowDataPacket row = new RowDataPacket(FIELD_COUNT);
         for (int i1 = 0, splitVarSize = splitVar.size(); i1 < splitVarSize; i1++)
         {
@@ -136,52 +138,4 @@ public final class SelectVariables
 
 
     }
-
-
-
-
-    private static final Map<String, String> variables = new HashMap<String, String>();
-    static {
-        variables.put("@@character_set_client", "utf8");
-        variables.put("@@character_set_connection", "utf8");
-        variables.put("@@character_set_results", "utf8");
-        variables.put("@@character_set_server", "utf8");
-        variables.put("@@init_connect", "");
-        variables.put("@@interactive_timeout", "172800");
-        variables.put("@@license", "GPL");
-        variables.put("@@lower_case_table_names", "1");
-        variables.put("@@max_allowed_packet", "16777216");
-        variables.put("@@net_buffer_length", "16384");
-        variables.put("@@net_write_timeout", "60");
-        variables.put("@@query_cache_size", "0");
-        variables.put("@@query_cache_type", "OFF");
-        variables.put("@@sql_mode", "STRICT_TRANS_TABLES");
-        variables.put("@@system_time_zone", "CST");
-        variables.put("@@time_zone", "SYSTEM");
-        variables.put("@@tx_isolation", "REPEATABLE-READ");
-        variables.put("@@wait_timeout", "172800");
-        variables.put("@@session.auto_increment_increment", "1");
-
-        variables.put("character_set_client", "utf8");
-        variables.put("character_set_connection", "utf8");
-        variables.put("character_set_results", "utf8");
-        variables.put("character_set_server", "utf8");
-        variables.put("init_connect", "");
-        variables.put("interactive_timeout", "172800");
-        variables.put("license", "GPL");
-        variables.put("lower_case_table_names", "1");
-        variables.put("max_allowed_packet", "16777216");
-        variables.put("net_buffer_length", "16384");
-        variables.put("net_write_timeout", "60");
-        variables.put("query_cache_size", "0");
-        variables.put("query_cache_type", "OFF");
-        variables.put("sql_mode", "STRICT_TRANS_TABLES");
-        variables.put("system_time_zone", "CST");
-        variables.put("time_zone", "SYSTEM");
-        variables.put("tx_isolation", "REPEATABLE-READ");
-        variables.put("wait_timeout", "172800");
-        variables.put("auto_increment_increment", "1");
-    }
-    
-
 }

--- a/src/test/java/org/opencloudb/parser/druid/DruidUpdateParserTest.java
+++ b/src/test/java/org/opencloudb/parser/druid/DruidUpdateParserTest.java
@@ -1,6 +1,9 @@
 package org.opencloudb.parser.druid;
 
+import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlUpdateStatement;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
 import org.junit.Assert;
@@ -12,6 +15,7 @@ import org.opencloudb.route.RouteResultset;
 
 import java.lang.reflect.Method;
 import java.sql.SQLNonTransientException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +34,17 @@ public class DruidUpdateParserTest {
      */
     @Test
     public void testUpdateShardColumn() throws NoSuchMethodException{
-        throwExceptionParse("update hotnews set id = 1 where name = 234;");
+        throwExceptionParse("update hotnews set id = 1 where name = 234;", true);
+        throwExceptionParse("update hotnews set id = 1 where id = 3;", true);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id = 1 and name = '234'", false);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id = 1 or name = '234'", true);
+        throwExceptionParse("update hotnews set id = 'A', name = '123' where id = 'A' and name = '234'", false);
+        throwExceptionParse("update hotnews set id = 'A', name = '123' where id = 'A' or name = '234'", true);
+        throwExceptionParse("update hotnews set id = 1.5, name = '123' where id = 1.5 and name = '234'", false);
+        throwExceptionParse("update hotnews set id = 1.5, name = '123' where id = 1.5 or name = '234'", true);
+
+        throwExceptionParse("update hotnews set id = 1, name = '123' where name = '234' and (id = 1 or age > 3)", true);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id = 1 and (name = '234' or age > 3)", false);
     }
 
     /**
@@ -39,10 +53,23 @@ public class DruidUpdateParserTest {
      */
     @Test
     public void testAliasUpdateShardColumn() throws NoSuchMethodException{
-        throwExceptionParse("update hotnews h set h.id = 1 where h.name = 234;");
+        throwExceptionParse("update hotnews h set h.id = 1 where h.name = 234;", true);
+        throwExceptionParse("update hotnews h set h.id = 1 where h.id = 3;", true);
+        throwExceptionParse("update hotnews h set h.id = 1, h.name = '123' where h.id = 1 and h.name = '234'", false);
+        throwExceptionParse("update hotnews h set h.id = 1, h.name = '123' where h.id = 1 or h.name = '234'", true);
+        throwExceptionParse("update hotnews h set h.id = 'A', h.name = '123' where h.id = 'A' and h.name = '234'", false);
+        throwExceptionParse("update hotnews h set h.id = 'A', h.name = '123' where h.id = 'A' or h.name = '234'", true);
+        throwExceptionParse("update hotnews h set h.id = 1.5, h.name = '123' where h.id = 1.5 and h.name = '234'", false);
+        throwExceptionParse("update hotnews h set h.id = 1.5, h.name = '123' where h.id = 1.5 or h.name = '234'", true);
+
+        throwExceptionParse("update hotnews h set id = 1, h.name = '123' where h.id = 1 and h.name = '234'", false);
+        throwExceptionParse("update hotnews h set h.id = 1, h.name = '123' where id = 1 or h.name = '234'", true);
+
+        throwExceptionParse("update hotnews h set h.id = 1, h.name = '123' where h.name = '234' and (h.id = 1 or h.age > 3)", true);
+        throwExceptionParse("update hotnews h set h.id = 1, h.name = '123' where h.id = 1 and (h.name = '234' or h.age > 3)", false);
     }
 
-    public void throwExceptionParse(String sql) throws NoSuchMethodException {
+    public void throwExceptionParse(String sql, boolean throwException) throws NoSuchMethodException {
         MySqlStatementParser parser = new MySqlStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();
         SQLStatement sqlStatement = statementList.get(0);
@@ -56,15 +83,85 @@ public class DruidUpdateParserTest {
         when(tableConfig.getParentTC()).thenReturn(null);
         RouteResultset routeResultset = new RouteResultset(sql, 11);
         Class c = DruidUpdateParser.class;
-        Method method = c.getDeclaredMethod("confirmShardColumnNotUpdated", new Class[]{List.class, SchemaConfig.class, String.class, String.class, String.class, RouteResultset.class});
+        Method method = c.getDeclaredMethod("confirmShardColumnNotUpdated", new Class[]{SQLUpdateStatement.class, SchemaConfig.class, String.class, String.class, String.class, RouteResultset.class});
         method.setAccessible(true);
         try {
-            method.invoke(c.newInstance(), update.getItems(), schemaConfig, tableName, "ID", "", routeResultset);
-            System.out.println("未抛异常，解析通过则不对！");
-            Assert.assertTrue(false);
+            method.invoke(c.newInstance(), update, schemaConfig, tableName, "ID", "", routeResultset);
+            if (throwException) {
+                System.out.println("未抛异常，解析通过则不对！");
+                Assert.assertTrue(false);
+            } else {
+                System.out.println("未抛异常，解析通过，此情况分片字段可能在update语句中但是实际不会被更新");
+                Assert.assertTrue(true);
+            }
         } catch (Exception e) {
-            System.out.println("抛异常原因为SQLNonTransientException则正确");
-            Assert.assertTrue(e.getCause() instanceof SQLNonTransientException);
+            if (throwException) {
+                System.out.println("抛异常原因为SQLNonTransientException则正确");
+                Assert.assertTrue(e.getCause() instanceof SQLNonTransientException);
+            } else {
+                System.out.println("抛异常，需要检查");
+                Assert.assertTrue(false);
+            }
+        }
+    }
+
+    /*
+    * 添加一个static方法用于打印一个SQL的where子句，比如这样的一条SQL:
+    * update mytab t set t.ptn_col = 'A', col1 = 3 where ptn_col = 'A' and (col1 = 4 or col2 > 5);
+    * where子句的语法树如下
+    *                  AND
+    *              /        \
+    *             =          OR
+    *          /   \       /    \
+    *     ptn_col 'A'    =       >
+    *                  /  \    /   \
+    *               col1  4  col2   5
+    * 其输出如下，(按层输出，并且每层最后输出下一层的节点数目)
+    * BooleanAnd			Num of nodes in next level: 2
+    * Equality	BooleanOr			Num of nodes in next level: 4
+    * ptn_col	'A'	Equality	Equality			Num of nodes in next level: 4
+    * col1	4	col2	5			Num of nodes in next level: 0
+    *
+    * 因为大部分的update的where子句都比较简单，按层次打印应该足够清晰，未来可以完全按照逻辑打印类似上面的整棵树结构
+     */
+    public static void printWhereClauseAST(SQLExpr sqlExpr) {
+        // where子句的AST sqlExpr可以通过 MySqlUpdateStatement.getWhere(); 获得
+        if (sqlExpr == null)
+            return;
+        ArrayList<SQLExpr> exprNode = new ArrayList<>();
+        int i = 0, curLevel = 1, nextLevel = 0;
+        SQLExpr iterExpr;
+        exprNode.add(sqlExpr);
+        while (true) {
+            iterExpr = exprNode.get(i++);
+            if (iterExpr == null)
+                break;
+
+            if (iterExpr instanceof SQLBinaryOpExpr) {
+                System.out.print(((SQLBinaryOpExpr) iterExpr).getOperator());
+            } else {
+                System.out.print(iterExpr.toString());
+            }
+            System.out.print("\t");
+            curLevel--;
+
+            if (iterExpr instanceof SQLBinaryOpExpr) {
+                if (((SQLBinaryOpExpr) iterExpr).getLeft() != null) {
+                    exprNode.add(((SQLBinaryOpExpr) iterExpr).getLeft());
+                    nextLevel++;
+                }
+                if (((SQLBinaryOpExpr) iterExpr).getRight() != null) {
+                    exprNode.add(((SQLBinaryOpExpr) iterExpr).getRight());
+                    nextLevel++;
+                }
+            }
+            if (curLevel == 0) {
+                System.out.println("\t\tNum of nodes in next level: " + nextLevel);
+                curLevel = nextLevel;
+                nextLevel = 0;
+            }
+            if (exprNode.size() == i)
+                break;
         }
     }
 }

--- a/src/test/java/org/opencloudb/route/DruidMysqlRouteStrategyTest.java
+++ b/src/test/java/org/opencloudb/route/DruidMysqlRouteStrategyTest.java
@@ -391,7 +391,7 @@ public class DruidMysqlRouteStrategyTest extends TestCase {
         }
         Assert.assertEquals(
                 true,
-                err.startsWith("parent relation column can't be updated ORDERS->CUSTOMER_ID"));
+                err.startsWith("Parent relevant column can't be updated ORDERS->CUSTOMER_ID"));
 
         // route by parent rule ,update sql
         sql = "update orders set id=1 ,name='aaa' where customer_id=2000001";
@@ -923,7 +923,7 @@ public class DruidMysqlRouteStrategyTest extends TestCase {
         Assert.assertEquals(1, rrs.getNodes().length);
         Assert.assertEquals("dn1", rrs.getNodes()[0].getName());
 
-        //insert ... on duplicate key ,partion key can't be updated
+        //insert ... on duplicate key ,sharding key can't be updated
         sql = "insert into employee (id,name,sharding_id) values(1,'testonly',10000) " +
                 "on duplicate key update name=VALUES(name),id = VALUES(id),sharding_id = VALUES(sharding_id)";
 
@@ -931,7 +931,7 @@ public class DruidMysqlRouteStrategyTest extends TestCase {
             rrs = routeStrategy.route(new SystemConfig(), schema,
                     ServerParse.SELECT, sql, null, null, cachePool);
         } catch (Exception e) {
-            Assert.assertEquals("partion key can't be updated: EMPLOYEE -> SHARDING_ID", e.getMessage());
+            Assert.assertEquals("Sharding column can't be updated: EMPLOYEE -> SHARDING_ID", e.getMessage());
         }
 
 


### PR DESCRIPTION
在JDBC初始化与mycat的连接时会获取一些mycat（或者说mysql的系统信息），mycat可能为了避免一次额外的后端查询通信，将这些配置信息hard code在SelectVariable类中，现在将这些参数与MyCAT的server配置中的一些配置项对应起来，使得这些信息也可以通过修改mycat的配置进行修改。

另外，发现一个mycat的限制。目前MyCAT仅支持大小为 16M-1以下的数据包，而MySQL对大于这个值的数据包会自动进行拆包，拼包的操作，MyCAT目前尚不支持，因此加入maxPacketSize的检查，设置其最大值为16M-1，如果超过这个值，会报错。

Exception in thread "main" java.lang.ExceptionInInitializerError
        at org.opencloudb.MycatStartup.main(MycatStartup.java:50)
Caused by: org.opencloudb.config.util.ConfigException: The specified maxPacketSize (33554432) is over limit, now the max
 supported value in MyCAT is 16777215
        at org.opencloudb.config.loader.xml.XMLServerLoader.loadSystem(XMLServerLoader.java:247)
        at org.opencloudb.config.loader.xml.XMLServerLoader.load(XMLServerLoader.java:96)
        at org.opencloudb.config.loader.xml.XMLServerLoader.<init>(XMLServerLoader.java:70)
        at org.opencloudb.config.loader.xml.XMLConfigLoader.<init>(XMLConfigLoader.java:56)
        at org.opencloudb.ConfigInitializer.<init>(ConfigInitializer.java:64)
        at org.opencloudb.MycatConfig.<init>(MycatConfig.java:69)
        at org.opencloudb.MycatServer.<init>(MycatServer.java:105)
        at org.opencloudb.MycatServer.<clinit>(MycatServer.java:73)
        ... 1 more