### PR TITLE
A trace component is used to trace mycat execution deeply（窥探mycat异步执行的神器）.

### DIFF
--- a/src/main/java/org/opencloudb/MycatConfig.java
+++ b/src/main/java/org/opencloudb/MycatConfig.java
@@ -24,6 +24,8 @@
 package org.opencloudb;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.StandardSocketOptions;
 import java.nio.channels.NetworkChannel;
 import java.util.ArrayList;
@@ -114,7 +116,13 @@ public class MycatConfig {
 		con.setPacketHeaderSize(system.getPacketHeaderSize());
 		con.setIdleTimeout(system.getIdleTimeout());
 		con.setCharset(system.getCharset());
-
+		// set local-port
+		// @since 2017-01-12 little-pan
+		final SocketAddress addr = channel.getLocalAddress();
+		if(addr instanceof InetSocketAddress){
+			final InetSocketAddress inetAddr = (InetSocketAddress)addr;
+			con.setLocalPort(inetAddr.getPort());
+		}
 	}
 
 	public Map<String, UserConfig> getUsers() {

--- a/src/main/java/org/opencloudb/MycatServer.java
+++ b/src/main/java/org/opencloudb/MycatServer.java
@@ -43,7 +43,6 @@ import org.opencloudb.backend.PhysicalDBPool;
 import org.opencloudb.buffer.BufferPool;
 import org.opencloudb.cache.CacheService;
 import org.opencloudb.classloader.DynaClassLoader;
-import org.opencloudb.config.ZkConfig;
 import org.opencloudb.config.model.SystemConfig;
 import org.opencloudb.interceptor.SQLInterceptor;
 import org.opencloudb.manager.ManagerConnectionFactory;

--- a/src/main/java/org/opencloudb/mysql/nio/MySQLConnectionAuthenticator.java
+++ b/src/main/java/org/opencloudb/mysql/nio/MySQLConnectionAuthenticator.java
@@ -36,6 +36,7 @@ import org.opencloudb.net.mysql.ErrorPacket;
 import org.opencloudb.net.mysql.HandshakePacket;
 import org.opencloudb.net.mysql.OkPacket;
 import org.opencloudb.net.mysql.Reply323Packet;
+import org.opencloudb.trace.Tracer;
 
 /**
  * MySQL 验证处理器
@@ -116,8 +117,9 @@ public class MySQLConnectionAuthenticator implements NIOHandler {
 				}
 
 			}
-
+			Tracer.trace(source);
 		} catch (RuntimeException e) {
+			Tracer.trace(source);
 			if (listener != null) {
 				listener.connectionError(e, source);
 				return;
@@ -139,6 +141,7 @@ public class MySQLConnectionAuthenticator implements NIOHandler {
 		if (charset != null) {
 			source.setCharset(charset);
 		} else {
+			Tracer.trace(source);
 			throw new RuntimeException("Unknown charsetIndex:" + charsetIndex);
 		}
 	}

--- a/src/main/java/org/opencloudb/mysql/nio/MySQLConnectionFactory.java
+++ b/src/main/java/org/opencloudb/mysql/nio/MySQLConnectionFactory.java
@@ -34,6 +34,7 @@ import org.opencloudb.config.model.DBHostConfig;
 import org.opencloudb.mysql.nio.handler.ResponseHandler;
 import org.opencloudb.net.NIOConnector;
 import org.opencloudb.net.factory.BackendConnectionFactory;
+import org.opencloudb.trace.Tracer;
 
 /**
  * @author mycat
@@ -72,6 +73,9 @@ public class MySQLConnectionFactory extends BackendConnectionFactory {
 					.postConnect(c);
 
 		}
+		
+		Tracer.trace(c, "created");
+		
 		return c;
 	}
 

--- a/src/main/java/org/opencloudb/mysql/nio/MySQLConnectionHandler.java
+++ b/src/main/java/org/opencloudb/mysql/nio/MySQLConnectionHandler.java
@@ -32,6 +32,7 @@ import org.opencloudb.net.mysql.EOFPacket;
 import org.opencloudb.net.mysql.ErrorPacket;
 import org.opencloudb.net.mysql.OkPacket;
 import org.opencloudb.net.mysql.RequestFilePacket;
+import org.opencloudb.trace.Tracer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -87,6 +88,8 @@ public class MySQLConnectionHandler extends BackendAsyncHandler {
 
     @Override
     protected void handleData(byte[] data) {
+    	Tracer.trace(source);
+    	
         switch (resultStatus) {
             //第一阶段
             case RESULT_STATUS_INIT:

--- a/src/main/java/org/opencloudb/mysql/nio/handler/GetConnectionHandler.java
+++ b/src/main/java/org/opencloudb/mysql/nio/handler/GetConnectionHandler.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.log4j.Logger;
 import org.opencloudb.backend.BackendConnection;
+import org.opencloudb.trace.Tracer;
 
 /**
  * wuzh
@@ -65,6 +66,8 @@ public class GetConnectionHandler implements ResponseHandler {
 		finishedCount.addAndGet(1);
 		logger.info("connected successfuly " + conn);
         conn.release();
+        
+        Tracer.trace(conn);
 	}
 
 	@Override
@@ -72,18 +75,22 @@ public class GetConnectionHandler implements ResponseHandler {
 		finishedCount.addAndGet(1);
 		logger.warn("connect error " + conn+ e);
         conn.release();
+        
+        Tracer.trace(conn);
 	}
 
 	@Override
 	public void errorResponse(byte[] err, BackendConnection conn) {
 		logger.warn("caught error resp: " + conn + " " + new String(err));
         conn.release();
+        
+        Tracer.trace(conn);
 	}
 
 	@Override
 	public void okResponse(byte[] ok, BackendConnection conn) {
 		logger.info("received ok resp: " + conn + " " + new String(ok));
-
+		Tracer.trace(conn);
 	}
 
 	@Override
@@ -109,7 +116,7 @@ public class GetConnectionHandler implements ResponseHandler {
 
 	@Override
 	public void connectionClose(BackendConnection conn, String reason) {
-
+		Tracer.trace(conn, reason);
 	}
 
 }

--- a/src/main/java/org/opencloudb/net/factory/FrontendConnectionFactory.java
+++ b/src/main/java/org/opencloudb/net/factory/FrontendConnectionFactory.java
@@ -29,6 +29,7 @@ import java.nio.channels.NetworkChannel;
 
 import org.opencloudb.MycatServer;
 import org.opencloudb.net.FrontendConnection;
+import org.opencloudb.trace.Tracer;
 
 /**
  * @author mycat
@@ -43,6 +44,9 @@ public abstract class FrontendConnectionFactory {
 
 		FrontendConnection c = getConnection(channel);
 		MycatServer.getInstance().getConfig().setSocketParams(c, true);
+		
+		Tracer.trace(c, "created");
+		
 		return c;
 	}
 

--- a/src/main/java/org/opencloudb/net/handler/FrontendAuthenticator.java
+++ b/src/main/java/org/opencloudb/net/handler/FrontendAuthenticator.java
@@ -38,6 +38,7 @@ import org.opencloudb.net.NIOProcessor;
 import org.opencloudb.net.mysql.AuthPacket;
 import org.opencloudb.net.mysql.MySQLPacket;
 import org.opencloudb.net.mysql.QuitPacket;
+import org.opencloudb.trace.Tracer;
 
 /**
  * 前端认证处理器
@@ -57,6 +58,8 @@ public class FrontendAuthenticator implements NIOHandler {
 
     @Override
     public void handle(byte[] data) {
+    	Tracer.trace(source);
+    	
         // check quit packet
         if (data.length == QuitPacket.QUIT.length && data[4] == MySQLPacket.COM_QUIT) {
             source.close("quit packet");

--- a/src/main/java/org/opencloudb/trace/Tracer.java
+++ b/src/main/java/org/opencloudb/trace/Tracer.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2013, OpenCloudDB/MyCAT and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software;Designed and Developed mainly by many Chinese 
+ * opensource volunteers. you can redistribute it and/or modify it under the 
+ * terms of the GNU General Public License version 2 only, as published by the
+ * Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * 
+ * Any questions about this component can be directed to it's project Web address 
+ * https://code.google.com/p/opencloudb/.
+ *
+ */
+
+package org.opencloudb.trace;
+
+import org.apache.log4j.Logger;
+import org.opencloudb.backend.BackendConnection;
+import org.opencloudb.net.FrontendConnection;
+
+/**
+ * <p>
+ * A component is used to trace mycat execution deeply, which includes basic trace 
+ *and frontend-or-backend connection trace, for debug intention and our high qualified 
+ *mycat server.
+ * </p>
+ * 
+ * <p>
+ * The tracer is disabled by default, and you can enable it by specifying
+ *the system property {@code -Dmycat.trace.enabled=true} and setting log4j
+ *debug level.
+ * </p>
+ * 
+ * @author little-pan
+ * @since 2017-01-11
+ */
+public final class Tracer {
+	final static Logger LOGGER = Logger.getLogger(Tracer.class);
+	
+	final static boolean trace,     traceStack,  useBuffer;
+	final static int     maxBuffer, initBuffer,  stackMaxDeep;
+	final static String  lineSep,   stackPrompt, stackIndent;
+	
+	final static Object[] zeroArgs = new Object[0];
+	
+	private final static ThreadLocal<StringBuilder> localBuffer = new ThreadLocal<StringBuilder>(){
+		@Override
+		protected StringBuilder initialValue(){
+			return (new StringBuilder(initBuffer));
+		}
+	};
+	
+	static{
+		trace = Boolean.parseBoolean(System.getProperty("mycat.trace.enabled", "false"));
+		
+		traceStack  = Boolean.parseBoolean(System.getProperty("mycat.trace.stack", "true"));
+		stackPrompt = System.getProperty("mycat.trace.stackPrompt", ">");
+		stackIndent = System.getProperty("mycat.trace.stackIndent", " ");
+		stackMaxDeep= Integer.parseInt(System.getProperty("mycat.trace.stackMaxDeep", "20"));
+				
+		useBuffer = Boolean.parseBoolean(System.getProperty("mycat.trace.useBuffer", "true"));
+		maxBuffer = Integer.parseInt(System.getProperty("mycat.trace.maxBuffer", "4096"));
+		initBuffer= Integer.parseInt(System.getProperty("mycat.trace.initBuffer", "512"));
+		
+		lineSep = System.getProperty("line.separator");
+	}
+	
+	private Tracer(){
+		// noop
+	}
+	
+	public final static void trace(final String format, final Object ...args){
+		if(trace && LOGGER.isDebugEnabled()){
+			trace0(2, null, format, args);
+		}
+	}
+	
+	public final static void trace(final String tag, final String format, final Object ...args){
+		if(trace && LOGGER.isDebugEnabled()){
+			trace0(2, tag, format, args);
+		}
+	}
+	
+	public final static void trace(final FrontendConnection fronend){
+		if(trace && LOGGER.isDebugEnabled()){
+			trace0(2, fronendTag(fronend), fronend+"");
+		}
+	}
+	
+	public final static void trace(final FrontendConnection fronend, final String format, final Object ...args){
+		if(trace && LOGGER.isDebugEnabled()){
+			trace0(2, fronendTag(fronend), format, args);
+		}
+	}
+	
+	private final static String fronendTag(final FrontendConnection fronend){
+		return (String.format("fronend#%x-%d", fronend.hashCode(), fronend.getId()));
+	}
+	
+	public final static void trace(final BackendConnection backend){
+		if(trace && LOGGER.isDebugEnabled()){
+			trace0(2, backendTag(backend), backend+"");
+		}
+	}
+	
+	public final static void trace(final BackendConnection backend, final String format, final Object ...args){
+		if(trace && LOGGER.isDebugEnabled()){
+			trace0(2, backendTag(backend), format, args);
+		}
+	}
+	
+	private final static String backendTag(final BackendConnection backend){
+		return (String.format("backend#%x-%d", backend.hashCode(), backend.getId()));
+	}
+	
+	final static void trace0(final int traces, 
+			final String tag, final String format, final Object ...args){
+		final StringBuilder buf = acquireBuffer();
+		try{
+			// tag: optional
+			if(tag != null){
+				buf.append('[').append(tag).append(']').append(' ');
+			}
+			buf.append((args == null) ? format: (String.format(format, args)));
+			if(traceStack){
+				final Thread curThread = Thread.currentThread();
+				final String thrName   = curThread.getName();
+				final StackTraceElement[] stack = curThread.getStackTrace();
+				final int size = stack.length, maxDeep = stackMaxDeep;
+				final int base = traces + 1/* ignored: trace(), getStackTrace() */;
+				for(int i = size, k = 0; i > base; ++k){
+					buf.append(lineSep);
+					if(tag != null){
+						buf.append('[').append(tag).append(']');
+					}
+					buf.append('[').append(thrName).append(']');
+					if(k == maxDeep){
+						buf.append('<').append(".........").append(i-base).append(" levels omitted");
+						break;
+					}
+					final StackTraceElement e = stack[--i];
+					final int w = (size - (i+1))<<1;
+					for(int j = 0; j < w; ++j){
+						buf.append(stackIndent);
+					}
+					buf.append(stackPrompt).append(' ').append(e);
+				}
+			}
+			LOGGER.debug(buf);
+		}finally{
+			releaseBuffer(buf);
+		}
+	}
+	
+	private final static StringBuilder acquireBuffer(){
+		if(useBuffer){
+			return (localBuffer.get());
+		}
+		return (new StringBuilder());
+	}
+	
+	private final static void releaseBuffer(final StringBuilder buf){
+		buf.setLength(0);
+		if(buf.capacity() > maxBuffer){
+			localBuffer.remove();
+		}
+	}
+	
+	private final static void testDeeper(){
+		trace("Tracer", "test");
+		trace("Tracer", "test: s0 = %d, s1 = %d", 1, 2);
+		trace("Tracer", "test: cur= %s", new java.util.Date());
+		trace((String)null, "test");
+		trace("test: JAN = %.2f, FEB = %.2f", 2017.01, 2017.02);
+		trace("test");
+	}
+	
+	private final static void test(){
+		testDeeper();
+	}
+	
+	public static void main(String args[]){
+		test();
+	}
+	
+}


### PR DESCRIPTION
A component is used to trace mycat execution deeply, which includes basic trace 
and frontend-or-backend connection trace, for debug intention and our high qualified 
mycat server.

The tracer is disabled by default, and you can enable it by specifying
the system property {@code -Dmycat.trace.enabled=true} and setting log4j
debug level.

跟踪示例：
1. 后端连接创建
# 后端连接tag - backend#hashCode-id
01/12 02:45:01.364  DEBUG [BusinessExecutor2] (Tracer.java:159) -[backend#17b3295-0] created
[backend#17b3295-0][BusinessExecutor2]> java.lang.Thread.run(Unknown Source)
[backend#17b3295-0][BusinessExecutor2]  > java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
[backend#17b3295-0][BusinessExecutor2]    > java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
[backend#17b3295-0][BusinessExecutor2]      > org.opencloudb.backend.PhysicalDatasource$1.run(PhysicalDatasource.java:342)
[backend#17b3295-0][BusinessExecutor2]        > org.opencloudb.mysql.nio.MySQLDataSource.createNewConnection(MySQLDataSource.java:51)
[backend#17b3295-0][BusinessExecutor2]          > org.opencloudb.mysql.nio.MySQLConnectionFactory.make(MySQLConnectionFactory.java:77)

2. 前端认证跟踪
# 前端连接tag - fronend#hashCode-id
# 2.1 连接创建
01/12 02:45:11.656  DEBUG [$_MyCatServer] (Tracer.java:159) -[fronend#1299f0a-0] created
[fronend#1299f0a-0][$_MyCatServer]> org.opencloudb.net.NIOAcceptor.run(NIOAcceptor.java:91)
[fronend#1299f0a-0][$_MyCatServer]  > org.opencloudb.net.NIOAcceptor.accept(NIOAcceptor.java:110)
[fronend#1299f0a-0][$_MyCatServer]    > org.opencloudb.net.factory.FrontendConnectionFactory.make(FrontendConnectionFactory.java:48)
# 2.2 连接认证
01/12 02:45:11.668  DEBUG [$_NIOREACTOR-0-RW] (Tracer.java:159) -[fronend#1299f0a-1] ServerConnection [id=1, schema=null, host=0:0:0:0:0:0:0:1, user=null,txIsolation=3, autocommit=true, schema=null]
[fronend#1299f0a-1][$_NIOREACTOR-0-RW]> java.lang.Thread.run(Unknown Source)
[fronend#1299f0a-1][$_NIOREACTOR-0-RW]  > org.opencloudb.net.NIOReactor$RW.run(NIOReactor.java:100)
[fronend#1299f0a-1][$_NIOREACTOR-0-RW]    > org.opencloudb.net.AbstractConnection.asynRead(AbstractConnection.java:274)
[fronend#1299f0a-1][$_NIOREACTOR-0-RW]      > org.opencloudb.net.NIOSocketWR.asynRead(NIOSocketWR.java:186)
[fronend#1299f0a-1][$_NIOREACTOR-0-RW]        > org.opencloudb.net.AbstractConnection.onReadData(AbstractConnection.java:313)
[fronend#1299f0a-1][$_NIOREACTOR-0-RW]          > org.opencloudb.net.FrontendConnection.handle(FrontendConnection.java:417)
[fronend#1299f0a-1][$_NIOREACTOR-0-RW]            > org.opencloudb.net.FrontendConnection.rawHandle(FrontendConnection.java:435)
[fronend#1299f0a-1][$_NIOREACTOR-0-RW]              > org.opencloudb.net.handler.FrontendAuthenticator.handle(FrontendAuthenticator.java:61)
