### PR TITLE
修复了DirectByteBufferPool.java里int类型内存变量越界问题

### DIFF
--- a/src/main/java/io/mycat/buffer/DirectByteBufferPool.java
+++ b/src/main/java/io/mycat/buffer/DirectByteBufferPool.java
@@ -3,6 +3,7 @@ package io.mycat.buffer;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +22,8 @@ public class DirectByteBufferPool implements BufferPool{
     private ByteBufferPage[] allPages;
     private final int chunkSize;
    // private int prevAllocatedPage = 0;
-    private AtomicInteger prevAllocatedPage;
+    //private AtomicInteger prevAllocatedPage;
+    private AtomicLong prevAllocatedPage;
     private final  int pageSize;
     private final short pageCount;
     private final int conReadBuferChunk ;
@@ -36,7 +38,8 @@ public class DirectByteBufferPool implements BufferPool{
         this.pageSize = pageSize;
         this.pageCount = pageCount;
         this.conReadBuferChunk = conReadBuferChunk;
-        prevAllocatedPage = new AtomicInteger(0);
+        //prevAllocatedPage = new AtomicInteger(0);
+        prevAllocatedPage = new AtomicLong(0);
         for (int i = 0; i < pageCount; i++) {
             allPages[i] = new ByteBufferPage(ByteBuffer.allocateDirect(pageSize), chunkSize);
         }
@@ -68,7 +71,7 @@ public class DirectByteBufferPool implements BufferPool{
 
     public ByteBuffer allocate(int size) {
        final int theChunkCount = size / chunkSize + (size % chunkSize == 0 ? 0 : 1);
-        int selectedPage =  prevAllocatedPage.incrementAndGet() % allPages.length;
+        int selectedPage =  (int)(prevAllocatedPage.incrementAndGet() % allPages.length);
         ByteBuffer byteBuf = allocateBuffer(theChunkCount, 0, selectedPage);
         if (byteBuf == null) {
             byteBuf = allocateBuffer(theChunkCount, selectedPage, allPages.length);


### PR DESCRIPTION
报错信息：
wrapper.log里会出现：
java.lang.ArrayIndexOutOfBoundsException: -158
        at io.mycat.buffer.DirectByteBufferPool.allocateBuffer(DirectByteBufferPool.java:122) ~[Mycat-server-1.6.5-DEV.jar:?]
        at io.mycat.buffer.DirectByteBufferPool.allocate(DirectByteBufferPool.java:74) ~[Mycat-server-1.6.5-DEV.jar:?]
        at io.mycat.net.AbstractConnection.setProcessor(AbstractConnection.java:212) ~[Mycat-server-1.6.5-DEV.jar:?]
        at io.mycat.net.FrontendConnection.setProcessor(FrontendConnection.java:130) ~[Mycat-server-1.6.5-DEV.jar:?]
        at io.mycat.net.NIOAcceptor.accept(NIOAcceptor.java:116) ~[Mycat-server-1.6.5-DEV.jar:?]
        at io.mycat.net.NIOAcceptor.run(NIOAcceptor.java:92) ~[Mycat-server-1.6.5-DEV.jar:?]