### PR TITLE
ER分片是子表插入时，获取joinkey字段时，其数据前后有引号导致hash算出来的分片错误

### DIFF
--- a/src/main/java/org/opencloudb/route/util/RouterUtil.java
+++ b/src/main/java/org/opencloudb/route/util/RouterUtil.java
@@ -1182,7 +1182,8 @@ public class RouterUtil {
 				throw new SQLNonTransientException(msg);
 			}
 
-			String joinKeyVal = insertStmt.getValues().getValues().get(joinKeyIndex).toString();
+			//String joinKeyVal = insertStmt.getValues().getValues().get(joinKeyIndex).toString();
+			String joinKeyVal = StringUtil.removeBackquote(insertStmt.getValues().getValues().get(joinKeyIndex).toString());
 
 			String sql = insertStmt.toString();
 


### PR DESCRIPTION
此项我看到1.6已做修改 bug#938
修改
processERChildTable函数
//String joinKeyVal = insertStmt.getValues().getValues().get(joinKeyIndex).toString();
改为如下：
String joinKeyVal = StringUtil.removeBackquote(insertStmt.getValues().getValues().get(joinKeyIndex).toString());