### PR TITLE
按天分片，跨头尾分片BUG修改

### DIFF
--- a/src/main/java/io/mycat/route/function/PartitionByDate.java
+++ b/src/main/java/io/mycat/route/function/PartitionByDate.java
@@ -7,6 +7,12 @@ import org.slf4j.Logger; import org.slf4j.LoggerFactory;
 
 import io.mycat.config.model.rule.RuleAlgorithm;
 
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
 /**
  * 例子 按日期列分区  格式 between操作解析的范例
  * 
@@ -64,7 +70,30 @@ public class PartitionByDate extends AbstractPartitionAlgorithm implements RuleA
 
 	@Override
 	public Integer[] calculateRange(String beginValue, String endValue) {
-		return AbstractPartitionAlgorithm.calculateSequenceRange(this, beginValue, endValue);
+		SimpleDateFormat format = new SimpleDateFormat(this.dateFormat);
+		try {
+			Date beginDate = format.parse(beginValue);
+			Date endDate = format.parse(endValue);
+			Calendar cal = Calendar.getInstance();
+			List<Integer> list = new ArrayList<Integer>();
+			while(beginDate.getTime() <= endDate.getTime()){
+				Integer nodeValue = this.calculate(format.format(beginDate));
+				if(Collections.frequency(list, nodeValue) < 1) list.add(nodeValue);
+				cal.setTime(beginDate);
+				cal.add(Calendar.DATE, 1);
+				beginDate = cal.getTime();
+			}
+			
+			Integer[] nodeArray = new Integer[list.size()];
+			for (int i=0;i<list.size();i++) {
+				nodeArray[i] = list.get(i);
+			}
+			
+			return nodeArray;
+		} catch (ParseException e) {
+			LOGGER.error(e);
+			return new Integer[0];
+		}
 	}
 
 	public void setsBeginDate(String sBeginDate) {


### PR DESCRIPTION
旧代码逻辑会照成一下问题

假设现在有3个分片，按1天一个分片，node值分别为0、1、2
2016-01-01----node0
2016-01-02----node1
2016-01-03----node2
2016-01-04----node0
2016-01-05----node1
2016-01-06----node2
2016-01-07----node0
2016-01-08----node1
2016-01-09----node2

第一种情况
查询2016-01-03至2016-01-04时，之前的代码会出现空指针异常（已修复）

第二种情况
查询2016-01-02至2016-01-05时，只会发送node1执行，略过了node2和node0

第三种情况
查询2016-01-01至2016-01-08时，只会发送到node0和node1，本应发送所有节点

现代码调整计算日期区间内的所有日期，不再只根据开始时间和结束时间计算路由