### PR TITLE
fix #1308 修复mycat预处理对smallint类型转换出错的BUG

### DIFF
--- a/src/main/java/io/mycat/util/ByteUtil.java
+++ b/src/main/java/io/mycat/util/ByteUtil.java
@@ -155,7 +155,8 @@ public class ByteUtil {
 	}
 
 	public static short getShort(byte[] bytes) {
-		return (short) ((0xff & bytes[0]) | (0xff00 & (bytes[1] << 8)));
+		return Short.parseShort(new String(bytes));
+//		return (short) ((0xff & bytes[0]) | (0xff00 & (bytes[1] << 8)));
 	}
 
 	public static char getChar(byte[] bytes) {


### PR DESCRIPTION
io.mycat.util.ByteUtil中getShort()方法获取short方式有误,
影响mycat预处理对smallint类型的转换, 修改getShort方法, 修复这个BUG