### PR TITLE
fix #1074

### DIFF
--- a/src/main/java/io/mycat/server/handler/ServerLoadDataInfileHandler.java
+++ b/src/main/java/io/mycat/server/handler/ServerLoadDataInfileHandler.java
@@ -638,6 +638,12 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler
             settings.getFormat().setQuoteEscape(loadData.getEscape().charAt(0));
             }
             settings.getFormat().setNormalizedNewline(loadData.getLineTerminatedBy().charAt(0));
+            /*
+             *  fix bug #1074 : LOAD DATA local INFILE导入的所有Boolean类型全部变成了false
+             *  不可见字符将在CsvParser被当成whitespace过滤掉, 使用settings.trimValues(false)来避免被过滤掉
+             *  TODO : 设置trimValues(false)之后, 会引起字段值前后的空白字符无法被过滤!
+             */
+            settings.trimValues(false);
             CsvParser parser = new CsvParser(settings);
             try
             {
@@ -685,6 +691,12 @@ public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler
             settings.getFormat().setQuoteEscape(loadData.getEscape().charAt(0));
         }
         settings.getFormat().setNormalizedNewline(loadData.getLineTerminatedBy().charAt(0));
+        /*
+         *  fix #1074 : LOAD DATA local INFILE导入的所有Boolean类型全部变成了false
+         *  不可见字符将在CsvParser被当成whitespace过滤掉, 使用settings.trimValues(false)来避免被过滤掉
+         *  TODO : 设置trimValues(false)之后, 会引起字段值前后的空白字符无法被过滤!
+         */
+        settings.trimValues(false);
         CsvParser parser = new CsvParser(settings);
         InputStreamReader reader = null;
         FileInputStream fileInputStream = null;


### PR DESCRIPTION
不可见字符将在CsvParser被当成whitespace过滤掉, 使用`settings.trimValues(false)`来避免被过滤掉。
但是，设置trimValues(false)之后, 会引起字段值前后的空白字符无法被过滤！后期需要寻求更优的解决方案！

ref : [how-to-use-univocity-parsers-to-process-non-printable-character](http://stackoverflow.com/questions/39318083/how-to-use-univocity-parsers-to-process-non-printable-character/39323748#39323748)