### PR TITLE
修复NullPointerException异常

### DIFF
--- a/src/main/java/io/mycat/backend/jdbc/JDBCConnection.java
+++ b/src/main/java/io/mycat/backend/jdbc/JDBCConnection.java
@@ -334,7 +334,7 @@ public class JDBCConnection implements BackendConnection {
 			ErrorPacket error = new ErrorPacket();
 			error.packetId = ++packetId;
 			error.errno = ErrorCode.ER_UNKNOWN_ERROR;
-			error.message = msg.getBytes();
+			error.message = ((msg == null) ? e.toString().getBytes() : msg.getBytes());
 			String err = null;
 			if(error.message!=null){
 			    err = new String(error.message);


### PR DESCRIPTION
此异常会导致JDBCConection不释放，最终 sql timeout