### PR TITLE
强化SQL中表名有库名前缀时的逻辑判断

### DIFF
--- a/src/main/java/io/mycat/server/ServerConnection.java
+++ b/src/main/java/io/mycat/server/ServerConnection.java
@@ -278,7 +278,7 @@ public class ServerConnection extends FrontendConnection {
 
 		} catch (Exception e) {
 			StringBuilder s = new StringBuilder();
-			LOGGER.warn(s.append(this).append(sql).toString() + " err:" + e.toString(),e);
+			LOGGER.warn(s.append(this).append(sql).toString() + " err:" ,e);
 			String msg = e.getMessage();
 			writeErrMessage(ErrorCode.ER_PARSE_ERROR, msg == null ? e.getClass().getSimpleName() : msg);
 			return;


### PR DESCRIPTION
1.当SQL的表名有库名前缀时
> select * from **ttdb**.tt_table limit 1;

现在的处理办法是去掉库名
> select * from tt_table limit 1;

改成判断该库名是否在Mycat中定义，若没有则提示异常，使之严谨。

2. 对于Exception e同时输出了e.toString()和e，有重复，去掉了e.toString()