### PR TITLE
reload @@config/@@config_all 功能增强, 真正实现热更新

### DIFF
--- a/src/main/java/io/mycat/MycatServer.java
+++ b/src/main/java/io/mycat/MycatServer.java
@@ -458,8 +458,6 @@ public class MycatServer {
 						long maxTimeout = sqlTimeout * 2;
 						
 						//根据 lastTime 确认事务的执行， 超过 sqlExecuteTimeout 阀值 close connection 
-						
-						//不停的有线程执行, 则超过10分钟强制关闭
 						long currentTime = TimeUtil.currentTimeMillis();
 						Iterator<PhysicalDBPool.OldConnection> iter = PhysicalDBPool.oldCons.iterator();
 						while( iter.hasNext() ) {

--- a/src/main/java/io/mycat/backend/ConMap.java
+++ b/src/main/java/io/mycat/backend/ConMap.java
@@ -1,7 +1,9 @@
 package io.mycat.backend;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -13,6 +15,7 @@ import io.mycat.backend.mysql.nio.MySQLConnection;
 import io.mycat.net.NIOProcessor;
 
 public class ConMap {
+	
 	// key -schema
 	private final ConcurrentHashMap<String, ConQueue> items = new ConcurrentHashMap<String, ConQueue>();
 
@@ -131,6 +134,39 @@ public class ConMap {
 
 		}
 		items.clear();
+	}
+    
+    /**
+     * 从 NIOProcessor 将  BackendConnection 移除到 old connection 待回收区
+     * @param dataSouce
+     * @return
+     */
+    public List<BackendConnection> shiftConnections(PhysicalDatasource dataSouce) {
+    	
+    	List<BackendConnection> backends = new ArrayList<BackendConnection>();
+    	
+        for (NIOProcessor processor : MycatServer.getInstance().getProcessors()) {
+            ConcurrentMap<Long, BackendConnection> map = processor.getBackends();
+            Iterator<Entry<Long, BackendConnection>> itor = map.entrySet().iterator();
+            while (itor.hasNext()) {
+                Entry<Long, BackendConnection> entry = itor.next();
+                BackendConnection con = entry.getValue();
+                if (con instanceof MySQLConnection) {
+                    if (((MySQLConnection) con).getPool() == dataSouce) {
+                    	backends.add( con );
+                        itor.remove();
+                    }
+                }else if(con instanceof JDBCConnection){
+                    if(((JDBCConnection) con).getPool() == dataSouce){
+                    	backends.add( con );
+                        itor.remove();
+                    }
+                }
+            }
+		}
+		items.clear();
+		
+		return backends;
 	}
 
 }

--- a/src/main/java/io/mycat/backend/datasource/PhysicalDatasource.java
+++ b/src/main/java/io/mycat/backend/datasource/PhysicalDatasource.java
@@ -50,8 +50,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class PhysicalDatasource {
-	private static final Logger LOGGER = LoggerFactory
-			.getLogger(PhysicalDatasource.class);
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(PhysicalDatasource.class);
 
 	private final String name;
 	private final int size;
@@ -63,8 +63,10 @@ public abstract class PhysicalDatasource {
 	private final DataHostConfig hostConfig;
 	private final ConnectionHeartBeatHandler conHeartBeatHanler = new ConnectionHeartBeatHandler();
 	private PhysicalDBPool dbPool;
+	
 	// 添加DataSource读计数
 	private AtomicLong readCount = new AtomicLong(0);
+	
 	// 添加DataSource写计数
 	private AtomicLong writeCount = new AtomicLong(0);
 
@@ -325,6 +327,13 @@ public abstract class PhysicalDatasource {
 	public void clearCons(String reason) {
 		this.conMap.clearConnections(reason, this);
 	}
+	
+	/**
+	 * 转移 Cons
+	 */
+	public List<BackendConnection> shiftCons() {		
+		return this.conMap.shiftConnections(this);
+	}
 
 	public void startHeartbeat() {
 		heartbeat.start();
@@ -334,11 +343,12 @@ public abstract class PhysicalDatasource {
 		heartbeat.stop();
 	}
 
-	public void doHeartbeat() {
+	public void doHeartbeat() {		
 		// 未到预定恢复时间，不执行心跳检测。
 		if (TimeUtil.currentTimeMillis() < heartbeatRecoveryTime) {
 			return;
 		}
+		
 		if (!heartbeat.isStop()) {
 			try {
 				heartbeat.heartbeat();
@@ -366,15 +376,14 @@ public abstract class PhysicalDatasource {
 	}
 
 	private void createNewConnection(final ResponseHandler handler,
-			final Object attachment, final String schema) throws IOException {
+			final Object attachment, final String schema) throws IOException {		
 		// aysn create connection
 		MycatServer.getInstance().getBusinessExecutor().execute(new Runnable() {
 			public void run() {
 				try {
 					createNewConnection(new DelegateResponseHandler(handler) {
 						@Override
-						public void connectionError(Throwable e,
-								BackendConnection conn) {
+						public void connectionError(Throwable e, BackendConnection conn) {
 							handler.connectionError(e, conn);
 						}
 
@@ -393,27 +402,29 @@ public abstract class PhysicalDatasource {
 	public void getConnection(String schema, boolean autocommit,
 			final ResponseHandler handler, final Object attachment)
 			throws IOException {
+		
+		// 从当前连接map中拿取已建立好的后端连接
 		BackendConnection con = this.conMap.tryTakeCon(schema, autocommit);
 		if (con != null) {
+			
+			//如果不为空，则绑定对应前端请求的handler
 			takeCon(con, handler, attachment, schema);
-			return;
+			return;	
+			
 		} else {
 			int activeCons = this.getActiveCount();// 当前最大活动连接
 			if (activeCons + 1 > size) {// 下一个连接大于最大连接数
 				LOGGER.error("the max activeConnnections size can not be max than maxconnections");
-				throw new IOException(
-						"the max activeConnnections size can not be max than maxconnections");
+				throw new IOException("the max activeConnnections size can not be max than maxconnections");
 			} else { // create connection
-				LOGGER.info("no ilde connection in pool,create new connection for "
-						+ this.name + " of schema " + schema);
+				LOGGER.info("no ilde connection in pool,create new connection for "	+ this.name + " of schema " + schema);
 				createNewConnection(handler, attachment, schema);
 			}
-
 		}
-
 	}
 
 	private void returnCon(BackendConnection c) {
+		
 		c.setAttachment(null);
 		c.setBorrowed(false);
 		c.setLastTime(TimeUtil.currentTimeMillis());
@@ -425,6 +436,7 @@ public abstract class PhysicalDatasource {
 		} else {
 			ok = queue.getManCommitCons().offer(c);
 		}
+		
 		if (!ok) {
 
 			LOGGER.warn("can't return to pool ,so close con " + c);
@@ -448,8 +460,15 @@ public abstract class PhysicalDatasource {
 
 	}
 
-	public abstract void createNewConnection(ResponseHandler handler,
-			String schema) throws IOException;
+	/**
+	 * 创建新连接
+	 */
+	public abstract void createNewConnection(ResponseHandler handler, String schema) throws IOException;
+	
+	/**
+	 * 测试连接，用于初始化及热更新配置检测
+	 */
+	public abstract boolean testConnection(String schema) throws IOException;
 
 	public long getHeartbeatRecoveryTime() {
 		return heartbeatRecoveryTime;

--- a/src/main/java/io/mycat/backend/jdbc/JDBCDatasource.java
+++ b/src/main/java/io/mycat/backend/jdbc/JDBCDatasource.java
@@ -19,24 +19,29 @@ import io.mycat.net.NIOConnector;
 import io.mycat.net.NIOProcessor;
 
 public class JDBCDatasource extends PhysicalDatasource {
-	static {
+	
+	static {		
 		// 加载可能的驱动
-		List<String> drivers = Lists.newArrayList("com.mysql.jdbc.Driver", "io.mycat.backend.jdbc.mongodb.MongoDriver","io.mycat.backend.jdbc.sequoiadb.SequoiaDriver", "oracle.jdbc.OracleDriver",
-				"com.microsoft.sqlserver.jdbc.SQLServerDriver","org.apache.hive.jdbc.HiveDriver","com.ibm.db2.jcc.DB2Driver","org.postgresql.Driver");
-		for (String driver : drivers)
-		{
-			try
-			{
+		List<String> drivers = Lists.newArrayList(
+				"com.mysql.jdbc.Driver", 
+				"io.mycat.backend.jdbc.mongodb.MongoDriver",
+				"io.mycat.backend.jdbc.sequoiadb.SequoiaDriver", 
+				"oracle.jdbc.OracleDriver",
+				"com.microsoft.sqlserver.jdbc.SQLServerDriver", 
+				"org.apache.hive.jdbc.HiveDriver",
+				"com.ibm.db2.jcc.DB2Driver", 
+				"org.postgresql.Driver");
+		
+		for (String driver : drivers) {
+			try {
 				Class.forName(driver);
-			} catch (ClassNotFoundException ignored)
-			{
+			} catch (ClassNotFoundException ignored) {
 			}
 		}
 	}
-	public JDBCDatasource(DBHostConfig config, DataHostConfig hostConfig,
-			boolean isReadNode) {
+	
+	public JDBCDatasource(DBHostConfig config, DataHostConfig hostConfig, boolean isReadNode) {
 		super(config, hostConfig, isReadNode);
-
 	}
 
 	@Override
@@ -48,21 +53,18 @@ public class JDBCDatasource extends PhysicalDatasource {
 	public void createNewConnection(ResponseHandler handler,String schema) throws IOException {
 		DBHostConfig cfg = getConfig();
 		JDBCConnection c = new JDBCConnection();
-
 		c.setHost(cfg.getIp());
 		c.setPort(cfg.getPort());
 		c.setPool(this);
 		c.setSchema(schema);
 		c.setDbType(cfg.getDbType());
 		
-		NIOProcessor processor = (NIOProcessor) MycatServer.getInstance()
-                .nextProcessor();
+		NIOProcessor processor = (NIOProcessor) MycatServer.getInstance().nextProcessor();
 		c.setProcessor(processor);
 		c.setId(NIOConnector.ID_GENERATOR.getId());  //复用mysql的Backend的ID，需要在process中存储
 
 		processor.addBackend(c);
 		try {
-
 			Connection con = getConnection();
 			// c.setIdleTimeout(pool.getConfig().getIdleTimeout());
 			c.setCon(con);
@@ -71,32 +73,52 @@ public class JDBCDatasource extends PhysicalDatasource {
 		} catch (Exception e) {
 			handler.connectionError(e, c);
 		}
+	}
+	
 
+	@Override
+	public boolean testConnection(String schema) throws IOException {
+		boolean isConnected = false;	
+		
+		Connection connection = null;
+		Statement statement = null;
+		try {
+			DBHostConfig cfg = getConfig();
+			connection = DriverManager.getConnection(cfg.getUrl(), cfg.getUser(), cfg.getPassword());
+			statement = connection.createStatement();			
+			if (connection != null && statement != null) {
+				isConnected = true;
+			}			
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {			
+			if (statement != null) {
+				try { statement.close(); } catch (SQLException e) {}
+			}
+			
+			if (connection != null) {
+				try { connection.close(); } catch (SQLException e) {}
+			}
+		}		
+		return isConnected;
 	}
 
-    Connection getConnection() throws SQLException
-    {
+    Connection getConnection() throws SQLException {
         DBHostConfig cfg = getConfig();
 		Connection connection = DriverManager.getConnection(cfg.getUrl(), cfg.getUser(), cfg.getPassword());
 		String initSql=getHostConfig().getConnectionInitSql();
-		if(initSql!=null&&!"".equals(initSql))
-		{     Statement statement =null;
-			try
-			{
-				 statement = connection.createStatement();
-				 statement.execute(initSql);
-			}finally
-			{
-				if(statement!=null)
-				{
+		if (initSql != null && !"".equals(initSql)) {
+			Statement statement = null;
+			try {
+				statement = connection.createStatement();
+				statement.execute(initSql);
+			} finally {
+				if (statement != null) {
 					statement.close();
 				}
 			}
 		}
 		return connection;
     }
-
-
-
-
+    
 }

--- a/src/main/java/io/mycat/backend/mysql/nio/MySQLDataSource.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/MySQLDataSource.java
@@ -23,14 +23,30 @@
  */
 package io.mycat.backend.mysql.nio;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.security.NoSuchAlgorithmException;
 
 import io.mycat.backend.datasource.PhysicalDatasource;
 import io.mycat.backend.heartbeat.DBHeartbeat;
 import io.mycat.backend.heartbeat.MySQLHeartbeat;
+import io.mycat.backend.mysql.SecurityUtil;
 import io.mycat.backend.mysql.nio.handler.ResponseHandler;
+import io.mycat.config.Capabilities;
 import io.mycat.config.model.DBHostConfig;
 import io.mycat.config.model.DataHostConfig;
+import io.mycat.net.mysql.AuthPacket;
+import io.mycat.net.mysql.BinaryPacket;
+import io.mycat.net.mysql.EOFPacket;
+import io.mycat.net.mysql.ErrorPacket;
+import io.mycat.net.mysql.HandshakePacket;
+import io.mycat.net.mysql.OkPacket;
+import io.mycat.net.mysql.QuitPacket;
+import io.mycat.net.mysql.Reply323Packet;
 
 /**
  * @author mycat
@@ -50,14 +66,146 @@ public class MySQLDataSource extends PhysicalDatasource {
 	public void createNewConnection(ResponseHandler handler,String schema) throws IOException {
 		factory.make(this, handler,schema);
 	}
+	
+	private long getClientFlags() {		
+		int flag = 0;
+        flag |= Capabilities.CLIENT_LONG_PASSWORD;
+        flag |= Capabilities.CLIENT_FOUND_ROWS;
+        flag |= Capabilities.CLIENT_LONG_FLAG;
+        flag |= Capabilities.CLIENT_CONNECT_WITH_DB;
+        // flag |= Capabilities.CLIENT_NO_SCHEMA;
+        // flag |= Capabilities.CLIENT_COMPRESS;
+        flag |= Capabilities.CLIENT_ODBC;
+        // flag |= Capabilities.CLIENT_LOCAL_FILES;
+        flag |= Capabilities.CLIENT_IGNORE_SPACE;
+        flag |= Capabilities.CLIENT_PROTOCOL_41;
+        flag |= Capabilities.CLIENT_INTERACTIVE;
+        // flag |= Capabilities.CLIENT_SSL;
+        flag |= Capabilities.CLIENT_IGNORE_SIGPIPE;
+        flag |= Capabilities.CLIENT_TRANSACTIONS;
+        // flag |= Capabilities.CLIENT_RESERVED;
+        flag |= Capabilities.CLIENT_SECURE_CONNECTION;
+        // client extension
+        // flag |= Capabilities.CLIENT_MULTI_STATEMENTS;
+        // flag |= Capabilities.CLIENT_MULTI_RESULTS;        
+        return flag;
+	}
+	
+	
+	private byte[] passwd(String pass, HandshakePacket hs) throws NoSuchAlgorithmException {
+		if (pass == null || pass.length() == 0) {
+			return null;
+		}
+		byte[] passwd = pass.getBytes();
+		int sl1 = hs.seed.length;
+		int sl2 = hs.restOfScrambleBuff.length;
+		byte[] seed = new byte[sl1 + sl2];
+		System.arraycopy(hs.seed, 0, seed, 0, sl1);
+		System.arraycopy(hs.restOfScrambleBuff, 0, seed, sl1, sl2);
+		return SecurityUtil.scramble411(passwd, seed);
+	}
+	
+	@Override
+	public boolean testConnection(String schema) throws IOException {
+		
+		boolean isConnected = true;
+		
+		Socket socket = null;
+		InputStream in = null;
+		OutputStream out = null;		
+		try {			
+			socket = new Socket(this.getConfig().getIp(), this.getConfig().getPort());
+			socket.setSoTimeout(1000 * 20);
+			socket.setReceiveBufferSize( 32768 );
+		    socket.setSendBufferSize( 32768 );
+			socket.setTcpNoDelay(true);
+	        socket.setKeepAlive(true);
+	        
+	        in = new BufferedInputStream(socket.getInputStream(), 32768);
+			out = new BufferedOutputStream( socket.getOutputStream(), 32768 );
+			
+			/**
+	         * Phase 1: MySQL to client. Send handshake packet.
+	        */
+			BinaryPacket bin1 = new BinaryPacket();
+			bin1.read(in);
+			
+			HandshakePacket handshake = new HandshakePacket();
+			handshake.read( bin1 );
+			
+			/**
+	         * Phase 2: client to MySQL. Send auth packet.
+	         */
+			AuthPacket authPacket = new AuthPacket();
+			authPacket.packetId = 1;
+			authPacket.clientFlags = getClientFlags();
+			authPacket.maxPacketSize = 1024 * 1024 * 16;
+			authPacket.charsetIndex = handshake.serverCharsetIndex & 0xff;
+			authPacket.user = this.getConfig().getUser();;
+			try {
+				authPacket.password = passwd(this.getConfig().getPassword(), handshake);
+			} catch (NoSuchAlgorithmException e) {
+				throw new RuntimeException(e.getMessage());
+			}
+			authPacket.database = schema;
+			authPacket.write(out);
+		    out.flush();
+			  
+			/**
+	         * Phase 3: MySQL to client. send OK/ERROR packet.
+	         */
+	        BinaryPacket bin2 = new BinaryPacket();
+	        bin2.read(in);
+	        switch (bin2.data[0]) {
+	        case OkPacket.FIELD_COUNT:
+	            break;
+	        case ErrorPacket.FIELD_COUNT:
+	            ErrorPacket err = new ErrorPacket();
+	            err.read(bin2);
+	            isConnected = false;
+	        case EOFPacket.FIELD_COUNT:		        	
+	        	// 发送323响应认证数据包
+	    		Reply323Packet r323 = new Reply323Packet();
+	    		r323.packetId = ++bin2.packetId;
+	    		String passwd = this.getConfig().getPassword();
+	    		if (passwd != null && passwd.length() > 0) {
+	    			r323.seed = SecurityUtil.scramble323(passwd, new String(handshake.seed)).getBytes();
+	    		}
+	    		r323.write(out);
+	    		out.flush();
+	            break;
+	        }			
+			
+		} catch (IOException e) {
+			e.printStackTrace();
+			isConnected = false;
+		} finally {			
+			try {
+				if (in != null) {
+					in.close();
+				}
+			} catch (IOException e) {}
+
+			try {
+				if (out != null) {
+					out.write(QuitPacket.QUIT);
+					out.flush();
+					out.close();
+				}
+			} catch (IOException e) {}
+
+			try {
+				if (socket != null)
+					socket.close();
+			} catch (IOException e) {}
+		}
+		
+		return isConnected;
+	}
 
 	@Override
 	public DBHeartbeat createHeartBeat() {
 		return new MySQLHeartbeat(this);
-	}
-
-	
-
-	
+	}	
 
 }

--- a/src/main/java/io/mycat/backend/postgresql/PostgreSQLDataSource.java
+++ b/src/main/java/io/mycat/backend/postgresql/PostgreSQLDataSource.java
@@ -34,4 +34,10 @@ public class PostgreSQLDataSource extends PhysicalDatasource {
 		factory.make(this, handler, schema);
 	}
 
+	@Override
+	public boolean testConnection(String schema) throws IOException {
+		// TODO Auto-generated method stub
+		return true;
+	}
+
 }

--- a/src/main/java/io/mycat/config/ConfigInitializer.java
+++ b/src/main/java/io/mycat/config/ConfigInitializer.java
@@ -23,9 +23,12 @@
  */
 package io.mycat.config;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.log4j.Logger;
 
 import io.mycat.backend.datasource.PhysicalDBNode;
 import io.mycat.backend.datasource.PhysicalDBPool;
@@ -54,6 +57,9 @@ import io.mycat.route.sequence.handler.IncrSequenceZKHandler;
  * @author mycat
  */
 public class ConfigInitializer {
+	
+	private static final Logger LOGGER = Logger.getLogger( ConfigInitializer.class );
+	
 	private volatile SystemConfig system;
 	private volatile MycatCluster cluster;
 	private volatile FirewallConfig firewall;
@@ -63,66 +69,153 @@ public class ConfigInitializer {
 	private volatile Map<String, PhysicalDBPool> dataHosts;
 
 	public ConfigInitializer(boolean loadDataHost) {
+		
 		//读取rule.xml和schema.xml
 		SchemaLoader schemaLoader = new XMLSchemaLoader();
+		
 		//读取server.xml
 		XMLConfigLoader configLoader = new XMLConfigLoader(schemaLoader);
+		
 		schemaLoader = null;
+		
 		//加载配置
 		this.system = configLoader.getSystemConfig();
 		this.users = configLoader.getUserConfigs();
 		this.schemas = configLoader.getSchemaConfigs();
+		
 		//是否重新加载DataHost和对应的DataNode
 		if (loadDataHost) {
 			this.dataHosts = initDataHosts(configLoader);
 			this.dataNodes = initDataNodes(configLoader);
 		}
+		
 		//权限管理
 		this.firewall = configLoader.getFirewallConfig();
 		this.cluster = initCobarCluster(configLoader);
+		
 		//不同类型的全局序列处理器的配置加载
 		if (system.getSequnceHandlerType() == SystemConfig.SEQUENCEHANDLER_MYSQLDB) {
 			IncrSequenceMySQLHandler.getInstance().load();
 		}
+		
 		if (system.getSequnceHandlerType() == SystemConfig.SEQUENCEHANDLER_LOCAL_TIME) {
 			IncrSequenceTimeHandler.getInstance().load();
 		}
+		
 		if (system.getSequnceHandlerType() == SystemConfig.SEQUENCEHANDLER_ZK_DISTRIBUTED) {
 			DistributedSequenceHandler.getInstance(system).load();
 		}
+		
 		if (system.getSequnceHandlerType() == SystemConfig.SEQUENCEHANDLER_ZK_GLOBAL_INCREMENT) {
 			IncrSequenceZKHandler.getInstance().load();
 		}
-		//检查user与schema配置对应以及schema配置不为空
-		this.checkConfig();
+		
+		/**
+		 * 配置文件初始化， 自检
+		 */
+		this.selfChecking();
+	}
+	
+	// 配置文件初始化， 自检
+	private void selfChecking() throws ConfigException {
+		
+		// 检查user与schema配置对应以及schema配置不为空
+		checkServerConfig();
+		
+		// schema 配置检测，含dataNode dataHost 及实际链路的连接测试
+		checkSchemaConfig();
 	}
 
-	private void checkConfig() throws ConfigException {
+	private void checkServerConfig() throws ConfigException {
+		
 		if (users == null || users.isEmpty()) {
-			return;
-		}
-		for (UserConfig uc : users.values()) {
-			if (uc == null) {
-				continue;
-			}
-			Set<String> authSchemas = uc.getSchemas();
-			if (authSchemas == null) {
-				continue;
-			}
-			for (String schema : authSchemas) {
-				if (!schemas.containsKey(schema)) {
-					String errMsg = "schema " + schema + " refered by user "
-							+ uc.getName() + " is not exist!";
-					throw new ConfigException(errMsg);
+			throw new ConfigException("SelfCheck### user all node is empty!");
+			
+		} else {
+			
+			for (UserConfig uc : users.values()) {
+				if (uc == null) {
+					throw new ConfigException("SelfCheck### users node within the item is empty!");
+				}
+				
+				Set<String> authSchemas = uc.getSchemas();
+				if (authSchemas == null) {
+					throw new ConfigException("SelfCheck### user " + uc.getName() + "refered schemas is empty!");
+				}
+				
+				for (String schema : authSchemas) {
+					if ( !schemas.containsKey(schema) ) {
+						String errMsg = "SelfCheck###  schema " + schema + " refered by user " + uc.getName() + " is not exist!";
+						throw new ConfigException(errMsg);
+					}
 				}
 			}
-		}
-
+		}		
+	}
+	
+	private void checkSchemaConfig() {
+		// check schema 节点
 		for (SchemaConfig sc : schemas.values()) {
 			if (null == sc) {
-				continue;
+				throw new ConfigException("SelfCheck### schema all node is empty!");
+				
+			} else {
+				
+				// check dataNode / dataHost 节点
+				if ( this.dataNodes != null &&  this.dataHosts != null  ) {
+					
+					Map<String, Boolean> map = new HashMap<String, Boolean>();
+					
+					Set<String> dataNodeNames = sc.getAllDataNodes();
+					for(String dataNodeName: dataNodeNames) {
+						
+						PhysicalDBNode node = this.dataNodes.get(dataNodeName);
+						if ( node == null ) {
+							throw new ConfigException("SelfCheck### schema dbnode is empty!");
+							
+						} else {							
+							String database = node.getDatabase();		
+							PhysicalDBPool pool = node.getDbPool();
+							
+							for (PhysicalDatasource ds : pool.getAllDataSources()) {							
+								String key = ds.getName() + "_" + database;
+								if ( map.get( key ) == null ) {										
+									map.put( key, false );
+									
+									boolean isConnected = false;
+									try {
+										isConnected = ds.testConnection( database );		
+										map.put( key, isConnected );
+									} catch (IOException e) {
+										LOGGER.warn("test conn error:", e);
+									}									
+									
+								}								
+							}
+						}
+					}
+					
+					//
+					boolean isConnectivity = true;
+					for (Map.Entry<String, Boolean> entry : map.entrySet()) {
+						String key = entry.getKey();
+						Boolean value = entry.getValue();
+						if ( !value && isConnectivity ) {
+							LOGGER.warn("SelfCheck### test " + key + " database connection failed ");							
+							isConnectivity = false;
+							
+						} else {
+							LOGGER.info("SelfCheck### test " + key + " database connection success ");
+						}
+					}
+					
+					if ( !isConnectivity ) {
+						throw new ConfigException("SelfCheck### there are some datasource connection failed, pls check!");
+					}
+					
+				}
 			}
-		}
+		}	
 	}
 
 	public SystemConfig getSystem() {

--- a/src/main/java/io/mycat/config/MycatConfig.java
+++ b/src/main/java/io/mycat/config/MycatConfig.java
@@ -43,6 +43,7 @@ import io.mycat.util.TimeUtil;
  * @author mycat
  */
 public class MycatConfig {
+	
 	private static final int RELOAD = 1;
 	private static final int ROLLBACK = 2;
     private static final int RELOAD_ALL = 3;
@@ -66,6 +67,7 @@ public class MycatConfig {
 	private final ReentrantLock lock;
 
 	public MycatConfig() {
+		
 		//读取schema.xml，rule.xml和server.xml
 		ConfigInitializer confInit = new ConfigInitializer(true);
 		this.system = confInit.getSystem();
@@ -77,12 +79,15 @@ public class MycatConfig {
 		for (PhysicalDBPool dbPool : dataHosts.values()) {
 			dbPool.setSchemas(getDataNodeSchemasOfDataHost(dbPool.getHostName()));
 		}
+		
 		this.firewall = confInit.getFirewall();
 		this.cluster = confInit.getCluster();
+		
 		//初始化重加载配置时间
 		this.reloadTime = TimeUtil.currentTimeMillis();
 		this.rollbackTime = -1L;
 		this.status = RELOAD;
+		
 		//配置加载锁
 		this.lock = new ReentrantLock();
 	}
@@ -93,10 +98,11 @@ public class MycatConfig {
 
 	public void setSocketParams(AbstractConnection con, boolean isFrontChannel)
 			throws IOException {
+		
 		int sorcvbuf = 0;
 		int sosndbuf = 0;
 		int soNoDelay = 0;
-		if (isFrontChannel) {
+		if ( isFrontChannel ) {
 			sorcvbuf = system.getFrontsocketsorcvbuf();
 			sosndbuf = system.getFrontsocketsosndbuf();
 			soNoDelay = system.getFrontSocketNoDelay();
@@ -105,7 +111,8 @@ public class MycatConfig {
 			sosndbuf = system.getBacksocketsosndbuf();
 			soNoDelay = system.getBackSocketNoDelay();
 		}
-		NetworkChannel channel=con.getChannel();
+		
+		NetworkChannel channel = con.getChannel();
 		channel.setOption(StandardSocketOptions.SO_RCVBUF, sorcvbuf);
 		channel.setOption(StandardSocketOptions.SO_SNDBUF, sosndbuf);
 		channel.setOption(StandardSocketOptions.TCP_NODELAY, soNoDelay == 1);
@@ -145,7 +152,7 @@ public class MycatConfig {
 
 	public String[] getDataNodeSchemasOfDataHost(String dataHost) {
 		ArrayList<String> schemas = new ArrayList<String>(30);
-		for (PhysicalDBNode dn : dataNodes.values()) {
+		for (PhysicalDBNode dn: dataNodes.values()) {
 			if (dn.getDbPool().getHostName().equals(dataHost)) {
 				schemas.add(dn.getDatabase());
 			}
@@ -193,11 +200,15 @@ public class MycatConfig {
 		return rollbackTime;
 	}
 
-	public void reload(Map<String, UserConfig> users,
+	public void reload(
+			Map<String, UserConfig> users,
 			Map<String, SchemaConfig> schemas,
 			Map<String, PhysicalDBNode> dataNodes,
-			Map<String, PhysicalDBPool> dataHosts, MycatCluster cluster,
-			FirewallConfig firewall, boolean reloadAll) {
+			Map<String, PhysicalDBPool> dataHosts, 
+			MycatCluster cluster,
+			FirewallConfig firewall, 
+			boolean reloadAll) {
+		
 		apply(users, schemas, dataNodes, dataHosts, cluster, firewall, reloadAll);
 		this.reloadTime = TimeUtil.currentTimeMillis();
 		this.status = reloadAll?RELOAD_ALL:RELOAD;
@@ -213,11 +224,14 @@ public class MycatConfig {
 		}
 	}
 
-	public void rollback(Map<String, UserConfig> users,
+	public void rollback(
+			Map<String, UserConfig> users,
 			Map<String, SchemaConfig> schemas,
 			Map<String, PhysicalDBNode> dataNodes,
-			Map<String, PhysicalDBPool> dataHosts, MycatCluster cluster,
+			Map<String, PhysicalDBPool> dataHosts, 
+			MycatCluster cluster,
 			FirewallConfig firewall) {
+		
 		apply(users, schemas, dataNodes, dataHosts, cluster, firewall, status==RELOAD_ALL);
 		this.rollbackTime = TimeUtil.currentTimeMillis();
 		this.status = ROLLBACK;
@@ -226,57 +240,59 @@ public class MycatConfig {
 	private void apply(Map<String, UserConfig> users,
 			Map<String, SchemaConfig> schemas,
 			Map<String, PhysicalDBNode> dataNodes,
-			Map<String, PhysicalDBPool> dataHosts, MycatCluster cluster,
-			FirewallConfig firewall, boolean isLoadAll) {
+			Map<String, PhysicalDBPool> dataHosts, 
+			MycatCluster cluster,
+			FirewallConfig firewall,
+			boolean isLoadAll) {
+		
 		final ReentrantLock lock = this.lock;
 		lock.lock();
 		try {
-            if(isLoadAll)
-            {
-                // stop datasource heartbeat
-                Map<String, PhysicalDBPool> oldDataHosts = this.dataHosts;
-                if (oldDataHosts != null)
-                {
-                    for (PhysicalDBPool n : oldDataHosts.values())
-                    {
-                        if (n != null)
-                        {
-                            n.stopHeartbeat();
-                        }
-                    }
-                }
-                this._dataNodes = this.dataNodes;
-                this._dataHosts = this.dataHosts;
-            }
+			
+			// old 处理
+			// 1、停止老的数据源心跳
+			// 2、备份老的数据源配置
+			//--------------------------------------------
+			if (isLoadAll) {				
+				Map<String, PhysicalDBPool> oldDataHosts = this.dataHosts;
+				if (oldDataHosts != null) {
+					for (PhysicalDBPool oldDbPool : oldDataHosts.values()) {
+						if (oldDbPool != null) {
+							oldDbPool.stopHeartbeat();
+						}
+					}
+				}
+				this._dataNodes = this.dataNodes;
+				this._dataHosts = this.dataHosts;
+			}
+			
 			this._users = this.users;
 			this._schemas = this.schemas;
-
 			this._cluster = this.cluster;
 			this._firewall = this.firewall;
 
-            if(isLoadAll)
-            {
-                // start datasoruce heartbeat
-                if (dataNodes != null)
-                {
-                    for (PhysicalDBPool n : dataHosts.values())
-                    {
-                        if (n != null)
-                        {
-                            n.startHeartbeat();
-                        }
-                    }
-                }
-                this.dataNodes = dataNodes;
-                this.dataHosts = dataHosts;
-            }
+			// new 处理
+			// 1、启动新的数据源心跳
+			// 2、执行新的配置
+			//---------------------------------------------------
+			if (isLoadAll) {
+				if (dataNodes != null) {
+					for (PhysicalDBPool newDbPool : dataHosts.values()) {
+						if ( newDbPool != null) {
+							newDbPool.startHeartbeat();
+						}
+					}
+				}
+				this.dataNodes = dataNodes;
+				this.dataHosts = dataHosts;
+			}			
 			this.users = users;
 			this.schemas = schemas;
 			this.cluster = cluster;
 			this.firewall = firewall;
+			
 		} finally {
 			lock.unlock();
 		}
-	}
-	
+	}	
 }

--- a/src/main/java/io/mycat/manager/handler/ShowHandler.java
+++ b/src/main/java/io/mycat/manager/handler/ShowHandler.java
@@ -26,6 +26,7 @@ package io.mycat.manager.handler;
 import io.mycat.config.ErrorCode;
 import io.mycat.manager.ManagerConnection;
 import io.mycat.manager.response.ShowBackend;
+import io.mycat.manager.response.ShowBackendOld;
 import io.mycat.manager.response.ShowCollation;
 import io.mycat.manager.response.ShowCommand;
 import io.mycat.manager.response.ShowConnection;
@@ -92,6 +93,9 @@ public final class ShowHandler {
 			break;
 		case ManagerParseShow.BACKEND:
 			ShowBackend.execute(c);
+			break;
+		case ManagerParseShow.BACKEND_OLD:
+			ShowBackendOld.execute(c);
 			break;
 		case ManagerParseShow.CONNECTION_SQL:
 			ShowConnectionSQL.execute(c);

--- a/src/main/java/io/mycat/manager/response/ReloadConfig.java
+++ b/src/main/java/io/mycat/manager/response/ReloadConfig.java
@@ -23,6 +23,7 @@
  */
 package io.mycat.manager.response;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.locks.ReentrantLock;
@@ -49,89 +50,129 @@ import io.mycat.net.mysql.OkPacket;
 
 /**
  * @author mycat
+ * @author zhuam
  */
 public final class ReloadConfig {
+	
 	private static final Logger LOGGER = LoggerFactory.getLogger(ReloadConfig.class);
 
 	public static void execute(ManagerConnection c, final boolean loadAll) {
-		final ReentrantLock lock = MycatServer.getInstance().getConfig()
-				.getLock();
+		final ReentrantLock lock = MycatServer.getInstance().getConfig().getLock();		
 		lock.lock();
 		try {
-			ListenableFuture<Boolean> listenableFuture = MycatServer.getInstance().getListeningExecutorService().submit(new Callable<Boolean>()
-            {
-                @Override
-                public Boolean call() throws Exception
-                {
-
-                    return loadAll?reload_all():reload();
-                }
-            });
-			Futures.addCallback(listenableFuture, new ReloadCallBack(c),  MycatServer.getInstance().getListeningExecutorService());
+			ListenableFuture<Boolean> listenableFuture = MycatServer.getInstance().getListeningExecutorService().submit(
+				new Callable<Boolean>() {
+					@Override
+					public Boolean call() throws Exception {
+						return loadAll ? reload_all() : reload();
+					}
+				}
+			);
+			Futures.addCallback(listenableFuture, new ReloadCallBack(c), MycatServer.getInstance().getListeningExecutorService());
 		} finally {
 			lock.unlock();
 		}
 	}
 
 	private static boolean reload_all() {
-		// 载入新的配置
-		ConfigInitializer loader = new ConfigInitializer(true);
-		Map<String, UserConfig> users = loader.getUsers();
-		Map<String, SchemaConfig> schemas = loader.getSchemas();
-		Map<String, PhysicalDBNode> dataNodes = loader.getDataNodes();
-		Map<String, PhysicalDBPool> dataHosts = loader.getDataHosts();
-		MycatCluster cluster = loader.getCluster();
-		FirewallConfig firewall = loader.getFirewall();
-
-		// 应用新配置
-		MycatConfig conf = MycatServer.getInstance().getConfig();
-		conf.setDataNodes(dataNodes);
 		
-		Map<String, PhysicalDBPool> cNodes = conf.getDataHosts();
-		boolean reloadStatus = true;
-		for (PhysicalDBPool dn : dataHosts.values()) {
-			dn.setSchemas(MycatServer.getInstance().getConfig().getDataNodeSchemasOfDataHost(dn.getHostName()));
-			// init datahost
-			String index = DnPropertyUtil.loadDnIndexProps().getProperty(dn.getHostName(),
-					"0");
-			if (!"0".equals(index)) {
-				LOGGER.info("init datahost: " + dn.getHostName()
-						+ "  to use datasource index:" + index);
-			}
-			dn.init(Integer.valueOf(index));
+		/**
+		 *  1、载入新的配置， ConfigInitializer 内部完成自检工作
+		 */
+		ConfigInitializer loader = new ConfigInitializer(true);
+		Map<String, UserConfig> newUsers = loader.getUsers();
+		Map<String, SchemaConfig> newSchemas = loader.getSchemas();
+		Map<String, PhysicalDBNode> newDataNodes = loader.getDataNodes();
+		Map<String, PhysicalDBPool> newDataHosts = loader.getDataHosts();
+		MycatCluster newCluster = loader.getCluster();
+		FirewallConfig newFirewall = loader.getFirewall();
 
-			//dn.init(0);
-			if (!dn.isInitSuccess()) {
-				reloadStatus = false;
+		/**
+		 *  2、承接
+		 *  2.1、老的 dataSource 继续承接新建请求
+		 *  2.2、新的 dataSource 开始初始化， 完毕后交由 2.3
+		 *  2.3、新的 dataSource 开始承接新建请求
+		 *  2.4、老的 dataSource 内部的事务执行完毕， 相继关闭
+		 *  2.5、老的 dataSource 超过阀值的，强制关闭
+		 */
+		
+		MycatConfig config = MycatServer.getInstance().getConfig();
+		
+		/**
+		 * 2.1 、获取老的 dataHosts
+		 */
+		Map<String, PhysicalDBPool> oldDataHosts = config.getDataHosts();
+		
+		boolean isReloadStatusOK = true;
+		
+		/**
+		 * 2.2、新的 dataHosts 初始化
+		 */
+		for (PhysicalDBPool dbPool : newDataHosts.values()) {					
+			String hostName = dbPool.getHostName();
+			
+			// 设置 schemas
+			ArrayList<String> dnSchemas = new ArrayList<String>(30);
+			for (PhysicalDBNode dn : newDataNodes.values()) {
+				if (dn.getDbPool().getHostName().equals(hostName)) {
+					dnSchemas.add(dn.getDatabase());
+				}
+			}
+			dbPool.setSchemas( dnSchemas.toArray(new String[dnSchemas.size()]) );
+			
+			// 获取 data host
+			String dnIndex = DnPropertyUtil.loadDnIndexProps().getProperty(dbPool.getHostName(), "0");
+			if ( !"0".equals(dnIndex) ) {
+				LOGGER.info("init datahost: " + dbPool.getHostName() + "  to use datasource index:" + dnIndex);
+			}			
+			
+			dbPool.init( Integer.valueOf(dnIndex) );			
+			if ( !dbPool.isInitSuccess() ) {
+				isReloadStatusOK = false;
 				break;
 			}
 		}
-		// 如果重载不成功，则清理已初始化的资源。
-		if (!reloadStatus) {
-			LOGGER.warn("reload failed ,clear previously created datasources ");
-			for (PhysicalDBPool dn : dataHosts.values()) {
-				dn.clearDataSources("reload config");
-				dn.stopHeartbeat();
+		
+		/**
+		 *  TODO： 确认初始化情况
+		 *    
+		 *  新的 dataHosts 是否初始化成功
+		 */
+		if ( isReloadStatusOK ) {
+			
+			/**
+			 * 2.3、 在老的配置上，应用新的配置，开始准备承接任务
+			 */
+			config.reload(newUsers, newSchemas, newDataNodes, newDataHosts, newCluster, newFirewall, true);
+
+			/**
+			 * 2.4、 处理旧的资源
+			 */
+			for (PhysicalDBPool dbPool : oldDataHosts.values()) {			
+				//TODO: 此处不能杀掉connection，需要考虑当前正在执行中的事务确保不丢失
+				dbPool.shiftDatasourcesOldCons();
+			}
+
+			//清理缓存
+			MycatServer.getInstance().getCacheService().clearCache();
+			return true;
+			
+		} else {
+			// 如果重载不成功，则清理已初始化的资源。
+			LOGGER.warn("reload failed, clear previously created datasources ");
+			for (PhysicalDBPool dbPool : newDataHosts.values()) {
+				dbPool.clearDataSources("reload config");
+				dbPool.stopHeartbeat();
 			}
 			return false;
 		}
-
-		// 应用重载
-		conf.reload(users, schemas, dataNodes, dataHosts, cluster, firewall, true);
-
-		// 处理旧的资源
-		for (PhysicalDBPool dn : cNodes.values()) {
-			dn.clearDataSources("reload config clear old datasources");
-			dn.stopHeartbeat();
-		}
-
-		//清理缓存
-		 MycatServer.getInstance().getCacheService().clearCache();
-		return true;
 	}
 
     private static boolean reload() {
-        // 载入新的配置
+    	
+    	/**
+		 *  1、载入新的配置， ConfigInitializer 内部完成自检工作, 由于不更新数据源信息,此处不自检 dataHost  dataNode
+		 */
         ConfigInitializer loader = new ConfigInitializer(false);
         Map<String, UserConfig> users = loader.getUsers();
         Map<String, SchemaConfig> schemas = loader.getSchemas();
@@ -139,19 +180,19 @@ public final class ReloadConfig {
         Map<String, PhysicalDBPool> dataHosts = loader.getDataHosts();
         MycatCluster cluster = loader.getCluster();
         FirewallConfig firewall = loader.getFirewall();
+        
+        /**
+         * 2、在老的配置上，应用新的配置
+         */
+        MycatServer.getInstance().getConfig().reload(users, schemas, dataNodes, dataHosts, cluster, firewall, false);
 
-        // 应用新配置
-        MycatServer instance = MycatServer.getInstance();
-        MycatConfig conf = instance.getConfig();
-
-        // 应用重载
-        conf.reload(users, schemas, dataNodes, dataHosts, cluster, firewall, false);
-
-
-        //清理缓存
-        instance.getCacheService().clearCache();
+        /**
+         * 3、清理缓存
+         */
+        MycatServer.getInstance().getCacheService().clearCache();
         return true;
     }
+    
 	/**
 	 * 异步执行回调类，用于回写数据给用户等。
 	 */

--- a/src/main/java/io/mycat/manager/response/ShowBackend.java
+++ b/src/main/java/io/mycat/manager/response/ShowBackend.java
@@ -32,7 +32,6 @@ import io.mycat.backend.mysql.PacketUtil;
 import io.mycat.backend.mysql.nio.MySQLConnection;
 import io.mycat.config.Fields;
 import io.mycat.manager.ManagerConnection;
-import io.mycat.net.AbstractConnection;
 import io.mycat.net.BackendAIOConnection;
 import io.mycat.net.NIOProcessor;
 import io.mycat.net.mysql.EOFPacket;

--- a/src/main/java/io/mycat/manager/response/ShowBackendOld.java
+++ b/src/main/java/io/mycat/manager/response/ShowBackendOld.java
@@ -1,0 +1,106 @@
+package io.mycat.manager.response;
+
+import java.nio.ByteBuffer;
+
+import io.mycat.backend.BackendConnection;
+import io.mycat.backend.datasource.PhysicalDBPool;
+import io.mycat.backend.mysql.PacketUtil;
+import io.mycat.backend.mysql.nio.MySQLConnection;
+import io.mycat.config.Fields;
+import io.mycat.manager.ManagerConnection;
+import io.mycat.net.mysql.EOFPacket;
+import io.mycat.net.mysql.FieldPacket;
+import io.mycat.net.mysql.ResultSetHeaderPacket;
+import io.mycat.net.mysql.RowDataPacket;
+import io.mycat.util.IntegerUtil;
+import io.mycat.util.LongUtil;
+import io.mycat.util.StringUtil;
+import io.mycat.util.TimeUtil;
+
+/**
+ * 查询 reload @@config_all 后产生的后端连接（待回收）
+ * 
+ * @author zhuam
+ */
+public class ShowBackendOld {
+	
+	private static final int FIELD_COUNT = 10;
+	private static final ResultSetHeaderPacket header = PacketUtil.getHeader(FIELD_COUNT);
+	private static final FieldPacket[] fields = new FieldPacket[FIELD_COUNT];
+	private static final EOFPacket eof = new EOFPacket();
+	
+	static {
+		int i = 0;
+		byte packetId = 0;
+		header.packetId = ++packetId;
+		fields[i] = PacketUtil.getField("id", Fields.FIELD_TYPE_LONG);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("mysqlId", Fields.FIELD_TYPE_LONG);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("host", Fields.FIELD_TYPE_VAR_STRING);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("port", Fields.FIELD_TYPE_LONG);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("l_port", Fields.FIELD_TYPE_LONG);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("net_in", Fields.FIELD_TYPE_LONGLONG);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("net_out", Fields.FIELD_TYPE_LONGLONG);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("life", Fields.FIELD_TYPE_LONGLONG);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("lasttime_idle", Fields.FIELD_TYPE_LONGLONG);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("shifttime_idle", Fields.FIELD_TYPE_LONGLONG);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("borrowed",Fields.FIELD_TYPE_VAR_STRING);
+		fields[i++].packetId = ++packetId;
+		eof.packetId = ++packetId;
+	}
+
+	public static void execute(ManagerConnection c) {
+		ByteBuffer buffer = c.allocate();
+		buffer = header.write(buffer, c, true);
+		for (FieldPacket field : fields) {
+			buffer = field.write(buffer, c, true);
+		}
+		buffer = eof.write(buffer, c, true);
+		byte packetId = eof.packetId;
+		String charset = c.getCharset();
+		
+		for (PhysicalDBPool.OldConnection oc : PhysicalDBPool.oldCons) {
+			if ( oc != null) {
+				RowDataPacket row = getRow(oc.getCon(), oc.getShiftTime(), charset);
+				row.packetId = ++packetId;
+				buffer = row.write(buffer, c, true);
+			}
+		}
+		
+		EOFPacket lastEof = new EOFPacket();
+		lastEof.packetId = ++packetId;
+		buffer = lastEof.write(buffer, c, true);
+		c.write(buffer);
+	}
+
+	private static RowDataPacket getRow(BackendConnection c, long shiftTime, String charset) {
+		RowDataPacket row = new RowDataPacket(FIELD_COUNT);
+		row.add(LongUtil.toBytes(c.getId()));
+		long threadId = 0;
+		if (c instanceof MySQLConnection) {
+			threadId = ((MySQLConnection) c).getThreadId();
+		}
+		row.add(LongUtil.toBytes(threadId));
+		row.add(StringUtil.encode(c.getHost(), charset));
+		row.add(IntegerUtil.toBytes(c.getPort()));
+		row.add(IntegerUtil.toBytes(c.getLocalPort()));
+		row.add(LongUtil.toBytes(c.getNetInBytes()));
+		row.add(LongUtil.toBytes(c.getNetOutBytes()));
+		row.add(LongUtil.toBytes((TimeUtil.currentTimeMillis() - c.getStartupTime()) / 1000L));
+		row.add(LongUtil.toBytes((TimeUtil.currentTimeMillis() - c.getLastTime()) / 1000L));
+		row.add(LongUtil.toBytes((TimeUtil.currentTimeMillis() - shiftTime) / 1000L));
+		boolean isBorrowed = c.isBorrowed();
+		row.add(isBorrowed ? "true".getBytes() : "false".getBytes());	
+		return row;
+	}
+
+}

--- a/src/main/java/io/mycat/manager/response/ShowBackendOld.java
+++ b/src/main/java/io/mycat/manager/response/ShowBackendOld.java
@@ -24,7 +24,7 @@ import io.mycat.util.TimeUtil;
  */
 public class ShowBackendOld {
 	
-	private static final int FIELD_COUNT = 10;
+	private static final int FIELD_COUNT = 11;
 	private static final ResultSetHeaderPacket header = PacketUtil.getHeader(FIELD_COUNT);
 	private static final FieldPacket[] fields = new FieldPacket[FIELD_COUNT];
 	private static final EOFPacket eof = new EOFPacket();

--- a/src/main/java/io/mycat/net/NIOProcessor.java
+++ b/src/main/java/io/mycat/net/NIOProcessor.java
@@ -195,11 +195,8 @@ public final class NIOProcessor {
 				continue;
 			}
 			// SQL执行超时的连接关闭
-			if (c.isBorrowed()
-					&& c.getLastTime() < TimeUtil.currentTimeMillis()
-							- sqlTimeout) {
-				LOGGER.warn("found backend connection SQL timeout ,close it "
-						+ c);
+			if (c.isBorrowed() && c.getLastTime() < TimeUtil.currentTimeMillis() - sqlTimeout) {
+				LOGGER.warn("found backend connection SQL timeout ,close it " + c);
 				c.close("sql timeout");
 			}
 

--- a/src/main/java/io/mycat/route/parser/ManagerParseShow.java
+++ b/src/main/java/io/mycat/route/parser/ManagerParseShow.java
@@ -65,17 +65,19 @@ public final class ManagerParseShow {
     public static final int SLOW_DATANODE = 31;
     public static final int SLOW_SCHEMA = 32;
     public static final int BACKEND = 33;
-    public static final int CACHE = 34;
-    public static final int SESSION = 35;
-    public static final int SYSPARAM = 36;
-    public static final int SYSLOG = 37;
-    public static final int HEARTBEAT_DETAIL = 38;
-    public static final int DATASOURCE_SYNC = 39;
-    public static final int DATASOURCE_SYNC_DETAIL = 40;
-    public static final int DATASOURCE_CLUSTER = 41;
+    public static final int BACKEND_OLD = 34;
+    
+    public static final int CACHE = 35;
+    public static final int SESSION = 36;
+    public static final int SYSPARAM = 37;
+    public static final int SYSLOG = 38;
+    public static final int HEARTBEAT_DETAIL = 39;
+    public static final int DATASOURCE_SYNC = 40;
+    public static final int DATASOURCE_SYNC_DETAIL = 41;
+    public static final int DATASOURCE_CLUSTER = 42;
 
-    public static final int WHITE_HOST=42;
-    public static final int WHITE_HOST_SET=43;
+	public static final int WHITE_HOST = 43;
+	public static final int WHITE_HOST_SET = 44;
 
 
     public static int parse(String stmt, int offset) {
@@ -204,12 +206,38 @@ public final class ManagerParseShow {
             char c5 = stmt.charAt(++offset);
             char c6 = stmt.charAt(++offset);
             if ((c1 == 'A' || c1 == 'a') && (c2 == 'C' || c2 == 'c') && (c3 == 'K' || c3 == 'k')
-                    && (c4 == 'E' || c4 == 'e') && (c5 == 'N' || c5 == 'n') && (c6 == 'D' || c6 == 'd')
-                    && (stmt.length() == ++offset || ParseUtil.isEOF(stmt.charAt(offset)))) {
+                    && (c4 == 'E' || c4 == 'e') && (c5 == 'N' || c5 == 'n') && (c6 == 'D' || c6 == 'd')) {
+                
+                if (stmt.length() > ++offset) {
+                    switch (stmt.charAt(offset)) {
+                    case ' ':
+                        return BACKEND;
+                    case '.':
+                        return show2BackendOld(stmt, offset);
+                    default:
+                        return OTHER;
+                    }
+                }
                 return BACKEND;
+                
             }
         }
         return OTHER;
+    }
+    
+    static int show2BackendOld(String stmt, int offset) {
+    	  if (stmt.length() > offset + "OLD".length()) {
+              char c1 = stmt.charAt(++offset);
+              char c2 = stmt.charAt(++offset);
+              char c3 = stmt.charAt(++offset);
+              if ((c1 == 'O' || c1 == 'o') && (c2 == 'L' || c2 == 'l') && (c3 == 'D' || c3 == 'd')) {
+                  if (stmt.length() > ++offset && stmt.charAt(offset) != ' ') {
+                      return OTHER;
+                  }
+                  return BACKEND_OLD;
+              }
+          }
+          return OTHER;
     }
 
     // SHOW @@C


### PR DESCRIPTION
1、前置config 增强的自检功能，含socket链路的交互检查
2、高并发下， 偶尔（测试的时候，连续多次reload，肯定会有一次出现） reload @@config_all 后 getConnectionHandler 阻塞，耗时1分钟 极易引发整体服务问题，
3、最后一个步骤， old datasource 不强杀，基本不丢事务 

//-------------------------------------------------------
整个reload 过程，大致如下：
1、载入新的配置， ConfigInitializer 内部完成自检工作
2、承接
2.1、老的 dataSource 继续承接新建请求
2.2、新的 dataSource 开始初始化， 完毕后交由 2.3
2.3、新的 dataSource 开始承接新建请求
2.4、老的 dataSource 内部的事务执行完毕， 相继关闭
2.5、老的 dataSource 超过阀值的，强制关闭
