### PR TITLE
修改对于update语句中set子句包含分片字段更新语句的处理逻辑

### DIFF
--- a/src/main/java/org/opencloudb/parser/druid/impl/DruidInsertParser.java
+++ b/src/main/java/org/opencloudb/parser/druid/impl/DruidInsertParser.java
@@ -193,7 +193,7 @@ public class DruidInsertParser extends DefaultDruidParser {
 				SQLBinaryOpExpr opExpr = (SQLBinaryOpExpr)expr;
 				String column = StringUtil.removeBackquote(opExpr.getLeft().toString().toUpperCase());
 				if(column.equals(partitionColumn)) {
-					String msg = "partion key can't be updated: " + tableName + " -> " + partitionColumn;
+					String msg = "Sharding column can't be updated: " + tableName + " -> " + partitionColumn;
 					LOGGER.warn(msg);
 					throw new SQLNonTransientException(msg);
 				}

--- a/src/main/java/org/opencloudb/parser/druid/impl/DruidUpdateParser.java
+++ b/src/main/java/org/opencloudb/parser/druid/impl/DruidUpdateParser.java
@@ -3,6 +3,9 @@ package org.opencloudb.parser.druid.impl;
 import java.sql.SQLNonTransientException;
 import java.util.List;
 
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.*;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
 import org.opencloudb.config.model.SchemaConfig;
 import org.opencloudb.config.model.TableConfig;
 import org.opencloudb.route.RouteResultset;
@@ -23,8 +26,7 @@ public class DruidUpdateParser extends DefaultDruidParser {
 		}
 		MySqlUpdateStatement update = (MySqlUpdateStatement)stmt;
 		String tableName = StringUtil.removeBackquote(update.getTableName().getSimpleName().toUpperCase());
-		
-		List<SQLUpdateSetItem> updateSetItem = update.getItems();
+
 		TableConfig tc = schema.getTables().get(tableName);
 
 		if(RouterUtil.isNoSharding(schema,tableName)) {//整个schema都不分库或者该表不拆分
@@ -42,7 +44,7 @@ public class DruidUpdateParser extends DefaultDruidParser {
 			return;
 		}
 
-		confirmShardColumnNotUpdated(updateSetItem, schema, tableName, partitionColumn, joinKey, rrs);
+		confirmShardColumnNotUpdated(update, schema, tableName, partitionColumn, joinKey, rrs);
 //		if(ctx.getTablesAndConditions().size() > 0) {
 //			Map<String, Set<ColumnRoutePair>> map = ctx.getTablesAndConditions().get(tableName);
 //			if(map != null) {
@@ -57,11 +59,124 @@ public class DruidUpdateParser extends DefaultDruidParser {
 //		System.out.println();
 		
 		if(schema.getTables().get(tableName).isGlobalTable() && ctx.getRouteCalculateUnit().getTablesAndConditions().size() > 1) {
-			throw new SQLNonTransientException("global table not supported multi table related update "+ tableName);
+			throw new SQLNonTransientException("global table is not supported in multi table related update "+ tableName);
 		}
 	}
 
-	private void confirmShardColumnNotUpdated(List<SQLUpdateSetItem> updateSetItem,SchemaConfig schema,String tableName,String partitionColumn,String joinKey,RouteResultset rrs) throws SQLNonTransientException {
+	/*
+	* 判断字段是否在SQL AST的节点中，比如 col 在 col = 'A' 中，这里要注意，一些子句中可能会在字段前加上表的别名，
+	* 比如 t.col = 'A'，这两种情况， 操作符(=)左边被druid解析器解析成不同的对象SQLIdentifierExpr(无表别名)和
+	* SQLPropertyExpr(有表别名)
+	 */
+	private static boolean columnInExpr(SQLExpr sqlExpr, String colName) throws SQLNonTransientException {
+		String column;
+		if (sqlExpr instanceof SQLIdentifierExpr) {
+			column = StringUtil.removeBackquote(((SQLIdentifierExpr) sqlExpr).getName()).toUpperCase();
+		} else if (sqlExpr instanceof SQLPropertyExpr) {
+			column = StringUtil.removeBackquote(((SQLPropertyExpr) sqlExpr).getName()).toUpperCase();
+		} else {
+			throw new SQLNonTransientException("Unhandled SQL AST node type encountered: " + sqlExpr.getClass());
+		}
+
+		return column.equals(colName.toUpperCase());
+	}
+
+	/*
+	* 当前节点是不是一个子查询
+	* IN (select...), ANY, EXISTS, ALL等关键字, IN (1,2,3...) 这种对应的是SQLInListExpr
+	 */
+	private static boolean isSubQueryClause(SQLExpr sqlExpr) throws SQLNonTransientException {
+		return (sqlExpr instanceof SQLInSubQueryExpr || sqlExpr instanceof SQLAnyExpr || sqlExpr instanceof SQLAllExpr
+				|| sqlExpr instanceof SQLQueryExpr || sqlExpr instanceof SQLExistsExpr);
+	}
+
+	/*
+    * 遍历where子句的AST，寻找是否有与update子句中更新分片字段相同的条件，
+    * o 如果发现有or或者xor，然后分片字段的条件在or或者xor中的，这种情况update也无法执行，比如
+    *   update mytab set ptn_col = val, col1 = val1 where col1 = val11 or ptn_col = val；
+    *   但是下面的这种update是可以执行的
+    *   update mytab set ptn_col = val, col1 = val1 where ptn_col = val and (col1 = val11 or col2 = val2);
+    * o 如果没有发现与update子句中更新分片字段相同的条件，则update也无法执行，比如
+    *   update mytab set ptn_col = val， col1 = val1 where col1 = val11 and col2 = val22;
+    * o 如果条件之间都是and，且有与更新分片字段相同的条件，这种情况是允许执行的。比如
+    *   update mytab set ptn_col = val, col1 = val1 where ptn_col = val and col1 = val11 and col2 = val2;
+    * o 对于一些特殊的运算符，比如between，not，或者子查询，遇到这些子句现在不会去检查分片字段是否在此类子句中，
+    *   即使分片字段在此类子句中，现在也认为对应的update语句无法执行。
+    *
+    * @param whereClauseExpr   where子句的语法树AST
+    * @param column   分片字段的名字
+    * @param value    分片字段要被更新成的值
+    * @hasOR          遍历到whereClauseExpr这个节点的时候，其上层路径中是否有OR/XOR关系运算
+    *
+    * @return         true，表示update不能执行，false表示可以执行
+     */
+	private boolean shardColCanBeUpdated(SQLExpr whereClauseExpr, String column, SQLExpr value, boolean hasOR)
+			throws SQLNonTransientException {
+		boolean canUpdate = false;
+		boolean parentHasOR = false;
+
+		if (whereClauseExpr == null)
+			return false;
+
+		if (whereClauseExpr instanceof SQLBinaryOpExpr) {
+			SQLBinaryOpExpr nodeOpExpr = (SQLBinaryOpExpr) whereClauseExpr;
+            /*
+            * 条件中有or或者xor的，如果分片字段出现在or/xor的一个子句中，则此update
+            * 语句无法执行
+             */
+			if ((nodeOpExpr.getOperator() == SQLBinaryOperator.BooleanOr) ||
+					(nodeOpExpr.getOperator() == SQLBinaryOperator.BooleanXor)) {
+				parentHasOR = true;
+			}
+			// 发现类似 col = value 的子句
+			if (nodeOpExpr.getOperator() == SQLBinaryOperator.Equality) {
+				boolean foundCol;
+				SQLExpr leftExpr = nodeOpExpr.getLeft();
+				SQLExpr rightExpr = nodeOpExpr.getRight();
+
+				foundCol = columnInExpr(leftExpr, column);
+
+				// 发现col = value子句，col刚好是分片字段，比较value与update要更新的值是否一样，并且是否在or/xor子句中
+				if (foundCol) {
+					if (rightExpr.getClass() != value.getClass()) {
+						throw new SQLNonTransientException("SQL AST nodes type mismatch!");
+					}
+
+					canUpdate = rightExpr.toString().equals(value.toString()) && (!hasOR) && (!parentHasOR);
+				}
+			} else if (nodeOpExpr.getOperator().isLogical()) {
+				if (nodeOpExpr.getLeft() != null) {
+					if (nodeOpExpr.getLeft() instanceof SQLBinaryOpExpr) {
+						canUpdate = shardColCanBeUpdated(nodeOpExpr.getLeft(), column, value, parentHasOR);
+					}
+					// else
+					// 此子语句不是 =,>,<等关系运算符(对应的类是SQLBinaryOpExpr)。比如between X and Y
+					// 或者 NOT，或者单独的子查询，这些情况，我们不做处理
+				}
+				if ((!canUpdate) && nodeOpExpr.getRight() != null) {
+					if (nodeOpExpr.getRight() instanceof SQLBinaryOpExpr) {
+						canUpdate = shardColCanBeUpdated(nodeOpExpr.getRight(), column, value, parentHasOR);
+					}
+					// else
+					// 此子语句不是 =,>,<等关系运算符(对应的类是SQLBinaryOpExpr)。比如between X and Y
+					// 或者 NOT，或者单独的子查询，这些情况，我们不做处理
+				}
+			} else if (isSubQueryClause(nodeOpExpr)){
+				// 对于子查询的检查有点复杂，这里暂时不支持
+				return false;
+			}
+			// else
+			// 其他类型的子句，忽略, 如果分片字段在这类子句中，此类情况目前不做处理，将返回false
+		}
+		// else
+		//此处说明update的where只有一个条件，并且不是 =,>,<等关系运算符(对应的类是SQLBinaryOpExpr)。比如between X and Y
+		// 或者 NOT，或者单独的子查询，这些情况，我们都不做处理
+
+		return canUpdate;
+	}
+
+	private void confirmShardColumnNotUpdated(SQLUpdateStatement update,SchemaConfig schema,String tableName,String partitionColumn,String joinKey,RouteResultset rrs) throws SQLNonTransientException {
+		List<SQLUpdateSetItem> updateSetItem = update.getItems();
 		if (updateSetItem != null && updateSetItem.size() > 0) {
 			boolean hasParent = (schema.getTables().get(tableName).getParentTC() != null);
 			for (SQLUpdateSetItem item : updateSetItem) {
@@ -71,13 +186,19 @@ public class DruidUpdateParser extends DefaultDruidParser {
 					column = column.substring(column.indexOf(".") + 1).trim().toUpperCase();
 				}
 				if (partitionColumn != null && partitionColumn.equals(column)) {
-					String msg = "partion key can't be updated " + tableName + "->" + partitionColumn;
-					LOGGER.warn(msg);
-					throw new SQLNonTransientException(msg);
+					boolean canUpdate;
+					canUpdate = ((update.getWhere() != null) && shardColCanBeUpdated(update.getWhere(),
+							partitionColumn, item.getValue(), false));
+
+					if (!canUpdate) {
+						String msg = "Sharding column can't be updated " + tableName + "->" + partitionColumn;
+						LOGGER.warn(msg);
+						throw new SQLNonTransientException(msg);
+					}
 				}
 				if (hasParent) {
 					if (column.equals(joinKey)) {
-						String msg = "parent relation column can't be updated " + tableName + "->" + joinKey;
+						String msg = "Parent relevant column can't be updated " + tableName + "->" + joinKey;
 						LOGGER.warn(msg);
 						throw new SQLNonTransientException(msg);
 					}

--- a/src/test/java/org/opencloudb/parser/druid/DruidUpdateParserTest.java
+++ b/src/test/java/org/opencloudb/parser/druid/DruidUpdateParserTest.java
@@ -1,6 +1,9 @@
 package org.opencloudb.parser.druid;
 
+import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlUpdateStatement;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
 import org.junit.Assert;
@@ -12,6 +15,7 @@ import org.opencloudb.route.RouteResultset;
 
 import java.lang.reflect.Method;
 import java.sql.SQLNonTransientException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +34,25 @@ public class DruidUpdateParserTest {
      */
     @Test
     public void testUpdateShardColumn() throws NoSuchMethodException{
-        throwExceptionParse("update hotnews set id = 1 where name = 234;");
+        throwExceptionParse("update hotnews set id = 1 where name = 234;", true);
+        throwExceptionParse("update hotnews set id = 1 where id = 3;", true);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id = 1 and name = '234'", false);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id = 1 or name = '234'", true);
+        throwExceptionParse("update hotnews set id = 'A', name = '123' where id = 'A' and name = '234'", false);
+        throwExceptionParse("update hotnews set id = 'A', name = '123' where id = 'A' or name = '234'", true);
+        throwExceptionParse("update hotnews set id = 1.5, name = '123' where id = 1.5 and name = '234'", false);
+        throwExceptionParse("update hotnews set id = 1.5, name = '123' where id = 1.5 or name = '234'", true);
+
+        throwExceptionParse("update hotnews set id = 1, name = '123' where name = '234' and (id = 1 or age > 3)", true);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id = 1 and (name = '234' or age > 3)", false);
+
+        // 子查询，特殊的运算符between等情况
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id = 1 and name in (select name from test)", false);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where name = '123' and id in (select id from test)", true);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id between 1 and 3", true);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id between 1 and 3 and name = '234'", true);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id between 1 and 3 or name = '234'", true);
+        throwExceptionParse("update hotnews set id = 1, name = '123' where id = 1 and name between '124' and '234'", false);
     }
 
     /**
@@ -39,10 +61,23 @@ public class DruidUpdateParserTest {
      */
     @Test
     public void testAliasUpdateShardColumn() throws NoSuchMethodException{
-        throwExceptionParse("update hotnews h set h.id = 1 where h.name = 234;");
+        throwExceptionParse("update hotnews h set h.id = 1 where h.name = 234;", true);
+        throwExceptionParse("update hotnews h set h.id = 1 where h.id = 3;", true);
+        throwExceptionParse("update hotnews h set h.id = 1, h.name = '123' where h.id = 1 and h.name = '234'", false);
+        throwExceptionParse("update hotnews h set h.id = 1, h.name = '123' where h.id = 1 or h.name = '234'", true);
+        throwExceptionParse("update hotnews h set h.id = 'A', h.name = '123' where h.id = 'A' and h.name = '234'", false);
+        throwExceptionParse("update hotnews h set h.id = 'A', h.name = '123' where h.id = 'A' or h.name = '234'", true);
+        throwExceptionParse("update hotnews h set h.id = 1.5, h.name = '123' where h.id = 1.5 and h.name = '234'", false);
+        throwExceptionParse("update hotnews h set h.id = 1.5, h.name = '123' where h.id = 1.5 or h.name = '234'", true);
+
+        throwExceptionParse("update hotnews h set id = 1, h.name = '123' where h.id = 1 and h.name = '234'", false);
+        throwExceptionParse("update hotnews h set h.id = 1, h.name = '123' where id = 1 or h.name = '234'", true);
+
+        throwExceptionParse("update hotnews h set h.id = 1, h.name = '123' where h.name = '234' and (h.id = 1 or h.age > 3)", true);
+        throwExceptionParse("update hotnews h set h.id = 1, h.name = '123' where h.id = 1 and (h.name = '234' or h.age > 3)", false);
     }
 
-    public void throwExceptionParse(String sql) throws NoSuchMethodException {
+    public void throwExceptionParse(String sql, boolean throwException) throws NoSuchMethodException {
         MySqlStatementParser parser = new MySqlStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();
         SQLStatement sqlStatement = statementList.get(0);
@@ -56,15 +91,86 @@ public class DruidUpdateParserTest {
         when(tableConfig.getParentTC()).thenReturn(null);
         RouteResultset routeResultset = new RouteResultset(sql, 11);
         Class c = DruidUpdateParser.class;
-        Method method = c.getDeclaredMethod("confirmShardColumnNotUpdated", new Class[]{List.class, SchemaConfig.class, String.class, String.class, String.class, RouteResultset.class});
+        Method method = c.getDeclaredMethod("confirmShardColumnNotUpdated", new Class[]{SQLUpdateStatement.class, SchemaConfig.class, String.class, String.class, String.class, RouteResultset.class});
         method.setAccessible(true);
         try {
-            method.invoke(c.newInstance(), update.getItems(), schemaConfig, tableName, "ID", "", routeResultset);
-            System.out.println("未抛异常，解析通过则不对！");
-            Assert.assertTrue(false);
+            method.invoke(c.newInstance(), update, schemaConfig, tableName, "ID", "", routeResultset);
+            if (throwException) {
+                System.out.println("未抛异常，解析通过则不对！");
+                Assert.assertTrue(false);
+            } else {
+                System.out.println("未抛异常，解析通过，此情况分片字段可能在update语句中但是实际不会被更新");
+                Assert.assertTrue(true);
+            }
         } catch (Exception e) {
-            System.out.println("抛异常原因为SQLNonTransientException则正确");
-            Assert.assertTrue(e.getCause() instanceof SQLNonTransientException);
+            if (throwException) {
+                System.out.println(e.getCause().getClass());
+                Assert.assertTrue(e.getCause() instanceof SQLNonTransientException);
+                System.out.println("抛异常原因为SQLNonTransientException则正确");
+            } else {
+                System.out.println("抛异常，需要检查");
+                Assert.assertTrue(false);
+            }
+        }
+    }
+
+    /*
+    * 添加一个static方法用于打印一个SQL的where子句，比如这样的一条SQL:
+    * update mytab t set t.ptn_col = 'A', col1 = 3 where ptn_col = 'A' and (col1 = 4 or col2 > 5);
+    * where子句的语法树如下
+    *                  AND
+    *              /        \
+    *             =          OR
+    *          /   \       /    \
+    *     ptn_col 'A'    =       >
+    *                  /  \    /   \
+    *               col1  4  col2   5
+    * 其输出如下，(按层输出，并且每层最后输出下一层的节点数目)
+    * BooleanAnd			Num of nodes in next level: 2
+    * Equality	BooleanOr			Num of nodes in next level: 4
+    * ptn_col	'A'	Equality	Equality			Num of nodes in next level: 4
+    * col1	4	col2	5			Num of nodes in next level: 0
+    *
+    * 因为大部分的update的where子句都比较简单，按层次打印应该足够清晰，未来可以完全按照逻辑打印类似上面的整棵树结构
+     */
+    public static void printWhereClauseAST(SQLExpr sqlExpr) {
+        // where子句的AST sqlExpr可以通过 MySqlUpdateStatement.getWhere(); 获得
+        if (sqlExpr == null)
+            return;
+        ArrayList<SQLExpr> exprNode = new ArrayList<>();
+        int i = 0, curLevel = 1, nextLevel = 0;
+        SQLExpr iterExpr;
+        exprNode.add(sqlExpr);
+        while (true) {
+            iterExpr = exprNode.get(i++);
+            if (iterExpr == null)
+                break;
+
+            if (iterExpr instanceof SQLBinaryOpExpr) {
+                System.out.print(((SQLBinaryOpExpr) iterExpr).getOperator());
+            } else {
+                System.out.print(iterExpr.toString());
+            }
+            System.out.print("\t");
+            curLevel--;
+
+            if (iterExpr instanceof SQLBinaryOpExpr) {
+                if (((SQLBinaryOpExpr) iterExpr).getLeft() != null) {
+                    exprNode.add(((SQLBinaryOpExpr) iterExpr).getLeft());
+                    nextLevel++;
+                }
+                if (((SQLBinaryOpExpr) iterExpr).getRight() != null) {
+                    exprNode.add(((SQLBinaryOpExpr) iterExpr).getRight());
+                    nextLevel++;
+                }
+            }
+            if (curLevel == 0) {
+                System.out.println("\t\tNum of nodes in next level: " + nextLevel);
+                curLevel = nextLevel;
+                nextLevel = 0;
+            }
+            if (exprNode.size() == i)
+                break;
         }
     }
 }

--- a/src/test/java/org/opencloudb/route/DruidMysqlRouteStrategyTest.java
+++ b/src/test/java/org/opencloudb/route/DruidMysqlRouteStrategyTest.java
@@ -391,7 +391,7 @@ public class DruidMysqlRouteStrategyTest extends TestCase {
         }
         Assert.assertEquals(
                 true,
-                err.startsWith("parent relation column can't be updated ORDERS->CUSTOMER_ID"));
+                err.startsWith("Parent relevant column can't be updated ORDERS->CUSTOMER_ID"));
 
         // route by parent rule ,update sql
         sql = "update orders set id=1 ,name='aaa' where customer_id=2000001";
@@ -923,7 +923,7 @@ public class DruidMysqlRouteStrategyTest extends TestCase {
         Assert.assertEquals(1, rrs.getNodes().length);
         Assert.assertEquals("dn1", rrs.getNodes()[0].getName());
 
-        //insert ... on duplicate key ,partion key can't be updated
+        //insert ... on duplicate key ,sharding key can't be updated
         sql = "insert into employee (id,name,sharding_id) values(1,'testonly',10000) " +
                 "on duplicate key update name=VALUES(name),id = VALUES(id),sharding_id = VALUES(sharding_id)";
 
@@ -931,7 +931,7 @@ public class DruidMysqlRouteStrategyTest extends TestCase {
             rrs = routeStrategy.route(new SystemConfig(), schema,
                     ServerParse.SELECT, sql, null, null, cachePool);
         } catch (Exception e) {
-            Assert.assertEquals("partion key can't be updated: EMPLOYEE -> SHARDING_ID", e.getMessage());
+            Assert.assertEquals("Sharding column can't be updated: EMPLOYEE -> SHARDING_ID", e.getMessage());
         }
 
 


### PR DESCRIPTION
对于set和where子句中对于分片字段实际上并没有更新的update语句，允许执行而不抛出异常。修改一些相关的报错语句的内容，添加了针对新的处理逻辑的测试用例，比如update针对and，or，子查询等情况。

代码实现思路
--------------
遍历where子句的AST，寻找是否有与update子句中更新分片字段相同的条件，
o 如果发现有or或者xor，然后分片字段的条件在or或者xor中的，这种情况update也无法执行，比如
  update mytab set ptn_col = val, col1 = val1 where col1 = val11 or ptn_col = val；
  但是下面的这种update是可以执行的
  update mytab set ptn_col = val, col1 = val1 where ptn_col = val and (col1 = val11 or col2 = val2);
o 如果没有发现与update子句中更新分片字段相同的条件，则update也无法执行，比如
  update mytab set ptn_col = val， col1 = val1 where col1 = val11 and col2 = val22;
o 如果条件之间都是and，且有与更新分片字段相同的条件，这种情况是允许执行的。比如
  update mytab set ptn_col = val, col1 = val1 where ptn_col = val and col1 = val11 and col2 = val2;
o 对于一些特殊的运算符，比如between，not，或者子查询，遇到这些子句现在不会去检查分片字段是否在此类子句中，
  即使分片字段在此类子句中，现在也认为对应的update语句无法执行。
  
添加一个static方法用于打印一个SQL的where子句，比如这样的一条SQL:
update mytab t set t.ptn_col = 'A', col1 = 3 where ptn_col = 'A' and (col1 = 4 or col2 > 5);
where子句的语法树如下
                 AND
             /        \
            =          OR
         /   \       /    \
    ptn_col 'A'    =       >
                 /  \    /   \
              col1  4  col2   5
其输出如下，(按层输出，并且每层最后输出下一层的节点数目)
BooleanAnd			Num of nodes in next level: 2
Equality	BooleanOr			Num of nodes in next level: 4
ptn_col	'A'	Equality	Equality			Num of nodes in next level: 4
col1	4	col2	5			Num of nodes in next level: 0

因为大部分的update的where子句都比较简单，按层次打印应该足够清晰，未来可以完全按照逻辑打印类似上面的整棵树结构


手动的简单测试：
-----------------
MySQL [TESTDB]> select * from test4ptn;
+------+----------+
| id   | date     |
+------+----------+
|    1 | 20160805 |
+------+----------+
1 row in set (0.01 sec)

MySQL [TESTDB]> update test4ptn set id = 2, date = 20160805 where id = 1 ;
ERROR 1064 (HY000): Sharding column can't be updated TEST4PTN->DATE
MySQL [TESTDB]> update test4ptn set id = 2, date = 20160805 ;
ERROR 1064 (HY000): Sharding column can't be updated TEST4PTN->DATE
MySQL [TESTDB]> update test4ptn set id = 2, date = 20160805 where id = 1 or date = 20160805;
ERROR 1064 (HY000): Sharding column can't be updated TEST4PTN->DATE
MySQL [TESTDB]> update test4ptn set id = 2, date = 20160805 where id = 1 and date = 20160805;
Query OK, 1 row affected (0.00 sec)
Rows matched: 1  Changed: 1  Warnings: 0

MySQL [TESTDB]> select * from test4ptn;
+------+----------+
| id   | date     |
+------+----------+
|    2 | 20160805 |
+------+----------+
1 row in set (0.01 sec)



更多的测试用例在DruidUpdateParserTest类中