### PR TITLE
fix #1294 修复预处理将空串识别为NULL的BUG

### DIFF
--- a/src/main/java/io/mycat/backend/mysql/BindValueUtil.java
+++ b/src/main/java/io/mycat/backend/mysql/BindValueUtil.java
@@ -67,9 +67,9 @@ public class BindValueUtil {
         case Fields.FIELD_TYPE_STRING:
         case Fields.FIELD_TYPE_VARCHAR:
             bv.value = mm.readStringWithLength(charset);
-            if (bv.value == null) {
-                bv.isNull = true;
-            }
+//            if (bv.value == null) {
+//                bv.isNull = true;
+//            }
             break;
         case Fields.FIELD_TYPE_DECIMAL:
         case Fields.FIELD_TYPE_NEW_DECIMAL:

--- a/src/main/java/io/mycat/backend/mysql/MySQLMessage.java
+++ b/src/main/java/io/mycat/backend/mysql/MySQLMessage.java
@@ -298,9 +298,9 @@ public class MySQLMessage {
 
     public String readStringWithLength(String charset) throws UnsupportedEncodingException {
         int length = (int) readLength();
-        if (length <= 0) {
-            return null;
-        }
+//        if (length <= 0) {
+//            return null;
+//        }
         String s = new String(data, position, length, charset);
         position += length;
         return s;


### PR DESCRIPTION
mycat预处理实现中，对于空串会识别为`NULL`，修复这个BUG