### PR TITLE
fixed : 修复mycat预处理多节点在useOffHeapForMerge = 1配置下返回结果异常的bug

### DIFF
--- a/src/main/java/io/mycat/net/mysql/BinaryRowDataPacket.java
+++ b/src/main/java/io/mycat/net/mysql/BinaryRowDataPacket.java
@@ -9,9 +9,11 @@ import java.util.List;
 
 import io.mycat.backend.mysql.BufferUtil;
 import io.mycat.config.Fields;
+import io.mycat.memory.unsafe.row.UnsafeRow;
 import io.mycat.net.FrontendConnection;
 import io.mycat.util.ByteUtil;
 import io.mycat.util.DateUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +47,33 @@ public class BinaryRowDataPacket extends MySQLPacket {
 	public BinaryRowDataPacket() {}
 	
 	/**
+	 * 从UnsafeRow转换成BinaryRowDataPacket
+	 * 
+	 * 说明: 当开启<b>isOffHeapuseOffHeapForMerge</b>参数时,会使用UnsafeRow封装数据,
+	 * 因此需要从这个对象里面将数据封装成BinaryRowDataPacket
+	 * 
+	 * @param fieldPackets
+	 * @param unsafeRow
+	 */
+	public void read(List<FieldPacket> fieldPackets, UnsafeRow unsafeRow) {
+		this.fieldPackets = fieldPackets;
+		this.fieldCount = unsafeRow.numFields();
+		this.fieldValues = new ArrayList<byte[]>(fieldCount);
+		this.nullBitMap = new byte[(fieldCount + 7 + 2) / 8];
+		
+		for(int i = 0; i < this.fieldCount; i++) {
+			byte[] fv = unsafeRow.getBinary(i);
+			FieldPacket fieldPk = fieldPackets.get(i);
+			if(fv == null) {
+				storeNullBitMap(i);
+				this.fieldValues.add(fv);
+			} else {
+				convert(fv, fieldPk);
+			}
+		}
+	}
+	
+	/**
 	 * 从RowDataPacket转换成BinaryRowDataPacket
 	 * @param fieldPackets 字段包集合
 	 * @param rowDataPk 文本协议行数据包
@@ -60,144 +89,158 @@ public class BinaryRowDataPacket extends MySQLPacket {
 			byte[] fv = _fieldValues.get(i);
 			FieldPacket fieldPk = fieldPackets.get(i);
 			if (fv == null) { // 字段值为null,根据协议规定存储nullBitMap
-				int bitMapPos = (i + 2) / 8;
-				int bitPos = (i + 2) % 8;
-				this.nullBitMap[bitMapPos] |= (byte) (1 << bitPos);
+				storeNullBitMap(i);
 				this.fieldValues.add(fv);
 			} else {
-				// 从RowDataPacket的fieldValue的数据转化成BinaryRowDataPacket的fieldValue数据
-				int fieldType = fieldPk.type;
-				switch (fieldType) {
-				case Fields.FIELD_TYPE_STRING:
-				case Fields.FIELD_TYPE_VARCHAR:
-				case Fields.FIELD_TYPE_VAR_STRING:
-				case Fields.FIELD_TYPE_ENUM:
-				case Fields.FIELD_TYPE_SET:
-				case Fields.FIELD_TYPE_LONG_BLOB:
-				case Fields.FIELD_TYPE_MEDIUM_BLOB:
-				case Fields.FIELD_TYPE_BLOB:
-				case Fields.FIELD_TYPE_TINY_BLOB:
-				case Fields.FIELD_TYPE_GEOMETRY:
-				case Fields.FIELD_TYPE_BIT:
-				case Fields.FIELD_TYPE_DECIMAL:
-				case Fields.FIELD_TYPE_NEW_DECIMAL:
-					// Fields
-					// value (lenenc_str) -- string
-					
-					// Example
-					// 03 66 6f 6f -- string = "foo"
-					this.fieldValues.add(_fieldValues.get(i));
-					break;
-				case Fields.FIELD_TYPE_LONGLONG:
-					// Fields
-					// value (8) -- integer
-
-					// Example
-					// 01 00 00 00 00 00 00 00 -- int64 = 1
-					long longVar = ByteUtil.getLong(_fieldValues.get(i));
-					this.fieldValues.add(ByteUtil.getBytes(longVar));
-					break;
-				case Fields.FIELD_TYPE_LONG:
-				case Fields.FIELD_TYPE_INT24:
-					// Fields
-					// value (4) -- integer
-
-					// Example
-					// 01 00 00 00 -- int32 = 1
-					int intVar = ByteUtil.getInt(_fieldValues.get(i));
-					this.fieldValues.add(ByteUtil.getBytes(intVar));
-					break;
-				case Fields.FIELD_TYPE_SHORT:
-				case Fields.FIELD_TYPE_YEAR:
-					// Fields
-					// value (2) -- integer
-
-					// Example
-					// 01 00 -- int16 = 1
-					short shortVar = ByteUtil.getShort(_fieldValues.get(i));
-					this.fieldValues.add(ByteUtil.getBytes(shortVar));
-					break;
-				case Fields.FIELD_TYPE_TINY:
-					// Fields
-					// value (1) -- integer
-
-					// Example
-					// 01 -- int8 = 1
-					int tinyVar = ByteUtil.getInt(_fieldValues.get(i));
-					byte[] bytes = new byte[1];
-					bytes[0] = (byte)tinyVar;
-					this.fieldValues.add(bytes);
-					break;
-				case Fields.FIELD_TYPE_DOUBLE:
-					// Fields
-					// value (string.fix_len) -- (len=8) double
-
-					// Example
-					// 66 66 66 66 66 66 24 40 -- double = 10.2
-					double doubleVar = ByteUtil.getDouble(_fieldValues.get(i));
-					this.fieldValues.add(ByteUtil.getBytes(doubleVar));
-					break;
-				case Fields.FIELD_TYPE_FLOAT:
-					// Fields
-					// value (string.fix_len) -- (len=4) float
-
-					// Example
-					// 33 33 23 41 -- float = 10.2
-					float floatVar = ByteUtil.getFloat(_fieldValues.get(i));
-					this.fieldValues.add(ByteUtil.getBytes(floatVar));
-					break;
-				case Fields.FIELD_TYPE_DATE:
-					try {
-						Date dateVar = DateUtil.parseDate(
-								ByteUtil.getDate(_fieldValues.get(i)),
-								DateUtil.DATE_PATTERN_ONLY_DATE);
-						this.fieldValues.add(ByteUtil.getBytes(dateVar, false));
-					} catch (ParseException e) {
-						LOGGER.error("error",e);
-					}
-					break;
-				case Fields.FIELD_TYPE_DATETIME:
-				case Fields.FIELD_TYPE_TIMESTAMP:
-					String dateStr = ByteUtil.getDate(_fieldValues.get(i));
-					Date dateTimeVar = null;
-					try {
-						if (dateStr.indexOf(".") > 0) {
-							dateTimeVar = DateUtil.parseDate(dateStr,
-									DateUtil.DATE_PATTERN_FULL);
-							this.fieldValues.add(ByteUtil.getBytes(dateTimeVar,
-									false));
-						} else {
-							dateTimeVar = DateUtil.parseDate(dateStr,
-									DateUtil.DEFAULT_DATE_PATTERN);
-							this.fieldValues.add(ByteUtil.getBytes(dateTimeVar,
-									false));
-						}
-					} catch (ParseException e) {
-						LOGGER.error("error",e);
-					}
-					break;
-				case Fields.FIELD_TYPE_TIME:
-					String timeStr = ByteUtil.getTime(_fieldValues.get(i));
-					Date timeVar = null;
-					try {
-						if (timeStr.indexOf(".") > 0) {
-							timeVar = DateUtil.parseDate(timeStr,
-									DateUtil.TIME_PATTERN_FULL);
-							this.fieldValues.add(ByteUtil.getBytes(timeVar,
-									true));
-						} else {
-							timeVar = DateUtil.parseDate(timeStr,
-									DateUtil.DEFAULT_TIME_PATTERN);
-							this.fieldValues.add(ByteUtil.getBytes(timeVar,
-									true));
-						}
-					} catch (ParseException e) {
-						LOGGER.error("error",e);
-					}
-					break;
-				}
+				convert(fv, fieldPk);
 			}
 		}
+	}
+	
+	private void storeNullBitMap(int i) {
+		int bitMapPos = (i + 2) / 8;
+		int bitPos = (i + 2) % 8;
+		this.nullBitMap[bitMapPos] |= (byte) (1 << bitPos);
+	}
+	
+	/**
+	 * 从RowDataPacket的fieldValue的数据转化成BinaryRowDataPacket的fieldValue数据
+	 * @param fv
+	 * @param fieldPk
+	 */
+	private void convert(byte[] fv, FieldPacket fieldPk) {
+		
+		int fieldType = fieldPk.type;
+		switch (fieldType) {
+		case Fields.FIELD_TYPE_STRING:
+		case Fields.FIELD_TYPE_VARCHAR:
+		case Fields.FIELD_TYPE_VAR_STRING:
+		case Fields.FIELD_TYPE_ENUM:
+		case Fields.FIELD_TYPE_SET:
+		case Fields.FIELD_TYPE_LONG_BLOB:
+		case Fields.FIELD_TYPE_MEDIUM_BLOB:
+		case Fields.FIELD_TYPE_BLOB:
+		case Fields.FIELD_TYPE_TINY_BLOB:
+		case Fields.FIELD_TYPE_GEOMETRY:
+		case Fields.FIELD_TYPE_BIT:
+		case Fields.FIELD_TYPE_DECIMAL:
+		case Fields.FIELD_TYPE_NEW_DECIMAL:
+			// Fields
+			// value (lenenc_str) -- string
+			
+			// Example
+			// 03 66 6f 6f -- string = "foo"
+			this.fieldValues.add(fv);
+			break;
+		case Fields.FIELD_TYPE_LONGLONG:
+			// Fields
+			// value (8) -- integer
+
+			// Example
+			// 01 00 00 00 00 00 00 00 -- int64 = 1
+			long longVar = ByteUtil.getLong(fv);
+			this.fieldValues.add(ByteUtil.getBytes(longVar));
+			break;
+		case Fields.FIELD_TYPE_LONG:
+		case Fields.FIELD_TYPE_INT24:
+			// Fields
+			// value (4) -- integer
+
+			// Example
+			// 01 00 00 00 -- int32 = 1
+			int intVar = ByteUtil.getInt(fv);
+			this.fieldValues.add(ByteUtil.getBytes(intVar));
+			break;
+		case Fields.FIELD_TYPE_SHORT:
+		case Fields.FIELD_TYPE_YEAR:
+			// Fields
+			// value (2) -- integer
+
+			// Example
+			// 01 00 -- int16 = 1
+			short shortVar = ByteUtil.getShort(fv);
+			this.fieldValues.add(ByteUtil.getBytes(shortVar));
+			break;
+		case Fields.FIELD_TYPE_TINY:
+			// Fields
+			// value (1) -- integer
+
+			// Example
+			// 01 -- int8 = 1
+			int tinyVar = ByteUtil.getInt(fv);
+			byte[] bytes = new byte[1];
+			bytes[0] = (byte)tinyVar;
+			this.fieldValues.add(bytes);
+			break;
+		case Fields.FIELD_TYPE_DOUBLE:
+			// Fields
+			// value (string.fix_len) -- (len=8) double
+
+			// Example
+			// 66 66 66 66 66 66 24 40 -- double = 10.2
+			double doubleVar = ByteUtil.getDouble(fv);
+			this.fieldValues.add(ByteUtil.getBytes(doubleVar));
+			break;
+		case Fields.FIELD_TYPE_FLOAT:
+			// Fields
+			// value (string.fix_len) -- (len=4) float
+
+			// Example
+			// 33 33 23 41 -- float = 10.2
+			float floatVar = ByteUtil.getFloat(fv);
+			this.fieldValues.add(ByteUtil.getBytes(floatVar));
+			break;
+		case Fields.FIELD_TYPE_DATE:
+			try {
+				Date dateVar = DateUtil.parseDate(
+						ByteUtil.getDate(fv),
+						DateUtil.DATE_PATTERN_ONLY_DATE);
+				this.fieldValues.add(ByteUtil.getBytes(dateVar, false));
+			} catch (ParseException e) {
+				LOGGER.error("error",e);
+			}
+			break;
+		case Fields.FIELD_TYPE_DATETIME:
+		case Fields.FIELD_TYPE_TIMESTAMP:
+			String dateStr = ByteUtil.getDate(fv);
+			Date dateTimeVar = null;
+			try {
+				if (dateStr.indexOf(".") > 0) {
+					dateTimeVar = DateUtil.parseDate(dateStr,
+							DateUtil.DATE_PATTERN_FULL);
+					this.fieldValues.add(ByteUtil.getBytes(dateTimeVar,
+							false));
+				} else {
+					dateTimeVar = DateUtil.parseDate(dateStr,
+							DateUtil.DEFAULT_DATE_PATTERN);
+					this.fieldValues.add(ByteUtil.getBytes(dateTimeVar,
+							false));
+				}
+			} catch (ParseException e) {
+				LOGGER.error("error",e);
+			}
+			break;
+		case Fields.FIELD_TYPE_TIME:
+			String timeStr = ByteUtil.getTime(fv);
+			Date timeVar = null;
+			try {
+				if (timeStr.indexOf(".") > 0) {
+					timeVar = DateUtil.parseDate(timeStr,
+							DateUtil.TIME_PATTERN_FULL);
+					this.fieldValues.add(ByteUtil.getBytes(timeVar,
+							true));
+				} else {
+					timeVar = DateUtil.parseDate(timeStr,
+							DateUtil.DEFAULT_TIME_PATTERN);
+					this.fieldValues.add(ByteUtil.getBytes(timeVar,
+							true));
+				}
+			} catch (ParseException e) {
+				LOGGER.error("error",e);
+			}
+			break;
+		}
+		
 	}
 	
 	public void write(FrontendConnection conn) {


### PR DESCRIPTION
当`server.xml`里面配置`useOffHeapForMerge = 1`时,使用新的内存管理方式保存数据，以及新的方式写数据到前端，预处理需要适配新的内存管理方式来返回正确的数据。

more : 
1. 重构了`BinaryRowDataPacket.java`相关代码
2. 代码调整 : `MultiNodeQueryHandler.java`两个`outputMergeResult`方法if条件移到for循环和while循环外面