### PR TITLE
fix navicat INFORMATION_SCHEMA.PROFILING

### DIFF
--- a/src/main/java/io/mycat/server/ServerConnection.java
+++ b/src/main/java/io/mycat/server/ServerConnection.java
@@ -200,7 +200,7 @@ public class ServerConnection extends FrontendConnection {
 		}
 
 		//fix navicat   SELECT STATE AS `State`, ROUND(SUM(DURATION),7) AS `Duration`, CONCAT(ROUND(SUM(DURATION)/*100,3), '%') AS `Percentage` FROM INFORMATION_SCHEMA.PROFILING WHERE QUERY_ID= GROUP BY STATE ORDER BY SEQ
-		if(ServerParse.SELECT == type &&sql.contains(" INFORMATION_SCHEMA.PROFILING ")&&sql.contains("CONCAT(ROUND(SUM(DURATION)/*100,3)"))
+		if(ServerParse.SELECT == type &&sql.contains(" INFORMATION_SCHEMA.PROFILING ")&&sql.contains("CONCAT(ROUND(SUM(DURATION)/"))
 		{
 			InformationSchemaProfiling.response(this);
 			return;


### PR DESCRIPTION
navicat 11.2.13中生成的sql部分有个0
```
CONCAT(ROUND(SUM(DURATION)/0*100,3), '%') AS 
```
所以
```
sql.contains("CONCAT(ROUND(SUM(DURATION)/") 
```
就可以了,否则还是err 1064