### PR TITLE
完善set xa=on语句的解析逻辑，修复之前的bug

### DIFF
--- a/src/main/java/io/mycat/server/parser/ServerParseSet.java
+++ b/src/main/java/io/mycat/server/parser/ServerParseSet.java
@@ -86,18 +86,27 @@ public final class ServerParseSet {
 	private static int xaFlag(String stmt, int offset) {
 		if (stmt.length() > offset + 1) {
 			char c1 = stmt.charAt(++offset);
-			char c2=stmt.charAt(++offset);
-			if ((c1 == 'A' || c1 == 'a')
-					&&( c2== ' '||c2=='=')) {
-				int value = autocommitValue(stmt, offset);
-				if (value == AUTOCOMMIT_ON) {
-					return XA_FLAG_ON;
-				} else if (value == AUTOCOMMIT_OFF) {
-					return XA_FLAG_OFF;
-				} else {
-					return OTHER;
+			if ((c1 == 'A' || c1 == 'a')) {
+				while (stmt.length() >= ++ offset) {
+					switch (stmt.charAt(offset)) {
+					case ' ':
+					case '\r':
+					case '\n':
+					case '\t':
+						continue;
+					case '=':
+						int value = autocommitValue(stmt, offset);
+						if (value == AUTOCOMMIT_ON) {
+							return XA_FLAG_ON;
+						} else if (value == AUTOCOMMIT_OFF) {
+							return XA_FLAG_OFF;
+						} else {
+							return OTHER;
+						}
+					default:
+						return OTHER;
+					}
 				}
-
 			}
 		}
 		return OTHER;

--- a/src/test/java/io/mycat/parser/ServerParserTest.java
+++ b/src/test/java/io/mycat/parser/ServerParserTest.java
@@ -480,5 +480,19 @@ public class ServerParserTest {
     	Assert.assertEquals(ServerParse.UNLOCK, ServerParse.parse("unlock tables"));
     	Assert.assertEquals(ServerParse.UNLOCK, ServerParse.parse(" unlock	 tables"));
     }
+    
+    @Test
+    public void testSetXAOn() {
+    	Assert.assertEquals(ServerParseSet.XA_FLAG_ON, ServerParseSet.parse("set xa=on", 3));
+    	Assert.assertEquals(ServerParseSet.XA_FLAG_ON, ServerParseSet.parse("set xa = on", 3));
+    	Assert.assertEquals(ServerParseSet.XA_FLAG_ON, ServerParseSet.parse("set xa \t\n\r = \t\n\r on", 3));
+    }
+    
+    @Test
+    public void testSetXAOff() {
+    	Assert.assertEquals(ServerParseSet.XA_FLAG_OFF, ServerParseSet.parse("set xa=off", 3));
+    	Assert.assertEquals(ServerParseSet.XA_FLAG_OFF, ServerParseSet.parse("set xa = off", 3));
+    	Assert.assertEquals(ServerParseSet.XA_FLAG_OFF, ServerParseSet.parse("set xa \t\n\r = \t\n\r off", 3));
+    }
 
 }


### PR DESCRIPTION
`set xa = on`
（ **=** 后面有空格，Tab或换行键）语句会解析错误