### PR TITLE
Update init_zk_data.sh with smarter JAVA and $MYCAT_HOME searching

### DIFF
--- a/src/main/assembly/bin/init_zk_data.sh
+++ b/src/main/assembly/bin/init_zk_data.sh
@@ -7,8 +7,8 @@ JAVA_CMD=""
 
 #function log_info <msg>
 #stdout: YYYY-mm-dd HH:MM:ss INFO msg
-function log_info() { date +o"%F %T INFO $1" }
-function log_error() { date +o"%F %T ERROR $1" }
+function log_info() { date +o"%F %T INFO $1" ; }
+function log_error() { date +o"%F %T ERROR $1" ; }
 
 #01. Locate java(JRE)
 java_in_wrapper="`sed -nr \
@@ -17,9 +17,10 @@ java_in_wrapper="`sed -nr \
 
 # test java(JRE) in this order: 
 #  wrapper.conf's java -> $JAVA_HOME/bin/java -> $PATH/java
-while java_cmd in ("$JAVA_CMD" "$JAVA_HOME/bin/java" "java") ; do
+for java_cmd in "$JAVA_CMD" "$JAVA_HOME/bin/java" "java" ; do
 	if $java_cmd -Xmx1m -version &>/dev/null ; then
 		JAVA_CMD=$java_cmd
+		break
 	fi
 done
 

--- a/src/main/assembly/bin/init_zk_data.sh
+++ b/src/main/assembly/bin/init_zk_data.sh
@@ -17,7 +17,7 @@ java_in_wrapper="`sed -nr \
 
 # test java(JRE) in this order: 
 #  wrapper.conf's java -> $JAVA_HOME/bin/java -> $PATH/java
-for java_cmd in "$JAVA_CMD" "$JAVA_HOME/bin/java" "java" ; do
+for java_cmd in "$java_in_wrapper" "$JAVA_HOME/bin/java" "java" ; do
 	if $java_cmd -Xmx1m -version &>/dev/null ; then
 		JAVA_CMD=$java_cmd
 		break

--- a/src/main/assembly/bin/init_zk_data.sh
+++ b/src/main/assembly/bin/init_zk_data.sh
@@ -1,19 +1,46 @@
 #!/bin/bash
 
-echo "check JAVA_HOME & java"
-JAVA_CMD=$JAVA_HOME/bin/java
+MYCAT_HOME="$(dirname `readlink -f $0`)/.."
 MAIN_CLASS=io.mycat.config.loader.zkprocess.xmltozk.XmltoZkMain
-if [ ! -d "$JAVA_HOME" ]; then
-    echo ---------------------------------------------------
-    echo WARN: JAVA_HOME environment variable is not set. 
-    echo ---------------------------------------------------
-    JAVA_CMD=java
+
+JAVA_CMD=""
+
+#function log_info <msg>
+#stdout: YYYY-mm-dd HH:MM:ss INFO msg
+function log_info() { date +o"%F %T INFO $1" }
+function log_error() { date +o"%F %T ERROR $1" }
+
+#01. Locate java(JRE)
+java_in_wrapper="`sed -nr \
+	-e 's/^wrapper.java.command=(.*)[[:blank:]]*$/\1/p' \
+	$MYCAT_HOME/conf/wrapper.conf`"
+
+# test java(JRE) in this order: 
+#  wrapper.conf's java -> $JAVA_HOME/bin/java -> $PATH/java
+while java_cmd in ("$JAVA_CMD" "$JAVA_HOME/bin/java" "java") ; do
+	if $java_cmd -Xmx1m -version &>/dev/null ; then
+		JAVA_CMD=$java_cmd
+	fi
+done
+
+if [ "$JAVA_CMD" == "" ]; then
+	cat <<EOF
+`date +'%F %T'` ERROR Not found usable java in following path:
+$java_in_wrapper, $JAVA_HOME/bin/java, \$PATH/java
+Operations would not going on.
+EOF
+	exit 1
 fi
 
-echo "---------set HOME_DIR------------"
-CURR_DIR=`pwd`
-cd ..
-MYCAT_HOME=`pwd`
-cd $CURR_DIR
-$JAVA_CMD -Xms256M -Xmx1G -XX:MaxPermSize=64M  -DMYCAT_HOME=$MYCAT_HOME -cp "$MYCAT_HOME/conf:$MYCAT_HOME/lib/*" $MAIN_CLASS
-echo "---------finished------------"
+log_info "JAVA_CMD=$JAVA_CMD"
+
+#02. Initialize /mycat of ZooKeeper
+log_info "Start to initialize /mycat of ZooKeeper"
+
+if ! $JAVA_CMD -Xms256M -Xmx1G  -DMYCAT_HOME=$MYCAT_HOME -cp "$MYCAT_HOME/conf:$MYCAT_HOME/lib/*" $MAIN_CLASS ; then
+	log_error "Something wrong happened, please refer logs above"
+	exit 1
+fi
+
+log_info "Done"
+exit 0


### PR DESCRIPTION
1. [修改] $JAVA_HOME判断逻辑有缺陷，改为直接尝试运行搜索路径下的java是否成功
2. [新增] java搜索路径增加为：$MYCAT/conf/wrapper.conf里的wrapper.java.command -> $JAVA_HOME/bin/java -> $PATH/java
3. [修改] $MYCAT_HOME路径不在以用户当前所处目录为基准，而以init_zk_data.sh脚本的所在目录的父目录作为基准
4. [新增] 无论用户所处当前目录在哪儿，init_zk_data.sh均可以安全调用了