### PR TITLE
修复 存在sql 改写的情况下,路由缓存可能缓存的结果不对的问题.  

### DIFF
--- a/src/main/java/io/mycat/backend/mysql/nio/handler/MiddlerQueryResultHandler.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/handler/MiddlerQueryResultHandler.java
@@ -36,7 +36,7 @@ public class MiddlerQueryResultHandler<T> implements MiddlerResultHandler<T> {
 	}
 	@Override
 	public void add(T t ) {
- 		reusult.add(new SQLCharExpr(t.toString()));
+ 		reusult.add(new SQLCharExpr(t==null?null:t.toString()));
  	}	 
 	 
 	@Override

--- a/src/main/java/io/mycat/backend/mysql/nio/handler/MultiNodeQueryHandler.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/handler/MultiNodeQueryHandler.java
@@ -499,19 +499,21 @@ public class MultiNodeQueryHandler extends MultiNodeHandler implements LoadDataR
 			}
 			//huangyiming add  中间过程缓存起来,isMiddleResultDone是确保合并部分执行完成后才会执行secondExecute
 			MiddlerResultHandler middlerResultHandler = source.getSession2().getMiddlerResultHandler();
- 			if(null != middlerResultHandler ){
-			    buffer.flip();
-                byte[] data = new byte[buffer.limit()];
-                buffer.get(data);
-                buffer.clear();
-                //如果该操作只是一个中间过程则把结果存储起来
-				 String str =  ResultSetUtil.getColumnValAsString(data, fields, 0);
-				 //真的需要数据合并的时候才合并
-				 if(rrs.isHasAggrColumn()){
-					 middlerResultHandler.getResult().clear();
-					 middlerResultHandler.add(str);	
-				 }
-				 isMiddleResultDone.set(false);
+ 			if(null != middlerResultHandler){
+ 				if(buffer.position() > 0){
+ 					buffer.flip();
+ 	                byte[] data = new byte[buffer.limit()];
+ 	                buffer.get(data);
+ 	                buffer.clear();
+ 	                //如果该操作只是一个中间过程则把结果存储起来
+ 					 String str =  ResultSetUtil.getColumnValAsString(data, fields, 0);
+ 					 //真的需要数据合并的时候才合并
+ 					 if(rrs.isHasAggrColumn()){
+ 						 middlerResultHandler.getResult().clear();
+ 						 middlerResultHandler.add(str);	
+ 					 }
+ 				}
+				isMiddleResultDone.set(false);
 		}else{
 			ByteBuffer byteBuffer = source.writeToBuffer(eof, buffer);
 			

--- a/src/main/java/io/mycat/route/RouteService.java
+++ b/src/main/java/io/mycat/route/RouteService.java
@@ -140,7 +140,6 @@ public class RouteService {
 		}
 
 		if (rrs != null && sqlType == ServerParse.SELECT && rrs.isCacheAble()) {
-			cacheKey = schema.getName() + rrs.getStatement();  //存在sql 改写的情况下,路由缓存可能缓存的结果不对,这里重新回去执行的sql
 			sqlRouteCache.putIfAbsent(cacheKey, rrs);
 		}
 		checkMigrateRule(schema.getName(),rrs,sqlType);

--- a/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
@@ -11,19 +11,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLExprImpl;
 import com.alibaba.druid.sql.ast.SQLObject;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLAllExpr;
+import com.alibaba.druid.sql.ast.expr.SQLAnyExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
 import com.alibaba.druid.sql.ast.expr.SQLExistsExpr;
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import com.alibaba.druid.sql.ast.expr.SQLInListExpr;
 import com.alibaba.druid.sql.ast.expr.SQLInSubQueryExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
 import com.alibaba.druid.sql.ast.expr.SQLListExpr;
+import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
 import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.alibaba.druid.sql.ast.expr.SQLSomeExpr;
 import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
 import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
+import com.alibaba.druid.sql.ast.statement.SQLSelectGroupByClause;
+import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import com.alibaba.druid.sql.ast.statement.SQLTableSource;
@@ -34,6 +44,7 @@ import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
 import com.alibaba.druid.sql.parser.SQLStatementParser;
 import com.google.common.base.Strings;
+import java.lang.Number;
 
 import io.mycat.MycatServer;
 import io.mycat.backend.mysql.nio.handler.MiddlerQueryResultHandler;
@@ -140,6 +151,7 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
                     }
                 }
             }
+            index++;
         }
 		}
 		
@@ -152,20 +164,26 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 			int subQuerySize = visitor.getSubQuerys().size();
 			if(subQuerySize==0&&ctx.getTables().size()==2){ //两表关联,考虑使用catlet
 			    if(ctx.getVisitor().getConditions() !=null && ctx.getVisitor().getConditions().size()>0){
+			    	rrs.setCacheAble(false);
 			    	return catletRoute(schema,ctx.getSql(),charset,sc);
 				}
 			}else if(subQuerySize==1){     //只涉及一张表的子查询,使用  MiddlerResultHandler 获取中间结果后,改写原有 sql 继续执行 TODO 后期可能会考虑多个子查询的情况.
 				SQLSelect sqlselect = visitor.getSubQuerys().get(0);
 				if((sqlselect.getParent() instanceof SQLQueryExpr 
 						&&sqlselect.getParent().getParent() instanceof MySqlSelectQueryBlock)
-					||sqlselect.getParent() instanceof SQLExistsExpr){
+					||sqlselect.getParent() instanceof SQLExistsExpr
+					||!visitor.getRelationships().isEmpty()
+					||sqlselect.getParent() instanceof SQLSomeExpr
+					||sqlselect.getParent() instanceof SQLAllExpr
+					||sqlselect.getParent() instanceof SQLAnyExpr){
 					return directRoute(rrs,ctx,schema,druidParser,statement,cachePool);
+				}else{
+					SQLSelectQuery sqlSelectQuery = sqlselect.getQuery();
+					if(((MySqlSelectQueryBlock)sqlSelectQuery).getFrom() instanceof SQLExprTableSource) {
+						rrs.setCacheAble(false);
+						return middlerResultRoute(schema,charset,sqlselect,sqlType,statement,sc);
+					}
 				}
-				SQLSelectQuery sqlSelectQuery = sqlselect.getQuery();
-				if(((MySqlSelectQueryBlock)sqlSelectQuery).getFrom() instanceof SQLExprTableSource) {
-					return middlerResultRoute(schema,charset,sqlselect,sqlType,statement,sc);
-				}
-				
 			}
 		}
 		return directRoute(rrs,ctx,schema,druidParser,statement,cachePool);
@@ -239,14 +257,20 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 	 * @return
 	 */
 	private String buildSql(SQLStatement statement,SQLSelect sqlselect,List param){
+		
 		SQLObject parent = sqlselect.getParent();
+		
 		if(parent instanceof SQLInSubQueryExpr){
-			SQLInListExpr inlistExpr = new SQLInListExpr();
-			inlistExpr.setTargetList(param);
-			inlistExpr.setExpr(((SQLInSubQueryExpr)parent).getExpr());
-			inlistExpr.setNot(((SQLInSubQueryExpr)parent).isNot());
-			inlistExpr.setParent(sqlselect.getParent());
-//			((SQLInSubQueryExpr)parent).setSubQuery(inlistExpr);
+			SQLExprImpl inlistExpr = null;
+			if(null==param||param.isEmpty()){
+				inlistExpr = getEmptyExpr(parent);
+			}else{
+				inlistExpr = new SQLInListExpr();
+				((SQLInListExpr)inlistExpr).setTargetList(param);
+				((SQLInListExpr)inlistExpr).setExpr(((SQLInSubQueryExpr)parent).getExpr());
+				((SQLInListExpr)inlistExpr).setNot(((SQLInSubQueryExpr)parent).isNot());
+				((SQLInListExpr)inlistExpr).setParent(sqlselect.getParent());
+			}
 			if(parent.getParent() instanceof MySqlSelectQueryBlock){
 				((MySqlSelectQueryBlock)parent.getParent()).setWhere(inlistExpr);
 			}else if(parent.getParent() instanceof SQLBinaryOpExpr){
@@ -258,37 +282,59 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 				}
 			}
 		}else if(parent instanceof SQLBinaryOpExpr){
-			SQLInListExpr inlistExpr = new SQLInListExpr();
-			inlistExpr.setTargetList(param);
 			SQLBinaryOpExpr pp = (SQLBinaryOpExpr)parent;
 			if(pp.getLeft() instanceof SQLQueryExpr){
 				SQLQueryExpr left = (SQLQueryExpr)pp.getLeft();
 				if(left.getSubQuery().equals(sqlselect)){
-					inlistExpr.setExpr(pp.getRight());
-					inlistExpr.setParent(left.getParent());
-					pp.setLeft(inlistExpr);
+					SQLExprImpl listExpr = null;
+					if(null==param||param.isEmpty()){
+						listExpr = getEmptyExpr(parent);
+					}else{
+						listExpr = new SQLListExpr();
+						listExpr.setParent(left.getParent());
+						((SQLListExpr)listExpr).getItems().addAll(param);
+					}
+					pp.setLeft(listExpr);
 				}
 			}else if(pp.getRight() instanceof SQLQueryExpr){
 				SQLQueryExpr right = (SQLQueryExpr)pp.getRight();
 				if(right.getSubQuery().equals(sqlselect)){
-					inlistExpr.setExpr(pp.getLeft());
-					inlistExpr.setParent(right.getParent());
-					pp.setRight(inlistExpr);
+					SQLExprImpl listExpr = null;
+					if(null==param||param.isEmpty()){
+						listExpr = getEmptyExpr(parent);
+					}else{
+						listExpr = new SQLListExpr();
+						listExpr.setParent(right.getParent());
+						((SQLListExpr)listExpr).getItems().addAll(param);
+					}
+					pp.setRight(listExpr);
 					
 				}
 			}else if(pp.getLeft() instanceof SQLInSubQueryExpr){
 				SQLInSubQueryExpr left = (SQLInSubQueryExpr)pp.getLeft();
 				if(left.getSubQuery().equals(sqlselect)){
-					inlistExpr.setExpr(pp.getRight());
-					inlistExpr.setNot(left.isNot());
-					inlistExpr.setParent(left.getParent());
+					SQLExprImpl inlistExpr = null;
+					if(null==param||param.isEmpty()){
+						inlistExpr = getEmptyExpr(parent);
+					}else{
+						inlistExpr = new SQLInListExpr();
+						((SQLInListExpr)inlistExpr).setTargetList(param);
+						((SQLInListExpr)inlistExpr).setExpr(pp.getRight());
+						((SQLInListExpr)inlistExpr).setNot(left.isNot());
+						((SQLInListExpr)inlistExpr).setParent(left.getParent());
+					}
 					pp.setLeft(inlistExpr);
 				}
 			}else if(pp.getRight() instanceof SQLInSubQueryExpr){
 				SQLInSubQueryExpr right = (SQLInSubQueryExpr)pp.getRight();
 				if(right.getSubQuery().equals(sqlselect)){
-					SQLListExpr listExpr = new SQLListExpr();
-					listExpr.getItems().addAll(param);
+					SQLExprImpl listExpr = null;
+					if(null==param||param.isEmpty()){
+						listExpr = getEmptyExpr(parent);
+					}else{
+						listExpr = new SQLListExpr();
+						((SQLListExpr)listExpr).getItems().addAll(param);
+					}
 					pp.setRight(listExpr);
 					
 				}
@@ -296,17 +342,55 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 		}else if(parent instanceof SQLQueryExpr){
 			if(parent.getParent() instanceof SQLBinaryOpExpr){
 				SQLBinaryOpExpr pp = (SQLBinaryOpExpr)parent.getParent();
-				SQLListExpr listExpr = new SQLListExpr();
-				listExpr.getItems().addAll(param);
+				SQLExprImpl listExpr = null;
+				if(null==param||param.isEmpty()){
+					listExpr = getEmptyExpr(parent);
+				}else{
+					listExpr = new SQLListExpr();
+					((SQLListExpr)listExpr).getItems().addAll(param);
+				}
 				if(pp.getLeft().equals(parent)){
 					pp.setLeft(listExpr);
 				}else if(pp.getRight().equals(parent)){
 					pp.setRight(listExpr);
 				}
+			}else if(parent.getParent() instanceof SQLSelectItem){
+				SQLSelectItem pp = (SQLSelectItem)parent.getParent();
+				SQLExprImpl listExpr = null;
+				if(null==param||param.isEmpty()){
+					listExpr = getEmptyExpr(parent);
+				}else{
+					listExpr = new SQLListExpr();
+					((SQLListExpr)listExpr).getItems().addAll(param);
+				}
+				pp.setExpr(listExpr);
+			}else if(parent.getParent() instanceof SQLSelectGroupByClause){
+				SQLSelectGroupByClause pp = (SQLSelectGroupByClause)parent.getParent();
+				
+				List<SQLExpr> items = pp.getItems();
+				for(int i=0;i<items.size();i++){
+					SQLExpr expr = items.get(i);
+					if(expr instanceof SQLQueryExpr 
+							&&((SQLQueryExpr)expr).getSubQuery().equals(sqlselect)){
+						
+						SQLExprImpl listExpr = null;
+						if(null==param||param.isEmpty()){
+							listExpr = getEmptyExpr(parent);
+						}else{
+							listExpr = new SQLListExpr();
+							((SQLListExpr)listExpr).getItems().addAll(param);
+						}
+						items.set(i, listExpr);
+					}
+				}
 			}
 
 		}
 		return statement.toString();
+	}
+	
+	private SQLExprImpl getEmptyExpr(SQLObject parent){
+		return new SQLNullExpr();
 	}
 	
 	

--- a/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
@@ -34,6 +34,7 @@ import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.ast.statement.SQLSelectGroupByClause;
 import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
+import com.alibaba.druid.sql.ast.statement.SQLSelectOrderByItem;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import com.alibaba.druid.sql.ast.statement.SQLTableSource;
@@ -246,6 +247,10 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 			sc.writeErrMessage(ErrorCode.ER_PARSE_ERROR, msg == null ? e.getClass().getSimpleName() : msg);
 			return null;
 		}
+		
+		if(rrs!=null){
+			rrs.setCacheAble(false);
+		}
 		return rrs;
 	}
 	
@@ -383,6 +388,17 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 						items.set(i, listExpr);
 					}
 				}
+			}else if(parent.getParent() instanceof SQLSelectOrderByItem){
+				SQLSelectOrderByItem orderItem = (SQLSelectOrderByItem)parent.getParent();
+				SQLExprImpl listExpr = null;
+				if(null==param||param.isEmpty()){
+					listExpr = getEmptyExpr(parent);
+				}else{
+					listExpr = new SQLListExpr();
+					((SQLListExpr)listExpr).getItems().addAll(param);
+				}
+				listExpr.setParent(orderItem);
+				orderItem.setExpr(listExpr);
 			}
 
 		}

--- a/src/main/java/io/mycat/route/parser/druid/MycatSchemaStatVisitor.java
+++ b/src/main/java/io/mycat/route/parser/druid/MycatSchemaStatVisitor.java
@@ -34,6 +34,7 @@ import com.alibaba.druid.sql.ast.statement.SQLSelect;
 import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlCreateTableStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlDeleteStatement;
@@ -290,6 +291,15 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
     @Override
     public boolean visit(SQLQueryExpr x) {
     	subQuerys.add(x.getSubQuery());
+    	return super.visit(x);
+    }
+    /*
+     * (non-Javadoc)
+     * @see com.alibaba.druid.sql.visitor.SchemaStatVisitor#visit(com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource)
+     */
+    @Override
+    public boolean visit(SQLSubqueryTableSource x){
+    	subQuerys.add(x.getSelect());
     	return super.visit(x);
     }
     

--- a/src/test/java/io/mycat/route/TestSelectBetweenSqlParser.java
+++ b/src/test/java/io/mycat/route/TestSelectBetweenSqlParser.java
@@ -1,5 +1,6 @@
 package io.mycat.route;
 
+import java.io.IOException;
 import java.sql.SQLNonTransientException;
 import java.util.Map;
 
@@ -15,6 +16,7 @@ import io.mycat.config.loader.xml.XMLSchemaLoader;
 import io.mycat.config.model.SchemaConfig;
 import io.mycat.config.model.SystemConfig;
 import io.mycat.route.factory.RouteStrategyFactory;
+import io.mycat.server.ServerConnection;
 
 /**
  * 修改内容
@@ -32,10 +34,11 @@ public class TestSelectBetweenSqlParser {
 		SchemaLoader schemaLoader = new XMLSchemaLoader(schemaFile, ruleFile);
 		schemaMap = schemaLoader.getSchemas();
 		MycatServer.getInstance().getConfig().getSchemas().putAll(schemaMap);
+		RouteStrategyFactory.init();
 	}
 
 	@Test
-	public void testBetweenSqlRoute() throws SQLNonTransientException {
+	public void testBetweenSqlRoute() throws SQLNonTransientException, IOException {
 		String sql = "select * from offer_detail where offer_id between 1 and 33";
 		SchemaConfig schema = schemaMap.get("cndb");
 		RouteResultset rrs = RouteStrategyFactory.getRouteStrategy().route(new SystemConfig(),schema, -1, sql, null,
@@ -57,9 +60,10 @@ public class TestSelectBetweenSqlParser {
 //		sql = "select a.* from offer_detail a join offer_date b on a.id=b.id " +
 //				"where b.col_date = '2014-04-02' and col_1 = 33 and offer_id =1";
 		schema = schemaMap.get("cndb");
-		rrs = RouteStrategyFactory.getRouteStrategy().route(new SystemConfig(),schema, -1, sql, null,
-				null, cachePool);
-		Assert.assertEquals(2, rrs.getNodes().length);    //这里2个表都有条件路由，取的是交集
+		// 两个路由规则不一样的表现在 走catlet. 不再取交集, catlet 测试时需要前端连接.这里注释掉.
+//		rrs = RouteStrategyFactory.getRouteStrategy().route(new SystemConfig(),schema, -1, sql, null,
+//				null, cachePool);
+//		Assert.assertEquals(2, rrs.getNodes().length);    //这里2个表都有条件路由，取的是交集, 
 		
 		//确认大于小于操作符
 		sql = "select b.* from  offer_date b " +


### PR DESCRIPTION
1. 修复 存在sql 改写的情况下,路由缓存可能缓存的结果不对的问题. 
    思路为,如果sql 需要改写,或拆分,不直接做缓存.缓存拆分后的sql.
2. 修复 存在子查询，并且子查询先执行的情况下,如果子查询没有返回结果.报空指针的问题.
3. 如果子查询为 =some,=any,=all  不改写sql时,走直接路由的方式.