### PR TITLE
修复新内存模式decimal列进行聚合的bug

### DIFF
--- a/src/main/java/io/mycat/sqlengine/mpp/UnsafeRowGrouper.java
+++ b/src/main/java/io/mycat/sqlengine/mpp/UnsafeRowGrouper.java
@@ -508,8 +508,8 @@ public class UnsafeRowGrouper {
 					case ColMeta.COL_TYPE_NEWDECIMAL:
 //						key.setDouble(i,
 //								BytesTools.getDouble(row.getBinary(curColMeta.colIndex)));
-						unsafeRowWriter.write(curColMeta.colIndex, 
-								new BigDecimal(new String(row.getBinary(i))));
+						unsafeRowWriter.write(i, 
+								new BigDecimal(new String(row.getBinary(curColMeta.colIndex))));
 						break;
 					case ColMeta.COL_TYPE_LONGLONG:
 						key.setLong(i,


### PR DESCRIPTION
在UnsafeRowGrouper的getGroupKey方法中，对decimal列的处理逻辑上出现问题(索引下标用错)导致聚合的结果出错，修复这个bug