### PR TITLE
子查询完善

### DIFF
--- a/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
@@ -175,12 +175,10 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 			    	return catletRoute(schema,ctx.getSql(),charset,sc);
 				}
 			}else if(subQuerySize==1){     //只涉及一张表的子查询,使用  MiddlerResultHandler 获取中间结果后,改写原有 sql 继续执行 TODO 后期可能会考虑多个子查询的情况.
-				SQLSelect sqlselect = visitor.getSubQuerys().get(0);
-				if((sqlselect.getParent() instanceof SQLQueryExpr 
-						&&sqlselect.getParent().getParent() instanceof MySqlSelectQueryBlock)
-					||sqlselect.getParent() instanceof SQLExistsExpr
+				SQLSelect sqlselect = visitor.getSubQuerys().iterator().next();
+				if(sqlselect.getParent() instanceof SQLExistsExpr
 					||!visitor.getRelationships().isEmpty()
-					||sqlselect.getParent() instanceof SQLSomeExpr
+					||sqlselect.getParent() instanceof SQLSomeExpr  /* 如果 some,all,any 没有被改写 直接路由  */
 					||sqlselect.getParent() instanceof SQLAllExpr
 					||sqlselect.getParent() instanceof SQLAnyExpr){
 					return directRoute(rrs,ctx,schema,druidParser,statement,cachePool);
@@ -407,6 +405,19 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 				}
 				listExpr.setParent(orderItem);
 				orderItem.setExpr(listExpr);
+			}else if(parent.getParent() instanceof MySqlSelectQueryBlock){
+				MySqlSelectQueryBlock query = (MySqlSelectQueryBlock)parent.getParent();
+				// select * from subtest1 a where (select 1 from subtest3); 这种情况会进入到当前分支.
+				// 改写为   select * from subtest1 a where (1); 或  select * from subtest1 a where (null);
+				SQLExprImpl listExpr = null;
+				if(null==param||param.isEmpty()){
+					listExpr = getEmptyExpr(parent);
+				}else{
+					listExpr = new SQLListExpr();
+					((SQLListExpr)listExpr).getItems().addAll(param);
+				}
+				listExpr.setParent(query);
+				query.setWhere(listExpr);
 			}
 
 		}

--- a/src/main/java/io/mycat/route/parser/druid/impl/DruidSelectParser.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/DruidSelectParser.java
@@ -303,7 +303,7 @@ public class DruidSelectParser extends DefaultDruidParser {
 		    	return true;
 			}
 		}else if(subQuerySize==1){     //只涉及一张表的子查询,使用  MiddlerResultHandler 获取中间结果后,改写原有 sql 继续执行 TODO 后期可能会考虑多个.
-			SQLSelectQuery sqlSelectQuery = visitor.getSubQuerys().get(0).getQuery();
+			SQLSelectQuery sqlSelectQuery = visitor.getSubQuerys().iterator().next().getQuery();
 			if(((MySqlSelectQueryBlock)sqlSelectQuery).getFrom() instanceof SQLExprTableSource) {
 				return true;
 			}


### PR DESCRIPTION
1.修复 类似 select * from subtest1 a where (select max(id) from subtest3) or a.id= 1; where条件子句中带有or 条件时,子查询直接路由的问题.
2.修复 类似 select * from subtest1 a where (select max(id) from subtest3) where子句中 只有一个 子查询时,子查询直接路由的问题.
           select * from subtest1 a where a.id in (select id from subtest3) 语句正常.
以上两个问题,修改为先执行子查询,获取返回结果，与主查询合并后,再执行.
3. 将 =some,=any 改写为 in 语句.=all 不做改写,直接路由.