### PR TITLE
修复部分单元测试因增加分片表规则一致性校验而出错的问题

### DIFF
--- a/src/test/java/io/mycat/route/function/RuleFunctionSuitTableTest.java
+++ b/src/test/java/io/mycat/route/function/RuleFunctionSuitTableTest.java
@@ -21,23 +21,23 @@ public class RuleFunctionSuitTableTest {
 	public void testAutoPartitionByLong() {
 		AutoPartitionByLong autoPartition=new AutoPartitionByLong();
 		autoPartition.setMapFile("autopartition-long.txt");
-		autoPartition.init(); // partition = 5
-		Assert.assertEquals(5, autoPartition.getPartitionNum());
+		autoPartition.init(); // partition = 3
+		Assert.assertEquals(3, autoPartition.getPartitionNum());
 		RuleConfig rule = new RuleConfig("id", "auto-partition-long");
 		rule.setRuleAlgorithm(autoPartition);
-		TableConfig tableConf = new TableConfig("test", "id", true, false, -1, "dn1,dn2,dn3",
+		TableConfig tableConf = new TableConfig("test", "id", true, false, -1, "dn1,dn2",
 				null, rule, true, null, false, null, null, null);
 		int suit1 = autoPartition.suitableFor(tableConf);
 		Assert.assertEquals(-1, suit1);
 		
 		tableConf.getDataNodes().clear();
-		tableConf.getDataNodes().addAll(Arrays.asList("dn1", "dn2", "dn3", "dn4", "dn5"));
+		tableConf.getDataNodes().addAll(Arrays.asList("dn1", "dn2", "dn3"));
 		
 		int suit2 = autoPartition.suitableFor(tableConf);
 		Assert.assertEquals(0, suit2);
 		
 		tableConf.getDataNodes().clear();
-		tableConf.getDataNodes().addAll(Arrays.asList("dn1", "dn2", "dn3", "dn4", "dn5", "dn6"));
+		tableConf.getDataNodes().addAll(Arrays.asList("dn1", "dn2", "dn3", "dn4"));
 		int suit3 = autoPartition.suitableFor(tableConf);
 		Assert.assertEquals(1, suit3);
 	}

--- a/src/test/resources/autopartition-long2.txt
+++ b/src/test/resources/autopartition-long2.txt
@@ -1,6 +1,6 @@
 # range start-end ,data node index
 0-200M=0
 200M1-400M=1
-400M1-600M=2
+#400M1-600M=2
 #600M1-800M=3
 #800M1-1000M=4

--- a/src/test/resources/route/rule.xml
+++ b/src/test/resources/route/rule.xml
@@ -42,6 +42,12 @@
 			<algorithm>rang-long</algorithm>
 		</rule>
 	</tableRule>
+	<tableRule name="auto-sharding-long2">
+		<rule>
+			<columns>id</columns>
+			<algorithm>rang-long2</algorithm>
+		</rule>
+	</tableRule>
 
     <tableRule name="auto-sharding-rang-mod">
         <rule>
@@ -73,6 +79,10 @@
 	<function name="rang-long"
 		class="io.mycat.route.function.AutoPartitionByLong">
 		<property name="mapFile">autopartition-long.txt</property>
+	</function>
+	<function name="rang-long2"
+		class="io.mycat.route.function.AutoPartitionByLong">
+		<property name="mapFile">autopartition-long2.txt</property>
 	</function>
 	<function name="by-date"
 		class="io.mycat.route.function.PartitionByDate">                            

--- a/src/test/resources/route/schema.xml
+++ b/src/test/resources/route/schema.xml
@@ -45,7 +45,7 @@
 		<table name="area" primaryKey="ID" type="global" dataNode="dn1,dn2,dn3" />
 		<table name="employee" primaryKey="id" dataNode="dn1,dn2"
 			rule="sharding-by-intfile" />
-		<table name="customer" dataNode="dn1,dn2" rule="auto-sharding-long">
+		<table name="customer" dataNode="dn1,dn2" rule="auto-sharding-long2">
 			<childTable name="orders" joinKey="customer_id" parentKey="id">
 				<childTable name="order_items" joinKey="order_id"
 					parentKey="id" />
@@ -62,29 +62,29 @@
 	</schema>
 
     <schema name="mysqldb"  sqlMaxLimit="100">
-        <table name="offer" dataNode="dn1,dn2" rule="offerRule" />
-        <table name="offer1" dataNode="dn1" rule="offerRule" />
+        <table name="offer" dataNode="dn1,dn2" rule="auto-sharding-long2" />
+        <table name="offer1" dataNode="dn1" />
     </schema>
     <schema name="oracledb"  sqlMaxLimit="100">
-        <table name="offer" dataNode="d_oracle1,d_oracle2" rule="offerRule" />
-        <table name="offer1" dataNode="d_oracle1" rule="offerRule" />
+        <table name="offer" dataNode="d_oracle1,d_oracle2" rule="auto-sharding-long2" />
+        <table name="offer1" dataNode="d_oracle1" />
     </schema>
 
 	<schema name="db2db"  sqlMaxLimit="100">
-		<table name="offer" dataNode="db2_1,db2_2" rule="offerRule" />
-		<table name="offer1" dataNode="db2_1" rule="offerRule" />
+		<table name="offer" dataNode="db2_1,db2_2" rule="auto-sharding-long2" />
+		<table name="offer1" dataNode="db2_1" />
 	</schema>
 
 
 	<schema name="sqlserverdb"  sqlMaxLimit="100">
-		<table name="offer" dataNode="sqlserver_1,sqlserver_2" rule="offerRule" />
-		<table name="offer1" dataNode="sqlserver_1" rule="offerRule" />
+		<table name="offer" dataNode="sqlserver_1,sqlserver_2" rule="auto-sharding-long2" />
+		<table name="offer1" dataNode="sqlserver_1" />
 	</schema>
 
 
 	<schema name="pgdb"  sqlMaxLimit="100">
-		<table name="offer" dataNode="pg_1,pg_2" rule="offerRule" />
-		<table name="offer1" dataNode="pg_1" rule="offerRule" />
+		<table name="offer" dataNode="pg_1,pg_2" rule="auto-sharding-long2" />
+		<table name="offer1" dataNode="pg_1" />
 	</schema>
 
 	<dataNode name="dn1" dataHost="localhost1" database="db1" />


### PR DESCRIPTION
增加了分片表规则一致性校验而导致部分单元测试测试失败，修复这些单元测试使其能够通过测试