### PR TITLE
1、修复load data infile对于没有配置rule属性的表导致报空指针错误，该错误由数据迁移功能引入。

### DIFF
--- a/src/main/java/io/mycat/backend/jdbc/JDBCConnection.java
+++ b/src/main/java/io/mycat/backend/jdbc/JDBCConnection.java
@@ -300,7 +300,8 @@ public class JDBCConnection implements BackendConnection {
 				con.setAutoCommit(autocommit);
 			}
 			int sqlType = rrn.getSqlType();
-             if(rrn.isCallStatement()&&"oracle".equalsIgnoreCase(getDbType()))
+             // if(rrn.isCallStatement()&&"oracle".equalsIgnoreCase(getDbType()))
+			if(rrn.isCallStatement()) //支持mysql,edit by dingw at 2017-05-07 16:04
              {
                  //存储过程暂时只支持oracle
                  ouputCallStatement(rrn,sc,orgin);

--- a/src/main/java/io/mycat/route/handler/HintSQLHandler.java
+++ b/src/main/java/io/mycat/route/handler/HintSQLHandler.java
@@ -31,9 +31,9 @@ import io.mycat.server.parser.ServerParse;
  * 处理注释中 类型为sql的情况 （按照 注释中的sql做路由解析，而不是实际的sql）
  */
 public class HintSQLHandler implements HintHandler {
-	
+
 	private RouteStrategy routeStrategy;
-	
+
 	public HintSQLHandler() {
 		this.routeStrategy = RouteStrategyFactory.getRouteStrategy();
 	}
@@ -41,19 +41,19 @@ public class HintSQLHandler implements HintHandler {
 	@Override
 	public RouteResultset route(SystemConfig sysConfig, SchemaConfig schema,
 			int sqlType, String realSQL, String charset, ServerConnection sc,
-			LayerCachePool cachePool, String hintSQLValue,int hintSqlType, Map hintMap)
-            throws SQLNonTransientException {
-		
-		RouteResultset rrs = routeStrategy.route(sysConfig, schema, hintSqlType,
-				hintSQLValue, charset, sc, cachePool);
-		
+			LayerCachePool cachePool, String hintSQLValue, int hintSqlType,
+			Map hintMap) throws SQLNonTransientException {
+
+		RouteResultset rrs = routeStrategy.route(sysConfig, schema,
+				hintSqlType, hintSQLValue, charset, sc, cachePool);
+
 		// 替换RRS中的SQL执行
 		RouteResultsetNode[] oldRsNodes = rrs.getNodes();
 		RouteResultsetNode[] newRrsNodes = new RouteResultsetNode[oldRsNodes.length];
 		for (int i = 0; i < newRrsNodes.length; i++) {
 			newRrsNodes[i] = new RouteResultsetNode(oldRsNodes[i].getName(),
 					oldRsNodes[i].getSqlType(), realSQL);
-            newRrsNodes[i].setSlot(oldRsNodes[i].getSlot());
+			newRrsNodes[i].setSlot(oldRsNodes[i].getSlot());
 		}
 		rrs.setNodes(newRrsNodes);
 
@@ -61,135 +61,125 @@ public class HintSQLHandler implements HintHandler {
 		if (ServerParse.CALL == sqlType) {
 			rrs.setCallStatement(true);
 
-             Procedure procedure=parseProcedure(realSQL,hintMap);
-            rrs.setProcedure(procedure);
-        //    String sql=procedure.toChangeCallSql(null);
-            String sql=realSQL;
-            for (RouteResultsetNode node : rrs.getNodes())
-            {
-                node.setProcedure(procedure);
-                node.setHintMap(hintMap);
-                node.setStatement(sql);
-            }
+			Procedure procedure = parseProcedure(realSQL, hintMap);
+			rrs.setProcedure(procedure);
+			// String sql=procedure.toChangeCallSql(null);
+			String sql = realSQL;
+			for (RouteResultsetNode node : rrs.getNodes()) {
+				node.setProcedure(procedure);
+				node.setHintMap(hintMap);
+				node.setStatement(sql);
+			}
 
 		}
 
 		return rrs;
 	}
 
+	private Procedure parseProcedure(String sql, Map hintMap) {
+		boolean fields = hintMap.containsKey("list_fields");
+		boolean isResultList = hintMap != null
+				&& ("list".equals(hintMap.get("result_type")) || fields);
+		Procedure procedure = new Procedure();
+		procedure.setOriginSql(sql);
+		procedure.setResultList(isResultList);
+		List<String> sqls = Splitter.on(";").trimResults().splitToList(sql);
+		Set<String> outSet = new HashSet<>();
+		for (int i = sqls.size() - 1; i >= 0; i--) {
+			String s = sqls.get(i);
+			if (Strings.isNullOrEmpty(s)) {
+				continue;
+			}
+			SQLStatementParser parser = new MySqlStatementParser(s);
+			SQLStatement statement = parser.parseStatement();
+			if (statement instanceof SQLSelectStatement) {
+				MySqlSelectQueryBlock selectQuery = (MySqlSelectQueryBlock) ((SQLSelectStatement) statement)
+						.getSelect().getQuery();
+				if (selectQuery != null) {
+					List<SQLSelectItem> selectItems = selectQuery
+							.getSelectList();
+					for (SQLSelectItem selectItem : selectItems) {
+						String select = selectItem.toString();
+						outSet.add(select);
+						procedure.getSelectColumns().add(select);
+					}
+				}
+				procedure.setSelectSql(s);
+			} else if (statement instanceof SQLCallStatement) {
+				SQLCallStatement sqlCallStatement = (SQLCallStatement) statement;
+				procedure.setName(sqlCallStatement.getProcedureName()
+						.getSimpleName());
+				List<SQLExpr> paramterList = sqlCallStatement.getParameters();
+				for (int i1 = 0; i1 < paramterList.size(); i1++) {
+					SQLExpr sqlExpr = paramterList.get(i1);
+					String pName = sqlExpr.toString();
+					String pType = null;
+					ProcedureParameter parameter = new ProcedureParameter();
+					parameter.setIndex(i1 + 1);
+					parameter.setName(pName);
+					
+					if (pName.startsWith("@")) {
+						pType = ProcedureParameter.OUT;
+						procedure.getParamterMap().put(pName, parameter);
+						procedure.getSelectColumns().add(pName);
+						outSet.add(pName);
+					} else {
+						pType = ProcedureParameter.IN;
+						procedure.getParamterMap().put(String.valueOf(i1 + 1),
+								parameter);
+					}
+					parameter.setParameterType(pType);
 
+				}
+				procedure.setCallSql(s);
+			} else if (statement instanceof SQLSetStatement) {
+				procedure.setSetSql(s);
+				SQLSetStatement setStatement = (SQLSetStatement) statement;
+				List<SQLAssignItem> sets = setStatement.getItems();
+				for (SQLAssignItem set : sets) {
+					String name = set.getTarget().toString();
+					SQLExpr value = set.getValue();
+					ProcedureParameter parameter = procedure.getParamterMap()
+							.get(name);
+					if (parameter != null) {
+						if (value instanceof SQLIntegerExpr) {
+							parameter.setValue(((SQLIntegerExpr) value)
+									.getNumber());
+							parameter.setJdbcType(Types.INTEGER);
+						} else if (value instanceof SQLNumberExpr) {
+							parameter.setValue(((SQLNumberExpr) value)
+									.getNumber());
+							parameter.setJdbcType(Types.NUMERIC);
+						} else if (value instanceof SQLTextLiteralExpr) {
+							parameter.setValue(((SQLTextLiteralExpr) value)
+									.getText());
+							parameter.setJdbcType(Types.VARCHAR);
+						} else if (value instanceof SQLValuableExpr) {
+							parameter.setValue(((SQLValuableExpr) value)
+									.getValue());
+							parameter.setJdbcType(Types.VARCHAR);
+						}
+					}
+				}
+			}
 
-    private   Procedure parseProcedure(String sql,Map hintMap)
-    {
-        boolean fields = hintMap.containsKey("list_fields");
-        boolean isResultList= hintMap != null && ("list".equals(hintMap.get("result_type"))|| fields);
-        Procedure procedure=new Procedure();
-        procedure.setOriginSql(sql);
-        procedure.setResultList(isResultList);
-        List<String> sqls= Splitter.on(";").trimResults().splitToList(sql)    ;
-        Set<String> outSet=new HashSet<>();
-        for (int i = sqls.size() - 1; i >= 0; i--)
-        {
-            String s = sqls.get(i);
-            if(Strings.isNullOrEmpty(s)) {
-                continue;
-            }
-            SQLStatementParser parser = new MySqlStatementParser(s);
-            SQLStatement statement = parser.parseStatement();
-            if(statement instanceof SQLSelectStatement)
-            {
-                MySqlSelectQueryBlock selectQuery= (MySqlSelectQueryBlock) ((SQLSelectStatement) statement).getSelect().getQuery();
-                if(selectQuery!=null)
-                {
-                    List<SQLSelectItem> selectItems=   selectQuery.getSelectList();
-                    for (SQLSelectItem selectItem : selectItems)
-                    {
-                        String select = selectItem.toString();
-                        outSet.add(select) ;
-                        procedure.getSelectColumns().add(select);
-                    }
-                }
-               procedure.setSelectSql(s);
-            }  else  if(statement instanceof SQLCallStatement)
-            {
-                SQLCallStatement sqlCallStatement = (SQLCallStatement) statement;
-                procedure.setName(sqlCallStatement.getProcedureName().getSimpleName());
-                List<SQLExpr> paramterList= sqlCallStatement.getParameters();
-                for (int i1 = 0; i1 < paramterList.size(); i1++)
-                {
-                    SQLExpr sqlExpr = paramterList.get(i1);
-                    String pName = sqlExpr.toString();
-                    String pType=outSet.contains(pName)? ProcedureParameter.OUT:ProcedureParameter.IN;
-                    ProcedureParameter parameter=new ProcedureParameter();
-                    parameter.setIndex(i1+1);
-                    parameter.setName(pName);
-                    parameter.setParameterType(pType);
-                    if(pName.startsWith("@"))
-                    {
-                        procedure.getParamterMap().put(pName, parameter);
-                    }   else
-                    {
-                        procedure.getParamterMap().put(String.valueOf(i1+1), parameter);
-                    }
-
-
-                }
-                procedure.setCallSql(s);
-            }   else  if(statement instanceof SQLSetStatement)
-            {
-                procedure.setSetSql(s);
-                SQLSetStatement setStatement= (SQLSetStatement) statement;
-                List<SQLAssignItem> sets= setStatement.getItems();
-                for (SQLAssignItem set : sets)
-                {
-                    String name=set.getTarget().toString();
-                     SQLExpr value=set.getValue();
-                    ProcedureParameter parameter = procedure.getParamterMap().get(name);
-                    if(parameter!=null)
-                    {
-                        if (value instanceof SQLIntegerExpr)
-                        {
-                           parameter.setValue(((SQLIntegerExpr) value).getNumber());
-                            parameter.setJdbcType(Types.INTEGER);
-                        }  else   if(value instanceof SQLNumberExpr)
-                        {
-                            parameter.setValue(((SQLNumberExpr) value).getNumber());
-                            parameter.setJdbcType(Types.NUMERIC);
-                        }
-                        else if(value instanceof SQLTextLiteralExpr)
-                        {
-                            parameter.setValue(((SQLTextLiteralExpr) value).getText());
-                            parameter.setJdbcType(Types.VARCHAR);
-                        }
-                        else
-                        if (value instanceof SQLValuableExpr)
-                        {
-                            parameter.setValue(((SQLValuableExpr) value).getValue());
-                            parameter.setJdbcType(Types.VARCHAR);
-                        }
-                    }
-                }
-            }
-
-        }
-        if(fields)
-        {
-            String list_fields =(String) hintMap.get("list_fields");
-            List<String> listFields = Splitter.on(",").trimResults().splitToList( list_fields);
-            for (String field : listFields)
-            {
-                if(!procedure.getParamterMap().containsKey(field))
-                {
-                    ProcedureParameter parameter=new ProcedureParameter();
-                    parameter.setParameterType(ProcedureParameter.OUT);
-                    parameter.setName(field);
-                    parameter.setJdbcType(-10);
-                    parameter.setIndex(procedure.getParamterMap().size()+1);
-                    procedure.getParamterMap().put(field,parameter);
-                }
-            }
-            procedure.getListFields().addAll(listFields);
-        }
-        return procedure;
-    }
+		}
+		if (fields) {
+			String list_fields = (String) hintMap.get("list_fields");
+			List<String> listFields = Splitter.on(",").trimResults()
+					.splitToList(list_fields);
+			for (String field : listFields) {
+				if (!procedure.getParamterMap().containsKey(field)) {
+					ProcedureParameter parameter = new ProcedureParameter();
+					parameter.setParameterType(ProcedureParameter.OUT);
+					parameter.setName(field);
+					parameter.setJdbcType(-10);
+					parameter.setIndex(procedure.getParamterMap().size() + 1);
+					procedure.getParamterMap().put(field, parameter);
+				}
+			}
+			procedure.getListFields().addAll(listFields);
+		}
+		return procedure;
+	}
 }

--- a/src/main/java/io/mycat/route/util/RouterUtil.java
+++ b/src/main/java/io/mycat/route/util/RouterUtil.java
@@ -1,23 +1,5 @@
 package io.mycat.route.util;
 
-import java.sql.SQLNonTransientException;
-import java.sql.SQLSyntaxErrorException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
@@ -37,7 +19,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.mycat.MycatServer;
 import io.mycat.backend.datasource.PhysicalDBNode;
 import io.mycat.backend.datasource.PhysicalDBPool;
-import io.mycat.backend.datasource.PhysicalDatasource;
 import io.mycat.backend.mysql.nio.handler.FetchStoreNodeOfChildTableHandler;
 import io.mycat.cache.LayerCachePool;
 import io.mycat.config.ErrorCode;
@@ -57,6 +38,13 @@ import io.mycat.server.parser.ServerParse;
 import io.mycat.sqlengine.mpp.ColumnRoutePair;
 import io.mycat.sqlengine.mpp.LoadData;
 import io.mycat.util.StringUtil;
+
+import org.slf4j.Logger; import org.slf4j.LoggerFactory;
+
+import java.sql.SQLNonTransientException;
+import java.sql.SQLSyntaxErrorException;
+import java.util.*;
+import java.util.concurrent.Callable;
 
 /**
  * 从ServerRouterUtil中抽取的一些公用方法，路由解析工具类
@@ -779,7 +767,7 @@ public class RouterUtil {
 	}
 
 	/**
-	 * 根据表名随机获取一个节点
+	 * 根据标名随机获取一个节点
 	 *
 	 * @param schema     数据库名
 	 * @param table      表名
@@ -794,41 +782,11 @@ public class RouterUtil {
 		Map<String, TableConfig> tables = schema.getTables();
 		TableConfig tc;
 		if (tables != null && (tc = tables.get(table)) != null) {
-			dataNode = getAliveRandomDataNode(tc);
+			dataNode = getRandomDataNode(tc);
 		}
 		return dataNode;
 	}
-	
-	/**
-	 * 解决getRandomDataNode方法获取错误节点的问题.
-	 * @param tc
-	 * @return
-	 */
-	private static String getAliveRandomDataNode(TableConfig tc) {
-		List<String> randomDns = tc.getDataNodes();
 
-		MycatConfig mycatConfig = MycatServer.getInstance().getConfig();
-		if (mycatConfig != null) {
-			for (String randomDn : randomDns) {
-				PhysicalDBNode physicalDBNode = mycatConfig.getDataNodes().get(randomDn);
-				if (physicalDBNode != null) {
-					if (physicalDBNode.getDbPool().getSource().isAlive()) {
-						for (PhysicalDBPool pool : MycatServer.getInstance().getConfig().getDataHosts().values()) {
-							PhysicalDatasource source = pool.getSource();
-							if (source.getHostConfig().containDataNode(randomDn) && pool.getSource().isAlive()) {
-								return randomDn;
-							}
-						}
-					}
-				}
-			}
-		}
-
-		// all fail return default
-		return tc.getRandomDataNode();
-	}
-
-	@Deprecated
     private static String getRandomDataNode(TableConfig tc) {
         //写节点不可用，意味着读节点也不可用。
         //直接使用下一个 dataHost
@@ -1144,7 +1102,7 @@ public class RouterUtil {
 			if(isSelect) {
 				// global select ,not cache route result
 				rrs.setCacheAble(false);
-				return routeToSingleNode(rrs, getAliveRandomDataNode(tc)/*getRandomDataNode(tc)*/, ctx.getSql());
+				return routeToSingleNode(rrs, getRandomDataNode(tc), ctx.getSql());
 			} else {//insert into 全局表的记录
 				return routeToMultiNode(false, rrs, tc.getDataNodes(), ctx.getSql(),true);
 			}
@@ -1569,8 +1527,164 @@ public class RouterUtil {
 		}
 		return false;
 	}
+	
+	/**
+	 * 该方法，返回是否是ER字表
+	 * @param schema
+	 * @param origSQL
+	 * @param sc
+	 * @return
+	 * @throws SQLNonTransientException
+	 * 
+	 * 备注说明：
+	 *     edit by ding.w at 2017.4.28, 主要处理 CLIENT_MULTI_STATEMENTS(insert into ; insert into)的情况
+	 *     目前仅支持mysql,并COM_QUERY请求包中的所有insert语句要么全部是er表，要么全部不是
+	 *     
+	 *     
+	 */
+	public static boolean processERChildTable(final SchemaConfig schema, final String origSQL,
+            final ServerConnection sc) throws SQLNonTransientException {
+	
+		MySqlStatementParser parser = new MySqlStatementParser(origSQL);
+		List<SQLStatement> statements = parser.parseStatementList();
+		
+		if(statements == null || statements.isEmpty() ) {
+			throw new SQLNonTransientException(String.format("无效的SQL语句:%s", origSQL));
+		}
+		
+		
+		boolean erFlag = false; //是否是er表
+		for(SQLStatement stmt : statements ) {
+			MySqlInsertStatement insertStmt = (MySqlInsertStatement) stmt; 
+			String tableName = insertStmt.getTableName().getSimpleName().toUpperCase();
+			final TableConfig tc = schema.getTables().get(tableName);
+			
+			if (null != tc && tc.isChildTable()) {
+				erFlag = true;
+				
+				String sql = insertStmt.toString();
+				
+				final RouteResultset rrs = new RouteResultset(sql, ServerParse.INSERT);
+				String joinKey = tc.getJoinKey();
+				//因为是Insert语句，用MySqlInsertStatement进行parse
+//				MySqlInsertStatement insertStmt = (MySqlInsertStatement) (new MySqlStatementParser(origSQL)).parseInsert();
+				//判断条件完整性，取得解析后语句列中的joinkey列的index
+				int joinKeyIndex = getJoinKeyIndex(insertStmt.getColumns(), joinKey);
+				if (joinKeyIndex == -1) {
+					String inf = "joinKey not provided :" + tc.getJoinKey() + "," + insertStmt;
+					LOGGER.warn(inf);
+					throw new SQLNonTransientException(inf);
+				}
+				//子表不支持批量插入
+				if (isMultiInsert(insertStmt)) {
+					String msg = "ChildTable multi insert not provided";
+					LOGGER.warn(msg);
+					throw new SQLNonTransientException(msg);
+				}
+				//取得joinkey的值
+				String joinKeyVal = insertStmt.getValues().getValues().get(joinKeyIndex).toString();
+				//解决bug #938，当关联字段的值为char类型时，去掉前后"'"
+				String realVal = joinKeyVal;
+				if (joinKeyVal.startsWith("'") && joinKeyVal.endsWith("'") && joinKeyVal.length() > 2) {
+					realVal = joinKeyVal.substring(1, joinKeyVal.length() - 1);
+				}
+
+				
+
+				// try to route by ER parent partion key
+				//如果是二级子表（父表不再有父表）,并且分片字段正好是joinkey字段，调用routeByERParentKey
+				RouteResultset theRrs = RouterUtil.routeByERParentKey(sc, schema, ServerParse.INSERT, sql, rrs, tc, realVal);
+				if (theRrs != null) {
+					boolean processedInsert=false;
+					//判断是否需要全局序列号
+	                if ( sc!=null && tc.isAutoIncrement()) {
+	                    String primaryKey = tc.getPrimaryKey();
+	                    processedInsert=processInsert(sc,schema,ServerParse.INSERT,sql,tc.getName(),primaryKey);
+	                }
+	                if(processedInsert==false){
+	                	rrs.setFinishedRoute(true);
+	                    sc.getSession2().execute(rrs, ServerParse.INSERT);
+	                }
+					// return true;
+	                //继续处理下一条
+	                continue;
+				}
+
+				// route by sql query root parent's datanode
+				//如果不是二级子表或者分片字段不是joinKey字段结果为空，则启动异步线程去后台分片查询出datanode
+				//只要查询出上一级表的parentkey字段的对应值在哪个分片即可
+				final String findRootTBSql = tc.getLocateRTableKeySql().toLowerCase() + joinKeyVal;
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug("find root parent's node sql " + findRootTBSql);
+				}
+
+				ListenableFuture<String> listenableFuture = MycatServer.getInstance().
+						getListeningExecutorService().submit(new Callable<String>() {
+					@Override
+					public String call() throws Exception {
+						FetchStoreNodeOfChildTableHandler fetchHandler = new FetchStoreNodeOfChildTableHandler();
+//						return fetchHandler.execute(schema.getName(), findRootTBSql, tc.getRootParent().getDataNodes());
+						return fetchHandler.execute(schema.getName(), findRootTBSql, tc.getRootParent().getDataNodes(), sc);
+					}
+				});
 
 
+				Futures.addCallback(listenableFuture, new FutureCallback<String>() {
+					@Override
+					public void onSuccess(String result) {
+						//结果为空，证明上一级表中不存在那条记录，失败
+						if (Strings.isNullOrEmpty(result)) {
+							StringBuilder s = new StringBuilder();
+							LOGGER.warn(s.append(sc.getSession2()).append(origSQL).toString() +
+									" err:" + "can't find (root) parent sharding node for sql:" + origSQL);
+							if(!sc.isAutocommit()) { // 处于事务下失败, 必须回滚
+								sc.setTxInterrupt("can't find (root) parent sharding node for sql:" + origSQL);
+							}
+							sc.writeErrMessage(ErrorCode.ER_PARSE_ERROR, "can't find (root) parent sharding node for sql:" + origSQL);
+							return;
+						}
+
+						if (LOGGER.isDebugEnabled()) {
+							LOGGER.debug("found partion node for child table to insert " + result + " sql :" + origSQL);
+						}
+						//找到分片，进行插入（和其他的一样，需要判断是否需要全局自增ID）
+						boolean processedInsert=false;
+	                    if ( sc!=null && tc.isAutoIncrement()) {
+	                        try {
+	                            String primaryKey = tc.getPrimaryKey();
+								processedInsert=processInsert(sc,schema,ServerParse.INSERT,origSQL,tc.getName(),primaryKey);
+							} catch (SQLNonTransientException e) {
+								LOGGER.warn("sequence processInsert error,",e);
+			                    sc.writeErrMessage(ErrorCode.ER_PARSE_ERROR , "sequence processInsert error," + e.getMessage());
+							}
+	                    }
+	                    if(processedInsert==false){
+	                    	RouteResultset executeRrs = RouterUtil.routeToSingleNode(rrs, result, origSQL);
+	    					sc.getSession2().execute(executeRrs, ServerParse.INSERT);
+	                    }
+
+					}
+
+					@Override
+					public void onFailure(Throwable t) {
+						StringBuilder s = new StringBuilder();
+						LOGGER.warn(s.append(sc.getSession2()).append(origSQL).toString() +
+								" err:" + t.getMessage());
+						sc.writeErrMessage(ErrorCode.ER_PARSE_ERROR, t.getMessage() + " " + s.toString());
+					}
+				}, MycatServer.getInstance().
+						getListeningExecutorService());
+				
+			} else if(erFlag) {
+				throw new SQLNonTransientException(String.format("%s包含不是ER分片的表", origSQL));
+			}
+		}
+		
+		
+		return erFlag;
+	}
+
+/*  该方法目前不支持 insert into table1 values  (1,2);insert into table2 values (2,3); 
 	public static boolean processERChildTable(final SchemaConfig schema, final String origSQL,
 	                                          final ServerConnection sc) throws SQLNonTransientException {
 		String tableName = StringUtil.getTableName(origSQL).toUpperCase();
@@ -1689,7 +1803,7 @@ public class RouterUtil {
 		}
 		return false;
 	}
-
+*/
 	/**
 	 * 寻找joinKey的索引
 	 *

--- a/src/main/java/io/mycat/server/handler/ServerLoadDataInfileHandler.java
+++ b/src/main/java/io/mycat/server/handler/ServerLoadDataInfileHandler.java
@@ -70,786 +70,706 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 /**
- * mysql命令行客户端也需要启用local file权限，加参数--local-infile=1
- * jdbc则正常，不用设置
- * load data sql中的CHARACTER SET 'gbk'   其中的字符集必须引号括起来，否则druid解析出错
+ * mysql命令行客户端也需要启用local file权限，加参数--local-infile=1 jdbc则正常，不用设置 load data
+ * sql中的CHARACTER SET 'gbk' 其中的字符集必须引号括起来，否则druid解析出错
  */
-public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler
-{
-    private ServerConnection serverConnection;
-    private String sql;
-    private String fileName;
-    private byte packID = 0;
-    private MySqlLoadDataInFileStatement statement;
-
-    private Map<String, LoadData> routeResultMap = new HashMap<>();
-
-    private LoadData loadData;
-    private ByteArrayOutputStream tempByteBuffer;
-    private long tempByteBuffrSize = 0;
-    private String tempFile;
-    private boolean isHasStoreToFile = false;
-    private String tempPath;
-    private String tableName;
-    private TableConfig tableConfig;
-    private int partitionColumnIndex = -1;
-    private LayerCachePool tableId2DataNodeCache;
-    private SchemaConfig schema;
-    private boolean isStartLoadData = false;
-
-    private boolean shoudAddSlot = false;
-
-    public int getPackID()
-    {
-        return packID;
-    }
-
-    public void setPackID(byte packID)
-    {
-        this.packID = packID;
-    }
-
-    public ServerLoadDataInfileHandler(ServerConnection serverConnection)
-    {
-        this.serverConnection = serverConnection;
-
-    }
-
-    private static String parseFileName(String sql)
-    {
-        if (sql.contains("'"))
-        {
-            int beginIndex = sql.indexOf("'");
-            return sql.substring(beginIndex + 1, sql.indexOf("'", beginIndex + 1));
-        } else if (sql.contains("\""))
-        {
-            int beginIndex = sql.indexOf("\"");
-            return sql.substring(beginIndex + 1, sql.indexOf("\"", beginIndex + 1));
-        }
-        return null;
-    }
-
-
-    private void parseLoadDataPram()
-    {
-        loadData = new LoadData();
-        SQLTextLiteralExpr rawLineEnd = (SQLTextLiteralExpr) statement.getLinesTerminatedBy();
-        String lineTerminatedBy = rawLineEnd == null ? "\n" : rawLineEnd.getText();
-        loadData.setLineTerminatedBy(lineTerminatedBy);
-
-        SQLTextLiteralExpr rawFieldEnd = (SQLTextLiteralExpr) statement.getColumnsTerminatedBy();
-        String fieldTerminatedBy = rawFieldEnd == null ? "\t" : rawFieldEnd.getText();
-        loadData.setFieldTerminatedBy(fieldTerminatedBy);
-
-        SQLTextLiteralExpr rawEnclosed = (SQLTextLiteralExpr) statement.getColumnsEnclosedBy();
-        String enclose = rawEnclosed == null ? null : rawEnclosed.getText();
-        loadData.setEnclose(enclose);
-
-        SQLTextLiteralExpr escapseExpr =  (SQLTextLiteralExpr)statement.getColumnsEscaped() ;
-         String escapse=escapseExpr==null?"\\":escapseExpr.getText();
-        loadData.setEscape(escapse);
-        String charset = statement.getCharset() != null ? statement.getCharset() : serverConnection.getCharset();
-        loadData.setCharset(charset);
-        loadData.setFileName(fileName);
-    }
-
-
-    @Override
-    public void start(String sql)
-    {
-        clear();
-        this.sql = sql;
-
-
-        SQLStatementParser parser = new MycatStatementParser(sql);
-        statement = (MySqlLoadDataInFileStatement) parser.parseStatement();
-        fileName = parseFileName(sql);
-
-        if (fileName == null)
-        {
-            serverConnection.writeErrMessage(ErrorCode.ER_FILE_NOT_FOUND, " file name is null !");
-            clear();
-            return;
-        }
-        schema = MycatServer.getInstance().getConfig()
-                .getSchemas().get(serverConnection.getSchema());
-        tableId2DataNodeCache = (LayerCachePool) MycatServer.getInstance().getCacheService().getCachePool("TableID2DataNodeCache");
-        tableName = statement.getTableName().getSimpleName().toUpperCase();
-        tableConfig = schema.getTables().get(tableName);
-      if(  tableConfig.getRule().getRuleAlgorithm() instanceof SlotFunction){
-          shoudAddSlot=true;
-      }
-        tempPath = SystemConfig.getHomePath() + File.separator + "temp" + File.separator + serverConnection.getId() + File.separator;
-        tempFile = tempPath + "clientTemp.txt";
-        tempByteBuffer = new ByteArrayOutputStream();
-
-        List<SQLExpr> columns = statement.getColumns();
-        if(tableConfig!=null)
-        {
-            String pColumn = getPartitionColumn();
-            if (pColumn != null && columns != null && columns.size() > 0) {
-                for (int i = 0, columnsSize = columns.size(); i < columnsSize; i++) {
-                    String column = StringUtil.removeBackquote(columns.get(i).toString());
-                    if (pColumn.equalsIgnoreCase(column)) {
-                        partitionColumnIndex = i;
-                    }
-                    if("_slot".equalsIgnoreCase(column)){
-                        shoudAddSlot=false;
-                    }
-                }
-
-            }
-        }
-            if(shoudAddSlot){
-                columns.add(new SQLIdentifierExpr("_slot"));
-            }
-        parseLoadDataPram();
-        if (statement.isLocal())
-        {
-            isStartLoadData = true;
-            //向客户端请求发送文件
-            ByteBuffer buffer = serverConnection.allocate();
-            RequestFilePacket filePacket = new RequestFilePacket();
-            filePacket.fileName = fileName.getBytes();
-            filePacket.packetId = 1;
-            filePacket.write(buffer, serverConnection, true);
-        } else
-        {
-            if (!new File(fileName).exists())
-            {
-                serverConnection.writeErrMessage(ErrorCode.ER_FILE_NOT_FOUND, fileName + " is not found!");
-                clear();
-            } else
-            {
-                parseFileByLine(fileName, loadData.getCharset(), loadData.getLineTerminatedBy());
-                RouteResultset rrs = buildResultSet(routeResultMap);
-                if (rrs != null)
-                {
-                    flushDataToFile();
-                    isStartLoadData = false;
-                    serverConnection.getSession2().execute(rrs, ServerParse.LOAD_DATA_INFILE_SQL);
-                }
-
-            }
-        }
-    }
-
-    @Override
-    public void handle(byte[] data)
-    {
-
-        try
-        {
-            if (sql == null)
-            {
-                serverConnection.writeErrMessage(ErrorCode.ER_UNKNOWN_COM_ERROR,
-                        "Unknown command");
-                clear();
-                return;
-            }
-            BinaryPacket packet = new BinaryPacket();
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(data, 0, data.length);
-            packet.read(inputStream);
-
-            saveByteOrToFile(packet.data, false);
-
-
-        } catch (IOException e)
-        {
-            throw new RuntimeException(e);
-        }
-
-
-    }
-
-    private synchronized void saveByteOrToFile(byte[] data, boolean isForce)
-    {
-
-        if (data != null)
-        {
-            tempByteBuffrSize = tempByteBuffrSize + data.length;
-            try
-            {
-                tempByteBuffer.write(data);
-            } catch (IOException e)
-            {
-                throw new RuntimeException(e);
-            }
-        }
-
-        if ((isForce && isHasStoreToFile) || tempByteBuffrSize > 200 * 1024 * 1024)    //超过200M 存文件
-        {
-            FileOutputStream channel = null;
-            try
-            {
-                File file = new File(tempFile);
-                Files.createParentDirs(file);
-                channel = new FileOutputStream(file, true);
-
-                tempByteBuffer.writeTo(channel);
-                tempByteBuffer=new ByteArrayOutputStream();
-               tempByteBuffrSize = 0;
-                isHasStoreToFile = true;
-            } catch (IOException e)
-            {
-                throw new RuntimeException(e);
-            } finally
-            {
-                try
-                {
-                    if (channel != null) {
-                        channel.close();
-                    }
-
-                } catch (IOException ignored)
-                {
-
-                }
-            }
-
-
-        }
-    }
-
-
-    private RouteResultset tryDirectRoute(String sql, String[] lineList)
-    {
-
-        RouteResultset rrs = new RouteResultset(sql, ServerParse.INSERT);
-        rrs.setLoadData(true);
-        if (tableConfig == null && schema.getDataNode() != null)
-        {
-            //走默认节点
-            RouteResultsetNode rrNode = new RouteResultsetNode(schema.getDataNode(), ServerParse.INSERT, sql);
-            rrNode.setSource(rrs);
-            rrs.setNodes(new RouteResultsetNode[]{rrNode});
-            return rrs;
-        }
-        else if (tableConfig != null&&tableConfig.isGlobalTable())
-        {
-            ArrayList<String> dataNodes= tableConfig.getDataNodes();
-            RouteResultsetNode[] rrsNodes=    new RouteResultsetNode[dataNodes.size()];
-            for (int i = 0, dataNodesSize = dataNodes.size(); i < dataNodesSize; i++)
-            {
-                String dataNode = dataNodes.get(i);
-                RouteResultsetNode rrNode = new RouteResultsetNode(dataNode, ServerParse.INSERT, sql);
-                rrsNodes[i]=rrNode;
-                if(rrs.getDataNodeSlotMap().containsKey(dataNode)){
-                    rrsNodes[i].setSlot(rrs.getDataNodeSlotMap().get(dataNode));
-                }
-                rrsNodes[i].setSource(rrs);
-            }
-
-            rrs.setNodes(rrsNodes);
-            return rrs;
-        }
-        else if (tableConfig != null)
-        {
-            DruidShardingParseInfo ctx = new DruidShardingParseInfo();
-            ctx.addTable(tableName);
-
-
-            if (partitionColumnIndex == -1 || partitionColumnIndex >= lineList.length)
-            {
-                return null;
-            } else
-            {
-                String value = lineList[partitionColumnIndex];
-                RouteCalculateUnit routeCalculateUnit = new RouteCalculateUnit();
-                routeCalculateUnit.addShardingExpr(tableName, getPartitionColumn(), parseFieldString(value,loadData.getEnclose()));
-                ctx.addRouteCalculateUnit(routeCalculateUnit);
-                try
-                {
-                	SortedSet<RouteResultsetNode> nodeSet = new TreeSet<RouteResultsetNode>();
-            		for(RouteCalculateUnit unit : ctx.getRouteCalculateUnits()) {
-            			RouteResultset rrsTmp = RouterUtil.tryRouteForTables(schema, ctx, unit, rrs, false, tableId2DataNodeCache);
-            			if(rrsTmp != null) {
-            				for(RouteResultsetNode node :rrsTmp.getNodes()) {
-            					nodeSet.add(node);
-            				}
-            			}
-            		}
-            		
-            		RouteResultsetNode[] nodes = new RouteResultsetNode[nodeSet.size()];
-            		int i = 0;
-            		for (Iterator<RouteResultsetNode> iterator = nodeSet.iterator(); iterator.hasNext();) {
-            			nodes[i] = (RouteResultsetNode) iterator.next();
-            			i++;
-            		}
-            		
-            		rrs.setNodes(nodes);
-                    return rrs;
-                } catch (SQLNonTransientException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }
-
-
-        }
-
-        return null;
-    }
-
-
-    private void parseOneLine(List<SQLExpr> columns, String tableName, String[] line, boolean toFile, String lineEnd)
-    {
-
-        RouteResultset rrs = tryDirectRoute(sql, line);
-        if (rrs == null || rrs.getNodes() == null || rrs.getNodes().length == 0)
-        {
-
-            String insertSql = makeSimpleInsert(columns, line, tableName, true);
-            rrs = serverConnection.routeSQL(insertSql, ServerParse.INSERT);
-        }
-
-
-        if (rrs == null || rrs.getNodes() == null || rrs.getNodes().length == 0)
-        {
-            //无路由处理
-        } else
-        {
-            for (RouteResultsetNode routeResultsetNode : rrs.getNodes())
-            {
-                String name = routeResultsetNode.getName();
-                LoadData data = routeResultMap.get(name);
-                if (data == null)
-                {
-                    data = new LoadData();
-                    data.setCharset(loadData.getCharset());
-                    data.setEnclose(loadData.getEnclose());
-                    data.setFieldTerminatedBy(loadData.getFieldTerminatedBy());
-                    data.setLineTerminatedBy(loadData.getLineTerminatedBy());
-                    data.setEscape(loadData.getEscape());
-                    routeResultMap.put(name, data);
-                }
-
-                    String jLine = joinField(line, data);
-                if(shoudAddSlot){
-                    jLine=jLine+loadData.getFieldTerminatedBy()+routeResultsetNode.getSlot();
-                }
-                    if (data.getData() == null)
-                    {
-                        data.setData(Lists.newArrayList(jLine));
-                    } else
-                    {
-
-                        data.getData().add(jLine);
-
-                    }
-
-                if (toFile
-                        //避免当导入数据跨多分片时内存溢出的情况
-                        && data.getData().size()>10000)
-                {
-                        saveDataToFile(data,name);
-                }
-
-            }
-        }
-    }
-
-    private void flushDataToFile()
-    {
-        for (Map.Entry<String, LoadData> stringLoadDataEntry : routeResultMap.entrySet())
-        {
-            LoadData value = stringLoadDataEntry.getValue();
-            if(   value.getFileName()!=null&&value.getData()!=null&&value.getData().size()>0)
-            {
-                saveDataToFile(value,stringLoadDataEntry.getKey());
-            }
-        }
-
-    }
-
-    private void saveDataToFile(LoadData data,String dnName)
-    {
-        if (data.getFileName() == null)
-        {
-            String dnPath = tempPath + dnName + ".txt";
-            data.setFileName(dnPath);
-        }
-
-           File dnFile = new File(data.getFileName());
-            try
-            {
-                if (!dnFile.exists()) {
-                                        Files.createParentDirs(dnFile);
-                                    }
-                           	Files.append(joinLine(data.getData(),data), dnFile, Charset.forName(loadData.getCharset()));
-
-            } catch (IOException e)
-            {
-                throw new RuntimeException(e);
-            }finally
-            {
-                data.setData(null);
-
-            }
-
-
-
-    }
-
-    private String joinLine(List<String> data, LoadData loadData)
-    {
-        StringBuilder sb = new StringBuilder();
-        for (String s : data)
-        {
-            sb.append(s).append(loadData.getLineTerminatedBy())   ;
-        }
-        return sb.toString();
-    }
-
-
-    private String joinField(String[] src, LoadData loadData)
-    {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0, srcLength = src.length; i < srcLength; i++)
-        {
-            String s = src[i]!=null?src[i]:"";
-            if(loadData.getEnclose()==null)
-            {
-                  sb.append(s);
-            }   else
-            {
-                sb.append(loadData.getEnclose()).append(s.replace(loadData.getEnclose(),loadData.getEscape()+loadData.getEnclose())).append(loadData.getEnclose());
-            }
-            if(i!=srcLength-1)
-            {
-                sb.append(loadData.getFieldTerminatedBy());
-            }
-        }
-
-            return sb.toString();
-
-    }
-
-
-    private RouteResultset buildResultSet(Map<String, LoadData> routeMap)
-    {
-        statement.setLocal(true);//强制local
-        SQLLiteralExpr fn = new SQLCharExpr(fileName);    //默认druid会过滤掉路径的分隔符，所以这里重新设置下
-        statement.setFileName(fn);
-        String srcStatement = statement.toString();
-        RouteResultset rrs = new RouteResultset(srcStatement, ServerParse.LOAD_DATA_INFILE_SQL);
-        rrs.setLoadData(true);
-        rrs.setStatement(srcStatement);
-        rrs.setAutocommit(serverConnection.isAutocommit());
-        rrs.setFinishedRoute(true);
-        int size = routeMap.size();
-        RouteResultsetNode[] routeResultsetNodes = new RouteResultsetNode[size];
-        int index = 0;
-        for (String dn : routeMap.keySet())
-        {
-            RouteResultsetNode rrNode = new RouteResultsetNode(dn, ServerParse.LOAD_DATA_INFILE_SQL, srcStatement);
-            rrNode.setSource(rrs);
-            rrNode.setTotalNodeSize(size);
-            rrNode.setStatement(srcStatement);
-            LoadData newLoadData = new LoadData();
-            ObjectUtil.copyProperties(loadData, newLoadData);
-            newLoadData.setLocal(true);
-            LoadData loadData1 = routeMap.get(dn);
-          //  if (isHasStoreToFile)
-            if (loadData1.getFileName()!=null)//此处判断是否有保存分库load的临时文件dn1.txt/dn2.txt，不是判断是否有clientTemp.txt
-            {
-                newLoadData.setFileName(loadData1.getFileName());
-            } else
-            {
-                newLoadData.setData(loadData1.getData());
-            }
-            rrNode.setLoadData(newLoadData);
-
-            routeResultsetNodes[index] = rrNode;
-            index++;
-        }
-        rrs.setNodes(routeResultsetNodes);
-        return rrs;
-    }
-
-
-    private String makeSimpleInsert(List<SQLExpr> columns, String[] fields, String table, boolean isAddEncose)
-    {
-        StringBuilder sb = new StringBuilder();
-        sb.append(LoadData.loadDataHint).append("insert into ").append(table.toUpperCase());
-        if (columns != null && columns.size() > 0)
-        {
-            sb.append("(");
-            for (int i = 0, columnsSize = columns.size(); i < columnsSize; i++)
-            {
-                SQLExpr column = columns.get(i);
-                sb.append(column.toString());
-                if (i != columnsSize - 1)
-                {
-                    sb.append(",");
-                }
-            }
-            sb.append(") ");
-        }
-
-        sb.append(" values (");
-        for (int i = 0, columnsSize = fields.length; i < columnsSize; i++)
-        {
-            String column = fields[i];
-            if (isAddEncose)
-            {
-                sb.append("'").append(parseFieldString(column, loadData.getEnclose())).append("'");
-            } else
-            {
-                sb.append(column);
-            }
-            if (i != columnsSize - 1)
-            {
-                sb.append(",");
-            }
-        }
-        sb.append(")");
-        return sb.toString();
-    }
-
-    private String parseFieldString(String value, String encose)
-    {
-        if (encose == null || "".equals(encose) || value == null)
-        {
-            return value;
-        } else if (value.startsWith(encose) && value.endsWith(encose))
-        {
-            return value.substring(encose.length() - 1, value.length() - encose.length());
-        }
-        return value;
-    }
-
-
-    @Override
-    public void end(byte packID)
-    {
-        isStartLoadData = false;
-        this.packID = packID;
-        //load in data空包 结束
-        saveByteOrToFile(null, true);
-        List<SQLExpr> columns = statement.getColumns();
-        String tableName = statement.getTableName().getSimpleName();
-        if (isHasStoreToFile)
-        {
-            parseFileByLine(tempFile, loadData.getCharset(), loadData.getLineTerminatedBy());
-        } else
-        {
-            String content = new String(tempByteBuffer.toByteArray(), Charset.forName(loadData.getCharset()));
-
-            // List<String> lines = Splitter.on(loadData.getLineTerminatedBy()).omitEmptyStrings().splitToList(content);
-            CsvParserSettings settings = new CsvParserSettings();
-            settings.setMaxColumns(65535);
-            settings.setMaxCharsPerColumn(65535);
-            settings.getFormat().setLineSeparator(loadData.getLineTerminatedBy());
-            settings.getFormat().setDelimiter(loadData.getFieldTerminatedBy().charAt(0));
-            if(loadData.getEnclose()!=null)
-            {
-                settings.getFormat().setQuote(loadData.getEnclose().charAt(0));
-            }
-            if(loadData.getEscape()!=null)
-            {
-            settings.getFormat().setQuoteEscape(loadData.getEscape().charAt(0));
-            }
-            settings.getFormat().setNormalizedNewline(loadData.getLineTerminatedBy().charAt(0));
-            /*
-             *  fix bug #1074 : LOAD DATA local INFILE导入的所有Boolean类型全部变成了false
-             *  不可见字符将在CsvParser被当成whitespace过滤掉, 使用settings.trimValues(false)来避免被过滤掉
-             *  TODO : 设置trimValues(false)之后, 会引起字段值前后的空白字符无法被过滤!
-             */
-            settings.trimValues(false);
-            CsvParser parser = new CsvParser(settings);
-            try
-            {
-                parser.beginParsing(new StringReader(content));
-                String[] row = null;
-
-                while ((row = parser.parseNext()) != null)
-                {
-                    parseOneLine(columns, tableName, row, false, null);
-                }
-            } finally
-            {
-                parser.stopParsing();
-            }
-
-
-        }
-
-        RouteResultset rrs = buildResultSet(routeResultMap);
-        if (rrs != null)
-        {
-            flushDataToFile();
-            serverConnection.getSession2().execute(rrs, ServerParse.LOAD_DATA_INFILE_SQL);
-        }
-
-
-        // sendOk(++packID);
-
-
-    }
-
-
-    private void parseFileByLine(String file, String encode, String split)
-    {
-        List<SQLExpr> columns = statement.getColumns();
-        CsvParserSettings settings = new CsvParserSettings();
-        settings.setMaxColumns(65535);
-        settings.setMaxCharsPerColumn(65535);
-        settings.getFormat().setLineSeparator(loadData.getLineTerminatedBy());
-        settings.getFormat().setDelimiter(loadData.getFieldTerminatedBy().charAt(0));
-        if(loadData.getEnclose()!=null)
-        {
-            settings.getFormat().setQuote(loadData.getEnclose().charAt(0));
-        }
-        if(loadData.getEscape()!=null)
-        {
-            settings.getFormat().setQuoteEscape(loadData.getEscape().charAt(0));
-        }
-        settings.getFormat().setNormalizedNewline(loadData.getLineTerminatedBy().charAt(0));
-        /*
-         *  fix #1074 : LOAD DATA local INFILE导入的所有Boolean类型全部变成了false
-         *  不可见字符将在CsvParser被当成whitespace过滤掉, 使用settings.trimValues(false)来避免被过滤掉
-         *  TODO : 设置trimValues(false)之后, 会引起字段值前后的空白字符无法被过滤!
-         */
-        settings.trimValues(false);
-        CsvParser parser = new CsvParser(settings);
-        InputStreamReader reader = null;
-        FileInputStream fileInputStream = null;
-        try
-        {
-
-            fileInputStream = new FileInputStream(file);
-            reader = new InputStreamReader(fileInputStream, encode);
-            parser.beginParsing(reader);
-            String[] row = null;
-
-            while ((row = parser.parseNext()) != null)
-            {
-                parseOneLine(columns, tableName, row, true, loadData.getLineTerminatedBy());
-            }
-
-
-        } catch (FileNotFoundException | UnsupportedEncodingException e)
-        {
-            throw new RuntimeException(e);
-        } finally
-        {
-            parser.stopParsing();
-            if(fileInputStream!=null)
-            {
-                try
-                {
-                    fileInputStream.close();
-                } catch (IOException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }
-            if (reader != null)
-            {
-                try
-                {
-                    reader.close();
-                } catch (IOException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }
-
-        }
-
-    }
-
-
-    public void clear()
-    {
-        isStartLoadData = false;
-        tableId2DataNodeCache = null;
-        schema = null;
-        tableConfig = null;
-        isHasStoreToFile = false;
-        packID = 0;
-        tempByteBuffrSize = 0;
-        tableName=null;
-        partitionColumnIndex = -1;
-        if (tempFile != null)
-        {
-            File temp = new File(tempFile);
-            if (temp.exists())
-            {
-                temp.delete();
-            }
-        }
-        if (tempPath != null && new File(tempPath).exists())
-        {
-            deleteFile(tempPath);
-        }
-        tempByteBuffer = null;
-        loadData = null;
-        sql = null;
-        fileName = null;
-        statement = null;
-        routeResultMap.clear();
-    }
-
-    @Override
-    public byte getLastPackId()
-    {
-        return packID;
-    }
-
-    @Override
-    public boolean isStartLoadData()
-    {
-        return isStartLoadData;
-    }
-
-    private String getPartitionColumn() {
-        		String pColumn;
-        		if (tableConfig.isSecondLevel()
-                				&& tableConfig.getParentTC().getPartitionColumn()
-                				.equals(tableConfig.getParentKey())) {
-            			pColumn = tableConfig.getJoinKey();
-            		}else {
-            			pColumn = tableConfig.getPartitionColumn();
-            		}
-        		return pColumn;
-        	}
-
-    /**
-     * 删除目录及其所有子目录和文件
-     *
-     * @param dirPath 要删除的目录路径
-     * @throws Exception
-     */
-    private static void deleteFile(String dirPath)
-    {
-        File fileDirToDel = new File(dirPath);
-        if (!fileDirToDel.exists())
-        {
-            return;
-        }
-        if (fileDirToDel.isFile())
-        {
-            fileDirToDel.delete();
-            return;
-        }
-        File[] fileList = fileDirToDel.listFiles();
-
-        for (int i = 0; i < fileList.length; i++)
-        {
-            File file = fileList[i];
-            if (file.isFile()&&file.exists())
-            {
-                boolean delete = file.delete();
-            } else if (file.isDirectory())
-            {
-                deleteFile(file.getAbsolutePath());
-                file.delete();
-            }
-        }
-        fileDirToDel.delete();
-    }
-
+public final class ServerLoadDataInfileHandler implements LoadDataInfileHandler {
+	private ServerConnection serverConnection;
+	private String sql;
+	private String fileName;
+	private byte packID = 0;
+	private MySqlLoadDataInFileStatement statement;
+
+	private Map<String, LoadData> routeResultMap = new HashMap<>();
+
+	private LoadData loadData;
+	private ByteArrayOutputStream tempByteBuffer;
+	private long tempByteBuffrSize = 0;
+	private String tempFile;
+	private boolean isHasStoreToFile = false;
+	private String tempPath;
+	private String tableName;
+	private TableConfig tableConfig;
+	private int partitionColumnIndex = -1;
+	private LayerCachePool tableId2DataNodeCache;
+	private SchemaConfig schema;
+	private boolean isStartLoadData = false;
+
+	private boolean shoudAddSlot = false;
+
+	public int getPackID() {
+		return packID;
+	}
+
+	public void setPackID(byte packID) {
+		this.packID = packID;
+	}
+
+	public ServerLoadDataInfileHandler(ServerConnection serverConnection) {
+		this.serverConnection = serverConnection;
+
+	}
+
+	private static String parseFileName(String sql) {
+		if (sql.contains("'")) {
+			int beginIndex = sql.indexOf("'");
+			return sql.substring(beginIndex + 1,
+					sql.indexOf("'", beginIndex + 1));
+		} else if (sql.contains("\"")) {
+			int beginIndex = sql.indexOf("\"");
+			return sql.substring(beginIndex + 1,
+					sql.indexOf("\"", beginIndex + 1));
+		}
+		return null;
+	}
+
+	private void parseLoadDataPram() {
+		loadData = new LoadData();
+		SQLTextLiteralExpr rawLineEnd = (SQLTextLiteralExpr) statement
+				.getLinesTerminatedBy();
+		String lineTerminatedBy = rawLineEnd == null ? "\n" : rawLineEnd
+				.getText();
+		loadData.setLineTerminatedBy(lineTerminatedBy);
+
+		SQLTextLiteralExpr rawFieldEnd = (SQLTextLiteralExpr) statement
+				.getColumnsTerminatedBy();
+		String fieldTerminatedBy = rawFieldEnd == null ? "\t" : rawFieldEnd
+				.getText();
+		loadData.setFieldTerminatedBy(fieldTerminatedBy);
+
+		SQLTextLiteralExpr rawEnclosed = (SQLTextLiteralExpr) statement
+				.getColumnsEnclosedBy();
+		String enclose = rawEnclosed == null ? null : rawEnclosed.getText();
+		loadData.setEnclose(enclose);
+
+		SQLTextLiteralExpr escapseExpr = (SQLTextLiteralExpr) statement
+				.getColumnsEscaped();
+		String escapse = escapseExpr == null ? "\\" : escapseExpr.getText();
+		loadData.setEscape(escapse);
+		String charset = statement.getCharset() != null ? statement
+				.getCharset() : serverConnection.getCharset();
+		loadData.setCharset(charset);
+		loadData.setFileName(fileName);
+	}
+
+	@Override
+	public void start(String sql) {
+		clear();
+		this.sql = sql;
+
+		SQLStatementParser parser = new MycatStatementParser(sql);
+		statement = (MySqlLoadDataInFileStatement) parser.parseStatement();
+		fileName = parseFileName(sql);
+
+		if (fileName == null) {
+			serverConnection.writeErrMessage(ErrorCode.ER_FILE_NOT_FOUND,
+					" file name is null !");
+			clear();
+			return;
+		}
+		schema = MycatServer.getInstance().getConfig().getSchemas()
+				.get(serverConnection.getSchema());
+		tableId2DataNodeCache = (LayerCachePool) MycatServer.getInstance()
+				.getCacheService().getCachePool("TableID2DataNodeCache");
+		tableName = statement.getTableName().getSimpleName().toUpperCase();
+		tableConfig = schema.getTables().get(tableName);
+		if (tableConfig.getRule() != null
+				&& tableConfig.getRule().getRuleAlgorithm() instanceof SlotFunction) {
+			shoudAddSlot = true;
+		}
+		tempPath = SystemConfig.getHomePath() + File.separator + "temp"
+				+ File.separator + serverConnection.getId() + File.separator;
+		tempFile = tempPath + "clientTemp.txt";
+		tempByteBuffer = new ByteArrayOutputStream();
+
+		List<SQLExpr> columns = statement.getColumns();
+		if (tableConfig != null) {
+			String pColumn = getPartitionColumn();
+			if (pColumn != null && columns != null && columns.size() > 0) {
+				for (int i = 0, columnsSize = columns.size(); i < columnsSize; i++) {
+					String column = StringUtil.removeBackquote(columns.get(i)
+							.toString());
+					if (pColumn.equalsIgnoreCase(column)) {
+						partitionColumnIndex = i;
+					}
+					if ("_slot".equalsIgnoreCase(column)) {
+						shoudAddSlot = false;
+					}
+				}
+
+			}
+		}
+		if (shoudAddSlot) {
+			columns.add(new SQLIdentifierExpr("_slot"));
+		}
+		parseLoadDataPram();
+		if (statement.isLocal()) {
+			isStartLoadData = true;
+			// 向客户端请求发送文件
+			ByteBuffer buffer = serverConnection.allocate();
+			RequestFilePacket filePacket = new RequestFilePacket();
+			filePacket.fileName = fileName.getBytes();
+			filePacket.packetId = 1;
+			filePacket.write(buffer, serverConnection, true);
+		} else {
+			if (!new File(fileName).exists()) {
+				serverConnection.writeErrMessage(ErrorCode.ER_FILE_NOT_FOUND,
+						fileName + " is not found!");
+				clear();
+			} else {
+				parseFileByLine(fileName, loadData.getCharset(),
+						loadData.getLineTerminatedBy());
+				RouteResultset rrs = buildResultSet(routeResultMap);
+				if (rrs != null) {
+					flushDataToFile();
+					isStartLoadData = false;
+					serverConnection.getSession2().execute(rrs,
+							ServerParse.LOAD_DATA_INFILE_SQL);
+				}
+
+			}
+		}
+	}
+
+	@Override
+	public void handle(byte[] data) {
+
+		try {
+			if (sql == null) {
+				serverConnection.writeErrMessage(
+						ErrorCode.ER_UNKNOWN_COM_ERROR, "Unknown command");
+				clear();
+				return;
+			}
+			BinaryPacket packet = new BinaryPacket();
+			ByteArrayInputStream inputStream = new ByteArrayInputStream(data,
+					0, data.length);
+			packet.read(inputStream);
+
+			saveByteOrToFile(packet.data, false);
+
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+	}
+
+	private synchronized void saveByteOrToFile(byte[] data, boolean isForce) {
+
+		if (data != null) {
+			tempByteBuffrSize = tempByteBuffrSize + data.length;
+			try {
+				tempByteBuffer.write(data);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		if ((isForce && isHasStoreToFile)
+				|| tempByteBuffrSize > 200 * 1024 * 1024) // 超过200M 存文件
+		{
+			FileOutputStream channel = null;
+			try {
+				File file = new File(tempFile);
+				Files.createParentDirs(file);
+				channel = new FileOutputStream(file, true);
+
+				tempByteBuffer.writeTo(channel);
+				tempByteBuffer = new ByteArrayOutputStream();
+				tempByteBuffrSize = 0;
+				isHasStoreToFile = true;
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			} finally {
+				try {
+					if (channel != null) {
+						channel.close();
+					}
+
+				} catch (IOException ignored) {
+
+				}
+			}
+
+		}
+	}
+
+	private RouteResultset tryDirectRoute(String sql, String[] lineList) {
+
+		RouteResultset rrs = new RouteResultset(sql, ServerParse.INSERT);
+		rrs.setLoadData(true);
+		if (tableConfig == null && schema.getDataNode() != null) {
+			// 走默认节点
+			RouteResultsetNode rrNode = new RouteResultsetNode(
+					schema.getDataNode(), ServerParse.INSERT, sql);
+			rrNode.setSource(rrs);
+			rrs.setNodes(new RouteResultsetNode[] { rrNode });
+			return rrs;
+		} else if (tableConfig != null && tableConfig.isGlobalTable()) {
+			ArrayList<String> dataNodes = tableConfig.getDataNodes();
+			RouteResultsetNode[] rrsNodes = new RouteResultsetNode[dataNodes
+					.size()];
+			for (int i = 0, dataNodesSize = dataNodes.size(); i < dataNodesSize; i++) {
+				String dataNode = dataNodes.get(i);
+				RouteResultsetNode rrNode = new RouteResultsetNode(dataNode,
+						ServerParse.INSERT, sql);
+				rrsNodes[i] = rrNode;
+				if (rrs.getDataNodeSlotMap().containsKey(dataNode)) {
+					rrsNodes[i].setSlot(rrs.getDataNodeSlotMap().get(dataNode));
+				}
+				rrsNodes[i].setSource(rrs);
+			}
+
+			rrs.setNodes(rrsNodes);
+			return rrs;
+		} else if (tableConfig != null) {
+			DruidShardingParseInfo ctx = new DruidShardingParseInfo();
+			ctx.addTable(tableName);
+
+			if (partitionColumnIndex == -1
+					|| partitionColumnIndex >= lineList.length) {
+				return null;
+			} else {
+				String value = lineList[partitionColumnIndex];
+				RouteCalculateUnit routeCalculateUnit = new RouteCalculateUnit();
+				routeCalculateUnit.addShardingExpr(tableName,
+						getPartitionColumn(),
+						parseFieldString(value, loadData.getEnclose()));
+				ctx.addRouteCalculateUnit(routeCalculateUnit);
+				try {
+					SortedSet<RouteResultsetNode> nodeSet = new TreeSet<RouteResultsetNode>();
+					for (RouteCalculateUnit unit : ctx.getRouteCalculateUnits()) {
+						RouteResultset rrsTmp = RouterUtil.tryRouteForTables(
+								schema, ctx, unit, rrs, false,
+								tableId2DataNodeCache);
+						if (rrsTmp != null) {
+							for (RouteResultsetNode node : rrsTmp.getNodes()) {
+								nodeSet.add(node);
+							}
+						}
+					}
+
+					RouteResultsetNode[] nodes = new RouteResultsetNode[nodeSet
+							.size()];
+					int i = 0;
+					for (Iterator<RouteResultsetNode> iterator = nodeSet
+							.iterator(); iterator.hasNext();) {
+						nodes[i] = (RouteResultsetNode) iterator.next();
+						i++;
+					}
+
+					rrs.setNodes(nodes);
+					return rrs;
+				} catch (SQLNonTransientException e) {
+					throw new RuntimeException(e);
+				}
+			}
+
+		}
+
+		return null;
+	}
+
+	private void parseOneLine(List<SQLExpr> columns, String tableName,
+			String[] line, boolean toFile, String lineEnd) {
+
+		RouteResultset rrs = tryDirectRoute(sql, line);
+		if (rrs == null || rrs.getNodes() == null || rrs.getNodes().length == 0) {
+
+			String insertSql = makeSimpleInsert(columns, line, tableName, true);
+			rrs = serverConnection.routeSQL(insertSql, ServerParse.INSERT);
+		}
+
+		if (rrs == null || rrs.getNodes() == null || rrs.getNodes().length == 0) {
+			// 无路由处理
+		} else {
+			for (RouteResultsetNode routeResultsetNode : rrs.getNodes()) {
+				String name = routeResultsetNode.getName();
+				LoadData data = routeResultMap.get(name);
+				if (data == null) {
+					data = new LoadData();
+					data.setCharset(loadData.getCharset());
+					data.setEnclose(loadData.getEnclose());
+					data.setFieldTerminatedBy(loadData.getFieldTerminatedBy());
+					data.setLineTerminatedBy(loadData.getLineTerminatedBy());
+					data.setEscape(loadData.getEscape());
+					routeResultMap.put(name, data);
+				}
+
+				String jLine = joinField(line, data);
+				if (shoudAddSlot) {
+					jLine = jLine + loadData.getFieldTerminatedBy()
+							+ routeResultsetNode.getSlot();
+				}
+				if (data.getData() == null) {
+					data.setData(Lists.newArrayList(jLine));
+				} else {
+
+					data.getData().add(jLine);
+
+				}
+
+				if (toFile
+				// 避免当导入数据跨多分片时内存溢出的情况
+						&& data.getData().size() > 10000) {
+					saveDataToFile(data, name);
+				}
+
+			}
+		}
+	}
+
+	private void flushDataToFile() {
+		for (Map.Entry<String, LoadData> stringLoadDataEntry : routeResultMap
+				.entrySet()) {
+			LoadData value = stringLoadDataEntry.getValue();
+			if (value.getFileName() != null && value.getData() != null
+					&& value.getData().size() > 0) {
+				saveDataToFile(value, stringLoadDataEntry.getKey());
+			}
+		}
+
+	}
+
+	private void saveDataToFile(LoadData data, String dnName) {
+		if (data.getFileName() == null) {
+			String dnPath = tempPath + dnName + ".txt";
+			data.setFileName(dnPath);
+		}
+
+		File dnFile = new File(data.getFileName());
+		try {
+			if (!dnFile.exists()) {
+				Files.createParentDirs(dnFile);
+			}
+			Files.append(joinLine(data.getData(), data), dnFile,
+					Charset.forName(loadData.getCharset()));
+
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		} finally {
+			data.setData(null);
+
+		}
+
+	}
+
+	private String joinLine(List<String> data, LoadData loadData) {
+		StringBuilder sb = new StringBuilder();
+		for (String s : data) {
+			sb.append(s).append(loadData.getLineTerminatedBy());
+		}
+		return sb.toString();
+	}
+
+	private String joinField(String[] src, LoadData loadData) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0, srcLength = src.length; i < srcLength; i++) {
+			String s = src[i] != null ? src[i] : "";
+			if (loadData.getEnclose() == null) {
+				sb.append(s);
+			} else {
+				sb.append(loadData.getEnclose())
+						.append(s.replace(loadData.getEnclose(),
+								loadData.getEscape() + loadData.getEnclose()))
+						.append(loadData.getEnclose());
+			}
+			if (i != srcLength - 1) {
+				sb.append(loadData.getFieldTerminatedBy());
+			}
+		}
+
+		return sb.toString();
+
+	}
+
+	private RouteResultset buildResultSet(Map<String, LoadData> routeMap) {
+		statement.setLocal(true);// 强制local
+		SQLLiteralExpr fn = new SQLCharExpr(fileName); // 默认druid会过滤掉路径的分隔符，所以这里重新设置下
+		statement.setFileName(fn);
+		String srcStatement = statement.toString();
+		RouteResultset rrs = new RouteResultset(srcStatement,
+				ServerParse.LOAD_DATA_INFILE_SQL);
+		rrs.setLoadData(true);
+		rrs.setStatement(srcStatement);
+		rrs.setAutocommit(serverConnection.isAutocommit());
+		rrs.setFinishedRoute(true);
+		int size = routeMap.size();
+		RouteResultsetNode[] routeResultsetNodes = new RouteResultsetNode[size];
+		int index = 0;
+		for (String dn : routeMap.keySet()) {
+			RouteResultsetNode rrNode = new RouteResultsetNode(dn,
+					ServerParse.LOAD_DATA_INFILE_SQL, srcStatement);
+			rrNode.setSource(rrs);
+			rrNode.setTotalNodeSize(size);
+			rrNode.setStatement(srcStatement);
+			LoadData newLoadData = new LoadData();
+			ObjectUtil.copyProperties(loadData, newLoadData);
+			newLoadData.setLocal(true);
+			LoadData loadData1 = routeMap.get(dn);
+			// if (isHasStoreToFile)
+			if (loadData1.getFileName() != null)// 此处判断是否有保存分库load的临时文件dn1.txt/dn2.txt，不是判断是否有clientTemp.txt
+			{
+				newLoadData.setFileName(loadData1.getFileName());
+			} else {
+				newLoadData.setData(loadData1.getData());
+			}
+			rrNode.setLoadData(newLoadData);
+
+			routeResultsetNodes[index] = rrNode;
+			index++;
+		}
+		rrs.setNodes(routeResultsetNodes);
+		return rrs;
+	}
+
+	private String makeSimpleInsert(List<SQLExpr> columns, String[] fields,
+			String table, boolean isAddEncose) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(LoadData.loadDataHint).append("insert into ")
+				.append(table.toUpperCase());
+		if (columns != null && columns.size() > 0) {
+			sb.append("(");
+			for (int i = 0, columnsSize = columns.size(); i < columnsSize; i++) {
+				SQLExpr column = columns.get(i);
+				sb.append(column.toString());
+				if (i != columnsSize - 1) {
+					sb.append(",");
+				}
+			}
+			sb.append(") ");
+		}
+
+		sb.append(" values (");
+		for (int i = 0, columnsSize = fields.length; i < columnsSize; i++) {
+			String column = fields[i];
+			if (isAddEncose) {
+				sb.append("'")
+						.append(parseFieldString(column, loadData.getEnclose()))
+						.append("'");
+			} else {
+				sb.append(column);
+			}
+			if (i != columnsSize - 1) {
+				sb.append(",");
+			}
+		}
+		sb.append(")");
+		return sb.toString();
+	}
+
+	private String parseFieldString(String value, String encose) {
+		if (encose == null || "".equals(encose) || value == null) {
+			return value;
+		} else if (value.startsWith(encose) && value.endsWith(encose)) {
+			return value.substring(encose.length() - 1,
+					value.length() - encose.length());
+		}
+		return value;
+	}
+
+	@Override
+	public void end(byte packID) {
+		isStartLoadData = false;
+		this.packID = packID;
+		// load in data空包 结束
+		saveByteOrToFile(null, true);
+		List<SQLExpr> columns = statement.getColumns();
+		String tableName = statement.getTableName().getSimpleName();
+		if (isHasStoreToFile) {
+			parseFileByLine(tempFile, loadData.getCharset(),
+					loadData.getLineTerminatedBy());
+		} else {
+			String content = new String(tempByteBuffer.toByteArray(),
+					Charset.forName(loadData.getCharset()));
+
+			// List<String> lines =
+			// Splitter.on(loadData.getLineTerminatedBy()).omitEmptyStrings().splitToList(content);
+			CsvParserSettings settings = new CsvParserSettings();
+			settings.setMaxColumns(65535);
+			settings.setMaxCharsPerColumn(65535);
+			settings.getFormat().setLineSeparator(
+					loadData.getLineTerminatedBy());
+			settings.getFormat().setDelimiter(
+					loadData.getFieldTerminatedBy().charAt(0));
+			if (loadData.getEnclose() != null) {
+				settings.getFormat().setQuote(loadData.getEnclose().charAt(0));
+			}
+			if (loadData.getEscape() != null) {
+				settings.getFormat().setQuoteEscape(
+						loadData.getEscape().charAt(0));
+			}
+			settings.getFormat().setNormalizedNewline(
+					loadData.getLineTerminatedBy().charAt(0));
+			/*
+			 * fix bug #1074 : LOAD DATA local INFILE导入的所有Boolean类型全部变成了false
+			 * 不可见字符将在CsvParser被当成whitespace过滤掉,
+			 * 使用settings.trimValues(false)来避免被过滤掉 TODO : 设置trimValues(false)之后,
+			 * 会引起字段值前后的空白字符无法被过滤!
+			 */
+			settings.trimValues(false);
+			CsvParser parser = new CsvParser(settings);
+			try {
+				parser.beginParsing(new StringReader(content));
+				String[] row = null;
+
+				while ((row = parser.parseNext()) != null) {
+					parseOneLine(columns, tableName, row, false, null);
+				}
+			} finally {
+				parser.stopParsing();
+			}
+
+		}
+
+		RouteResultset rrs = buildResultSet(routeResultMap);
+		if (rrs != null) {
+			flushDataToFile();
+			serverConnection.getSession2().execute(rrs,
+					ServerParse.LOAD_DATA_INFILE_SQL);
+		}
+
+		// sendOk(++packID);
+
+	}
+
+	private void parseFileByLine(String file, String encode, String split) {
+		List<SQLExpr> columns = statement.getColumns();
+		CsvParserSettings settings = new CsvParserSettings();
+		settings.setMaxColumns(65535);
+		settings.setMaxCharsPerColumn(65535);
+		settings.getFormat().setLineSeparator(loadData.getLineTerminatedBy());
+		settings.getFormat().setDelimiter(
+				loadData.getFieldTerminatedBy().charAt(0));
+		if (loadData.getEnclose() != null) {
+			settings.getFormat().setQuote(loadData.getEnclose().charAt(0));
+		}
+		if (loadData.getEscape() != null) {
+			settings.getFormat().setQuoteEscape(loadData.getEscape().charAt(0));
+		}
+		settings.getFormat().setNormalizedNewline(
+				loadData.getLineTerminatedBy().charAt(0));
+		/*
+		 * fix #1074 : LOAD DATA local INFILE导入的所有Boolean类型全部变成了false
+		 * 不可见字符将在CsvParser被当成whitespace过滤掉, 使用settings.trimValues(false)来避免被过滤掉
+		 * TODO : 设置trimValues(false)之后, 会引起字段值前后的空白字符无法被过滤!
+		 */
+		settings.trimValues(false);
+		CsvParser parser = new CsvParser(settings);
+		InputStreamReader reader = null;
+		FileInputStream fileInputStream = null;
+		try {
+
+			fileInputStream = new FileInputStream(file);
+			reader = new InputStreamReader(fileInputStream, encode);
+			parser.beginParsing(reader);
+			String[] row = null;
+
+			while ((row = parser.parseNext()) != null) {
+				parseOneLine(columns, tableName, row, true,
+						loadData.getLineTerminatedBy());
+			}
+
+		} catch (FileNotFoundException | UnsupportedEncodingException e) {
+			throw new RuntimeException(e);
+		} finally {
+			parser.stopParsing();
+			if (fileInputStream != null) {
+				try {
+					fileInputStream.close();
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+			if (reader != null) {
+				try {
+					reader.close();
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+
+		}
+
+	}
+
+	public void clear() {
+		isStartLoadData = false;
+		tableId2DataNodeCache = null;
+		schema = null;
+		tableConfig = null;
+		isHasStoreToFile = false;
+		packID = 0;
+		tempByteBuffrSize = 0;
+		tableName = null;
+		partitionColumnIndex = -1;
+		if (tempFile != null) {
+			File temp = new File(tempFile);
+			if (temp.exists()) {
+				temp.delete();
+			}
+		}
+		if (tempPath != null && new File(tempPath).exists()) {
+			deleteFile(tempPath);
+		}
+		tempByteBuffer = null;
+		loadData = null;
+		sql = null;
+		fileName = null;
+		statement = null;
+		routeResultMap.clear();
+	}
+
+	@Override
+	public byte getLastPackId() {
+		return packID;
+	}
+
+	@Override
+	public boolean isStartLoadData() {
+		return isStartLoadData;
+	}
+
+	private String getPartitionColumn() {
+		String pColumn;
+		if (tableConfig.isSecondLevel()
+				&& tableConfig.getParentTC().getPartitionColumn()
+						.equals(tableConfig.getParentKey())) {
+			pColumn = tableConfig.getJoinKey();
+		} else {
+			pColumn = tableConfig.getPartitionColumn();
+		}
+		return pColumn;
+	}
+
+	/**
+	 * 删除目录及其所有子目录和文件
+	 *
+	 * @param dirPath
+	 *            要删除的目录路径
+	 * @throws Exception
+	 */
+	private static void deleteFile(String dirPath) {
+		File fileDirToDel = new File(dirPath);
+		if (!fileDirToDel.exists()) {
+			return;
+		}
+		if (fileDirToDel.isFile()) {
+			fileDirToDel.delete();
+			return;
+		}
+		File[] fileList = fileDirToDel.listFiles();
+
+		for (int i = 0; i < fileList.length; i++) {
+			File file = fileList[i];
+			if (file.isFile() && file.exists()) {
+				boolean delete = file.delete();
+			} else if (file.isDirectory()) {
+				deleteFile(file.getAbsolutePath());
+				file.delete();
+			}
+		}
+		fileDirToDel.delete();
+	}
 
 }


### PR DESCRIPTION
2、优化对ER字表多multiment支持。
   支持 
   insert into er_table (字段列表) values (值列表);
   insert into er_table (字段列表) values (值列表);
  该语句应用场景比较常见，比如订单表与订单选项，我们利用mybatis时，可以利用多mulit
statment一次插入一个集合。例如DAO部分的声明：
  void addOrderItem(Integer orderID，List<OrderItem> items);