### PR TITLE
fix #1278 修复PHP5.3,5.4版本PDO使用服务端prepare的BUG

### DIFF
--- a/src/main/java/io/mycat/net/mysql/ExecutePacket.java
+++ b/src/main/java/io/mycat/net/mysql/ExecutePacket.java
@@ -76,10 +76,10 @@ import io.mycat.backend.mysql.PreparedStatement;
  * 
  *  values:                    for all non-NULL values, each parameters appends its value
  *                             as described in Row Data Packet: Binary (column values)
- * @see http://dev.mysql.com/doc/internals/en/execute-packet.html
+ * @see https://dev.mysql.com/doc/internals/en/com-stmt-execute.html
  * </pre>
  * 
- * @author mycat
+ * @author mycat, CrazyPig
  */
 public class ExecutePacket extends MySQLPacket {
 
@@ -108,13 +108,15 @@ public class ExecutePacket extends MySQLPacket {
 
         // 读取NULL指示器数据
         int parameterCount = values.length;
-        nullBitMap = new byte[(parameterCount + 7) / 8];
-        for (int i = 0; i < nullBitMap.length; i++) {
-            nullBitMap[i] = mm.read();
+        if(parameterCount > 0) {
+	        nullBitMap = new byte[(parameterCount + 7) / 8];
+	        for (int i = 0; i < nullBitMap.length; i++) {
+	            nullBitMap[i] = mm.read();
+	        }
+	
+	        // 当newParameterBoundFlag==1时，更新参数类型。
+	        newParameterBoundFlag = mm.read();
         }
-
-        // 当newParameterBoundFlag==1时，更新参数类型。
-        newParameterBoundFlag = mm.read();
         if (newParameterBoundFlag == (byte) 1) {
             for (int i = 0; i < parameterCount; i++) {
                 pstmt.getParametersType()[i] = mm.readUB2();


### PR DESCRIPTION
PHP5.3和5.4版本通过PDO使用服务端预处理连接mycat抛ArrayIndexOutOfBoundsException异常，原因在于低版本的PDO对mysql `COM_STMT_EXECUTE`协议的实现与mysql官方实现存在歧义。对`ExecutePacket`类的读取方式做修改以兼容低版本的PHP PDO

**低版本(5.3和5.4可以测出来)的PHP PDO出现BUG原因分析:**

mysql协议COM_STMT_EXECUTE: [https://dev.mysql.com/doc/internals/en/com-stmt-execute.html](https://dev.mysql.com/doc/internals/en/com-stmt-execute.html)

```
COM_STMT_EXECUTE
  execute a prepared statement

  direction: client -> server
  response: COM_STMT_EXECUTE Response

  payload:
    1              [17] COM_STMT_EXECUTE
    4              stmt-id
    1              flags
    4              iteration-count
      if num-params > 0:
    n              NULL-bitmap, length: (num-params+7)/8
    1              new-params-bound-flag
      if new-params-bound-flag == 1:
    n              type of each parameter, length: num-params * 2
    n              value of each parameter
```

低版本在没有绑定参数的情况下不会发送`new-params-bound-flag`，造成mycat原来的处理逻辑读取额外的字节导致ArrayIndexOutOfBoundsException。新版本即使在没有绑定参数的情况下也会发送`new-params-bound-flag`。
