### PR TITLE
fix #1086

### DIFF
--- a/src/main/java/io/mycat/server/handler/ServerPrepareHandler.java
+++ b/src/main/java/io/mycat/server/handler/ServerPrepareHandler.java
@@ -152,7 +152,7 @@ public class ServerPrepareHandler implements FrontendPrepareHandler {
     			sql = sql.replaceFirst("\\?", "NULL");
     			continue;
     		}
-    		switch(paramType) {
+    		switch(paramType & 0xff) {
     		case Fields.FIELD_TYPE_TINY:
     			sql = sql.replaceFirst("\\?", String.valueOf(bindValue.byteBinding));
     			break;


### PR DESCRIPTION
修复c++执行mycat预处理处理`unsigned`字段判断字段类型出错的bug

link :
```
The type of each parameter is made up of two bytes:
- the type as in Protocol::ColumnType
- a flag byte which has the highest bit set if the type is unsigned [80]
```
from [mysql protocol document](https://dev.mysql.com/doc/internals/en/com-stmt-execute.html)