### PR TITLE
解决Java高编译低运行错误(ConcurrentHashMap.keySet)

### DIFF
--- a/src/main/java/io/mycat/config/Versions.java
+++ b/src/main/java/io/mycat/config/Versions.java
@@ -31,7 +31,7 @@ public abstract class Versions {
     /**协议版本**/
     public static final byte PROTOCOL_VERSION = 10;
 
-    /**服务器版�?**/
+    /**服务器版本**/
     public static byte[] SERVER_VERSION = "5.6.29-mycat-1.6.5-BETA-20170424174212".getBytes();
 
     public static void setServerVersion(String version) {
@@ -42,7 +42,7 @@ public abstract class Versions {
                 break;
         }
 
-        // 重新拼接mycat version字节数组
+        // 閲嶆柊鎷兼帴mycat version瀛楄妭鏁扮粍
         byte[] newMycatVersion = new byte[mysqlVersionPart.length + SERVER_VERSION.length - startIndex];
         System.arraycopy(mysqlVersionPart, 0, newMycatVersion, 0, mysqlVersionPart.length);
         System.arraycopy(SERVER_VERSION, startIndex, newMycatVersion, mysqlVersionPart.length,

--- a/src/main/java/io/mycat/config/Versions.java
+++ b/src/main/java/io/mycat/config/Versions.java
@@ -42,7 +42,7 @@ public abstract class Versions {
                 break;
         }
 
-        // 閲嶆柊鎷兼帴mycat version瀛楄妭鏁扮粍
+        // 生成mycat version信息
         byte[] newMycatVersion = new byte[mysqlVersionPart.length + SERVER_VERSION.length - startIndex];
         System.arraycopy(mysqlVersionPart, 0, newMycatVersion, 0, mysqlVersionPart.length);
         System.arraycopy(SERVER_VERSION, startIndex, newMycatVersion, mysqlVersionPart.length,


### PR DESCRIPTION
1.Java高编译低运行错误(ConcurrentHashMap.keySet)，如果jdk1.8编译mycat,用jdk1.7去执行则会出现java.lang.NoSuchMethodError: java.util.concurrent.ConcurrentHashMap.keySet() 
Ljava/util/concurrent/ConcurrentHashMap$KeySetView;错误，改为noblockingsession类统一使用concurrentMap接口，避免出现jdk版本不一致导致的错误。
2.服务器上version.java中文字是乱码，改为中文