### PR TITLE
fix #1420

### DIFF
--- a/src/main/java/io/mycat/backend/mysql/nio/handler/MultiNodeQueryHandler.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/handler/MultiNodeQueryHandler.java
@@ -704,6 +704,7 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements LoadDataR
 				// @since 2016-03-25
 				dataMergeSvr.onNewRecord(dataNode, row);
 			} else {
+				row[3] = ++packetId;
 				RowDataPacket rowDataPkg =null;
 				// cache primaryKey-> dataNode
 				if (primaryKeyIndex != -1) {
@@ -713,7 +714,6 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements LoadDataR
 					LayerCachePool pool = MycatServer.getInstance().getRouterservice().getTableId2DataNodeCache();
 					pool.putIfAbsent(priamaryKeyTable, primaryKey, dataNode);
 				}
-				row[3] = ++packetId;
 				if( prepared ) {
 					if(rowDataPkg==null) {
 						rowDataPkg = new RowDataPacket(fieldCount);

--- a/src/main/java/io/mycat/net/mysql/BinaryRowDataPacket.java
+++ b/src/main/java/io/mycat/net/mysql/BinaryRowDataPacket.java
@@ -83,6 +83,7 @@ public class BinaryRowDataPacket extends MySQLPacket {
 		this.fieldPackets = fieldPackets;
 		this.fieldCount = rowDataPk.fieldCount;
 		this.fieldValues = new ArrayList<byte[]>(fieldCount);
+		this.packetId = rowDataPk.packetId;
 		this.nullBitMap = new byte[(fieldCount + 7 + 2) / 8];
 		
 		List<byte[]> _fieldValues = rowDataPk.fieldValues;


### PR DESCRIPTION
### PR描述

修复因packetId错乱而导致mysql c api mysql_stmt_store_result错误返回的BUG

### 详细解释

根据Issue #1420 描述，只有在mycat第一次启动或者执行`reload @@config`，使用mysql c API 连接mysql会出现`Lost connection`异常，对应的API是`mysql_stmt_store_result`

**测试时候发现一定是要分片表，而且不走merge的情况下才会出现上述异常**

定位到`MultiNodeHandler.java`类的`rowResponse`方法，其中对于不走merge的情况，rowpacket的packetid在走缓存处理的逻辑中，没有重设packetid，导致packetid乱序，从而在使用mysql c api的时候异常返回，连接被异常关闭