### PR TITLE
修复MultiNodeQueryHandler fieldPackets多余列存储问题

### DIFF
--- a/src/main/java/io/mycat/backend/mysql/nio/handler/MultiNodeQueryHandler.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/handler/MultiNodeQueryHandler.java
@@ -609,6 +609,7 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements LoadDataR
 							&& !columToIndx.containsKey(fieldName)) {
 						if (shouldRemoveAvgField.contains(fieldName)) {
 							shouldSkip = true;
+							fieldPackets.remove(fieldPackets.size() - 1);
 						}
 						if (shouldRenameAvgField.contains(fieldName)) {
 							String newFieldName = fieldName.substring(0,


### PR DESCRIPTION
MultiNodeQueryHandler的fieldPackets数组在遇到avg函数会多存储AVG[i]COUNT这一列,当遇到这种情况,需要从fieldPackets中去除这个列