### PR TITLE
feature #1203 兼容高版本mysql jdbc连接mycat

### DIFF
--- a/src/main/java/io/mycat/config/Capabilities.java
+++ b/src/main/java/io/mycat/config/Capabilities.java
@@ -108,5 +108,7 @@ public interface Capabilities {
     // 通知服务器客户端可以处理由多语句或者存储过程执行生成的多结果集。
     // 当打开CLIENT_MULTI_STATEMENTS时，这个标志自动的被打开。
     public static final int CLIENT_MULTI_RESULTS = 131072;
+    
+    public static final int CLIENT_PLUGIN_AUTH = 0x00080000; // 524288
 
 }

--- a/src/main/java/io/mycat/config/model/SystemConfig.java
+++ b/src/main/java/io/mycat/config/model/SystemConfig.java
@@ -152,6 +152,10 @@ public final class SystemConfig {
 	private int mycatNodeId=1;
 	private int useCompression =0;	
 	private int useSqlStat = 1;
+	
+	// 是否使用HandshakeV10Packet来与client进行通讯, 1:是 , 0:否(使用HandshakePacket)
+	// 使用HandshakeV10Packet为的是兼容高版本的jdbc驱动, 后期稳定下来考虑全部采用HandshakeV10Packet来通讯
+	private int useHandshakeV10 = 0;
 
 	//处理分布式事务开关，默认为不过滤分布式事务
 	private int handleDistributedTransactions = 0;
@@ -916,4 +920,14 @@ public final class SystemConfig {
 	public void setHandleDistributedTransactions(int handleDistributedTransactions) {
 		this.handleDistributedTransactions = handleDistributedTransactions;
 	}
+
+	public int getUseHandshakeV10() {
+		return useHandshakeV10;
+	}
+
+	public void setUseHandshakeV10(int useHandshakeV10) {
+		this.useHandshakeV10 = useHandshakeV10;
+	}
+	
+	
 }

--- a/src/main/java/io/mycat/net/FrontendConnection.java
+++ b/src/main/java/io/mycat/net/FrontendConnection.java
@@ -34,6 +34,7 @@ import io.mycat.config.Versions;
 import io.mycat.net.handler.*;
 import io.mycat.net.mysql.ErrorPacket;
 import io.mycat.net.mysql.HandshakePacket;
+import io.mycat.net.mysql.HandshakeV10Packet;
 import io.mycat.net.mysql.MySQLPacket;
 import io.mycat.net.mysql.OkPacket;
 import io.mycat.util.CompressUtil;
@@ -428,17 +429,32 @@ public abstract class FrontendConnection extends AbstractConnection {
 			this.seed = seed;
 
 			// 发送握手数据包
-			HandshakePacket hs = new HandshakePacket();
-			hs.packetId = 0;
-			hs.protocolVersion = Versions.PROTOCOL_VERSION;
-			hs.serverVersion = Versions.SERVER_VERSION;
-			hs.threadId = id;
-			hs.seed = rand1;
-			hs.serverCapabilities = getServerCapabilities();
-			hs.serverCharsetIndex = (byte) (charsetIndex & 0xff);
-			hs.serverStatus = 2;
-			hs.restOfScrambleBuff = rand2;
-			hs.write(this);
+			boolean useHandshakeV10 = MycatServer.getInstance().getConfig().getSystem().getUseHandshakeV10() == 1;
+			if(useHandshakeV10) {
+				HandshakeV10Packet hs = new HandshakeV10Packet();
+				hs.packetId = 0;
+				hs.protocolVersion = Versions.PROTOCOL_VERSION;
+				hs.serverVersion = Versions.SERVER_VERSION;
+				hs.threadId = id;
+				hs.seed = rand1;
+				hs.serverCapabilities = getServerCapabilities();
+				hs.serverCharsetIndex = (byte) (charsetIndex & 0xff);
+				hs.serverStatus = 2;
+				hs.restOfScrambleBuff = rand2;
+				hs.write(this);
+			} else {
+				HandshakePacket hs = new HandshakePacket();
+				hs.packetId = 0;
+				hs.protocolVersion = Versions.PROTOCOL_VERSION;
+				hs.serverVersion = Versions.SERVER_VERSION;
+				hs.threadId = id;
+				hs.seed = rand1;
+				hs.serverCapabilities = getServerCapabilities();
+				hs.serverCharsetIndex = (byte) (charsetIndex & 0xff);
+				hs.serverStatus = 2;
+				hs.restOfScrambleBuff = rand2;
+				hs.write(this);
+			}
 
 			// asynread response
 			this.asynRead();
@@ -502,6 +518,10 @@ public abstract class FrontendConnection extends AbstractConnection {
 		flag |= Capabilities.CLIENT_SECURE_CONNECTION;
         flag |= Capabilities.CLIENT_MULTI_STATEMENTS;
         flag |= Capabilities.CLIENT_MULTI_RESULTS;
+        boolean useHandshakeV10 = MycatServer.getInstance().getConfig().getSystem().getUseHandshakeV10() == 1;
+        if(useHandshakeV10) {
+        	flag |= Capabilities.CLIENT_PLUGIN_AUTH;
+        }
 		return flag;
 	}
 

--- a/src/main/java/io/mycat/net/mysql/HandshakeV10Packet.java
+++ b/src/main/java/io/mycat/net/mysql/HandshakeV10Packet.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2013, OpenCloudDB/MyCAT and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software;Designed and Developed mainly by many Chinese 
+ * opensource volunteers. you can redistribute it and/or modify it under the 
+ * terms of the GNU General Public License version 2 only, as published by the
+ * Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * 
+ * Any questions about this component can be directed to it's project Web address 
+ * https://code.google.com/p/opencloudb/.
+ *
+ */
+package io.mycat.net.mysql;
+
+import java.nio.ByteBuffer;
+
+import io.mycat.config.Capabilities;
+import io.mycat.backend.mysql.BufferUtil;
+import io.mycat.net.FrontendConnection;
+
+/**
+ * From mycat server to client during initial handshake.
+ * 
+ * <pre>
+ * Bytes                        Name
+ * -----                        ----
+ * 1                            protocol_version (always 0x0a)
+ * n (string[NULL])             server_version
+ * 4                            thread_id
+ * 8 (string[8])                auth-plugin-data-part-1
+ * 1                            (filler) always 0x00
+ * 2                            capability flags (lower 2 bytes)
+ *   if more data in the packet:
+ * 1                            character set
+ * 2                            status flags
+ * 2                            capability flags (upper 2 bytes)
+ *   if capabilities & CLIENT_PLUGIN_AUTH {
+ * 1                            length of auth-plugin-data
+ *   } else {
+ * 1                            0x00
+ *   }
+ * 10 (string[10])              reserved (all 0x00)
+ *   if capabilities & CLIENT_SECURE_CONNECTION {
+ * string[$len]   auth-plugin-data-part-2 ($len=MAX(13, length of auth-plugin-data - 8))
+ *   }
+ *   if capabilities & CLIENT_PLUGIN_AUTH {
+ * string[NUL]    auth-plugin name
+ * }
+ * 
+ * @see http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#Protocol::HandshakeV10
+ * </pre>
+ * 
+ * @author CrazyPig
+ * @since 2016-11-13
+ * 
+ */
+public class HandshakeV10Packet extends MySQLPacket {
+    private static final byte[] FILLER_10 = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    private static final byte[] DEFAULT_AUTH_PLUGIN_NAME = "mysql_native_password".getBytes();
+    
+    public byte protocolVersion;
+    public byte[] serverVersion;
+    public long threadId;
+    public byte[] seed; // auth-plugin-data-part-1
+    public int serverCapabilities;
+    public byte serverCharsetIndex;
+    public int serverStatus;
+    public byte[] restOfScrambleBuff; // auth-plugin-data-part-2
+    public byte[] authPluginName = DEFAULT_AUTH_PLUGIN_NAME;
+
+    public void write(FrontendConnection c) {
+
+    	ByteBuffer buffer = c.allocate();
+        BufferUtil.writeUB3(buffer, calcPacketSize());
+        buffer.put(packetId);
+        buffer.put(protocolVersion);
+        BufferUtil.writeWithNull(buffer, serverVersion);
+        BufferUtil.writeUB4(buffer, threadId);
+        buffer.put(seed);
+        buffer.put((byte)0); // [00] filler
+        BufferUtil.writeUB2(buffer, serverCapabilities); // capability flags (lower 2 bytes)
+        buffer.put(serverCharsetIndex);
+        BufferUtil.writeUB2(buffer, serverStatus);
+        BufferUtil.writeUB2(buffer, (serverCapabilities >> 16)); // capability flags (upper 2 bytes)
+        if((serverCapabilities & Capabilities.CLIENT_PLUGIN_AUTH) != 0) {
+        	if(restOfScrambleBuff.length <= 13) {
+        		buffer.put((byte) (seed.length + 13));
+        	} else {
+        		buffer.put((byte) (seed.length + restOfScrambleBuff.length));
+        	}
+        } else {
+        	buffer.put((byte) 0);
+        }
+        buffer.put(FILLER_10);
+        if((serverCapabilities & Capabilities.CLIENT_SECURE_CONNECTION) != 0) {
+        	buffer.put(restOfScrambleBuff);
+        	// restOfScrambleBuff.length always to be 12
+        	if(restOfScrambleBuff.length < 13) {
+        		for(int i = 13 - restOfScrambleBuff.length; i > 0; i--) {
+        			buffer.put((byte)0);
+        		}
+        	}
+        }
+        if((serverCapabilities & Capabilities.CLIENT_PLUGIN_AUTH) != 0) {
+        	BufferUtil.writeWithNull(buffer, authPluginName);
+        }
+        c.write(buffer);
+    }
+
+    @Override
+    public int calcPacketSize() {
+        int size = 1; // protocol version
+        size += (serverVersion.length + 1); // server version
+        size += 4; // connection id
+        size += seed.length;
+        size += 1; // [00] filler
+        size += 2; // capability flags (lower 2 bytes)
+        size += 1; // character set
+        size += 2; // status flags
+        size += 2; // capability flags (upper 2 bytes)
+        size += 1;
+        size += 10; // reserved (all [00])
+        if((serverCapabilities & Capabilities.CLIENT_SECURE_CONNECTION) != 0) {
+        	// restOfScrambleBuff.length always to be 12
+        	if(restOfScrambleBuff.length <= 13) {
+        		size += 13;
+        	} else {
+        		size += restOfScrambleBuff.length;
+        	}
+        }
+        if((serverCapabilities & Capabilities.CLIENT_PLUGIN_AUTH) != 0) {
+        	size += (authPluginName.length + 1); // auth-plugin name
+        }
+        return size;
+    }
+
+    @Override
+    protected String getPacketInfo() {
+        return "MySQL HandshakeV10 Packet";
+    }
+
+}

--- a/src/main/resources/server.xml
+++ b/src/main/resources/server.xml
@@ -10,6 +10,7 @@
 <!DOCTYPE mycat:server SYSTEM "server.dtd">
 <mycat:server xmlns:mycat="http://io.mycat/">
 	<system>
+	<property name="useHandshakeV10">1</property>
 	<property name="useSqlStat">0</property>  <!-- 1为开启实时统计、0为关闭 -->
 	<property name="useGlobleTableCheck">0</property>  <!-- 1为开启全加班一致性检测、0为关闭 -->
 

--- a/src/test/java/io/mycat/sqlexecute/MycatMulitJdbcVersionTest.java
+++ b/src/test/java/io/mycat/sqlexecute/MycatMulitJdbcVersionTest.java
@@ -1,0 +1,157 @@
+package io.mycat.sqlexecute;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * 
+ * 测试mycat对不同版本的mysql jdbc的兼容性 
+ * 
+ * 
+ * <p>
+ * 关联issue: @see https://github.com/MyCATApache/Mycat-Server/issues/1203
+ * 
+ * <p>
+ * <b>Note:</b> </br>
+ * 1. 请将这个类放到新建的project独立运行, mycat pom.xml里面使用的mysql驱动会影响测试结果 </br>
+ * 2. 确保project新建lib子目录并且在lib子目录里面放置了各类版本的mysql jdbc驱动
+ * 3. 程序会动态加载不同版本的jdbc驱动, 请不要将任何mysql jdbc驱动加入classpath, 否则也可能影响测试结果
+ * 
+ * @author CrazyPig
+ * @since 2016-11-13
+ *
+ */
+public class MycatMulitJdbcVersionTest {
+	
+	private static final String JDBC_URL = "jdbc:mysql://localhost:8066/TESTDB";
+	private static final String USER = "root";
+	private static final String PASSWORD = "123456";
+	private static final Map<String, String> jdbcVersionMap = new HashMap<String, String>();
+	private static final Map<String, Driver> tmpDriverMap = new HashMap<String, Driver>();
+	
+	// 动态加载jdbc驱动
+	private static void dynamicLoadJdbc(String mysqlJdbcFile) throws Exception {
+		URL u = new URL("jar:file:lib/" + mysqlJdbcFile + "!/");
+		String classname = jdbcVersionMap.get(mysqlJdbcFile);
+		URLClassLoader ucl = new URLClassLoader(new URL[] { u });
+		Driver d = (Driver)Class.forName(classname, true, ucl).newInstance();
+		DriverShim driver = new DriverShim(d);
+		DriverManager.registerDriver(driver);
+		tmpDriverMap.put(mysqlJdbcFile, driver);
+	}
+	
+	// 每一次测试完卸载对应版本的jdbc驱动
+	private static void dynamicUnLoadJdbc(String mysqlJdbcFile) throws SQLException {
+		DriverManager.deregisterDriver(tmpDriverMap.get(mysqlJdbcFile));
+	}
+	
+	// 进行一次测试
+	private static void testOneVersion(String mysqlJdbcFile) {
+		
+		System.out.println("start test mysql jdbc version : " + mysqlJdbcFile);
+		
+		try {
+			dynamicLoadJdbc(mysqlJdbcFile);
+		} catch (Exception e1) {
+			e1.printStackTrace();
+		}
+		
+		Connection conn = null;
+		try {
+			conn = DriverManager.getConnection(JDBC_URL, USER, PASSWORD);
+			Statement stmt = conn.createStatement();
+			ResultSet rs = stmt.executeQuery("select user()");
+			System.out.println("select user() output : ");
+			while(rs.next()) {
+				System.out.println(rs.getObject(1));
+			}
+			rs = stmt.executeQuery("show tables");
+			System.out.println("show tables output : ");
+			while(rs.next()) {
+				System.out.println(rs.getObject(1));
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			if(conn != null) {
+				try {
+					conn.close();
+				} catch (SQLException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+		
+		try {
+			dynamicUnLoadJdbc(mysqlJdbcFile);
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+		
+		System.out.println("end !!!");
+		System.out.println();
+	}
+	
+	public static void main(String[] args) {
+		
+		// 多版本mysql jdbc驱动兼容性测试
+		
+		// NOTE: 注意将对应的jar放到lib子目录, 不需要加入classpath!!!
+		jdbcVersionMap.put("mysql-connector-java-6.0.3.jar", "com.mysql.cj.jdbc.Driver");
+		jdbcVersionMap.put("mysql-connector-java-5.1.6.jar", "com.mysql.jdbc.Driver");
+		jdbcVersionMap.put("mysql-connector-java-5.1.31.jar", "com.mysql.jdbc.Driver");
+		jdbcVersionMap.put("mysql-connector-java-5.1.35.jar", "com.mysql.jdbc.Driver");
+		jdbcVersionMap.put("mysql-connector-java-5.1.39.jar", "com.mysql.jdbc.Driver");
+		
+		// 更多的jdbc驱动...
+		
+		for(String mysqlJdbcFile : jdbcVersionMap.keySet()) {
+			testOneVersion(mysqlJdbcFile);
+		}
+		
+	}
+
+}
+
+class DriverShim implements Driver {
+    private Driver driver;
+    DriverShim(Driver d) { this.driver = d; }
+    public boolean acceptsURL(String u) throws SQLException {
+        return this.driver.acceptsURL(u);
+    }
+    public Connection connect(String u, Properties p) throws SQLException {
+        return this.driver.connect(u, p);
+    }
+	@Override
+	public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+		return this.driver.getPropertyInfo(url, info);
+	}
+	@Override
+	public int getMajorVersion() {
+		return this.driver.getMajorVersion();
+	}
+	@Override
+	public int getMinorVersion() {
+		return this.driver.getMinorVersion();
+	}
+	@Override
+	public boolean jdbcCompliant() {
+		return this.driver.jdbcCompliant();
+	}
+	@Override
+	public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+		return this.driver.getParentLogger();
+	}
+}


### PR DESCRIPTION
针对issue #1092
新增HandshakeV10Packet用于解决高版本jdbc驱动连接mycat抛如下异常:

```bash
com.mysql.cj.core.exceptions.UnableToConnectException: CLIENT_PLUGIN_AUTH is required
```

PS: 在`server.xml`里面新增useHandshakeV10配置参数，当useHandshakeV10  = 1 表示启用HandshakeV10Packet来跟client通讯，如果useHandshakeV10 = 0，仍然用老的HandshakePacket跟client通讯。这么做主要考虑有BUG的情况可以屏蔽这部分功能。后期使用稳定可以直接使用HandshakeV10Packet进行处理