### PR TITLE
修复Mycat处理select @@语句的漏洞

### DIFF
--- a/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
@@ -368,7 +368,8 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 		case ServerParse.SHOW:// if origSQL is like show tables
 			return analyseShowSQL(schema, rrs, stmt);
 		case ServerParse.SELECT://if origSQL is like select @@
-			if(stmt.contains("@@")){
+			int index = stmt.indexOf("@@");
+			if(index > 0 && "SELECT".equals(stmt.substring(0, index).trim().toUpperCase())){
 				return analyseDoubleAtSgin(schema, rrs, stmt);
 			}
 			break;


### PR DESCRIPTION
Mycat对于select @@语句的判断逻辑如下（DruidMycatRouteStrategy类的routeSystemInfo方法）：

  case ServerParse.SELECT://if origSQL is like select @@

    if(stmt.contains("@@")){

        return analyseDoubleAtSgin(schema, rrs, stmt);

    }
  
如果一个查询中包含@@，如:
> select * from tt_table where id = "aabb@@ccdd";

也会按照select @@的判断逻辑处理，导致路由结果有误
