### PR TITLE
修复,XA事务 涉及到一个mysql实例中多个数据库时,执行报错的问题.

### DIFF
--- a/src/main/java/io/mycat/backend/mysql/nio/MySQLConnection.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/MySQLConnection.java
@@ -388,7 +388,7 @@ public class MySQLConnection extends BackendAIOConnection {
 		if (!modifiedSQLExecuted && rrn.isModifySQL()) {
 			modifiedSQLExecuted = true;
 		}
-		String xaTXID = sc.getSession2().getXaTXID();
+		String xaTXID = sc.getSession2().getXaTXID()+",'"+getSchema()+"'";
 		synAndDoExecute(xaTXID, rrn, sc.getCharsetIndex(), sc.getTxIsolation(),
 				autocommit);
 	}
@@ -419,7 +419,7 @@ public class MySQLConnection extends BackendAIOConnection {
 		}
 		int txIsoLationSyn = (txIsolation == clientTxIsoLation) ? 0 : 1;
 		int autoCommitSyn = (conAutoComit == expectAutocommit) ? 0 : 1;
-		int synCount = schemaSyn + charsetSyn + txIsoLationSyn + autoCommitSyn;
+		int synCount = schemaSyn + charsetSyn + txIsoLationSyn + autoCommitSyn + (xaCmd!=null?1:0);
 		if (synCount == 0 && this.xaStatus != TxState.TX_STARTED_STATE) {
 			// not need syn connection
 			sendQueryCmd(rrn.getStatement());

--- a/src/main/java/io/mycat/backend/mysql/nio/handler/CommitNodeHandler.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/handler/CommitNodeHandler.java
@@ -61,7 +61,7 @@ public class CommitNodeHandler implements ResponseHandler {
 		   MySQLConnection mysqlCon = (MySQLConnection) conn;
 		   if (mysqlCon.getXaStatus() == 1)
 		   {
-			   String xaTxId = session.getXaTXID();
+			   String xaTxId = session.getXaTXID()+",'"+mysqlCon.getSchema()+"'";
 			   String[] cmds = new String[]{"XA END " + xaTxId,
 					   "XA PREPARE " + xaTxId};
 			   mysqlCon.execBatchCmd(cmds);
@@ -91,7 +91,7 @@ public class CommitNodeHandler implements ResponseHandler {
 				case 1:
 					if (mysqlCon.batchCmdFinished())
 					{
-						String xaTxId = session.getXaTXID();
+						String xaTxId = session.getXaTXID()+",'"+mysqlCon.getSchema()+"'";
 						mysqlCon.execCmd("XA COMMIT " + xaTxId);
 						mysqlCon.setXaStatus(TxState.TX_PREPARED_STATE);
 					}

--- a/src/main/java/io/mycat/backend/mysql/nio/handler/MultiNodeCoordinator.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/handler/MultiNodeCoordinator.java
@@ -59,7 +59,7 @@ public class MultiNodeCoordinator implements ResponseHandler {
 				conn.setResponseHandler(this);
 				//process the XA_END XA_PREPARE Command
 				MySQLConnection mysqlCon = (MySQLConnection) conn;
-				String xaTxId = session.getXaTXID();
+				String xaTxId = session.getXaTXID() +",'"+ mysqlCon.getSchema()+"'";
 				if (mysqlCon.getXaStatus() == TxState.TX_STARTED_STATE)
 				{
 					//recovery Log
@@ -122,6 +122,7 @@ public class MultiNodeCoordinator implements ResponseHandler {
 			MySQLConnection mysqlCon = (MySQLConnection) conn;
 			String xaTxId = session.getXaTXID();
 			if (xaTxId != null) {
+				xaTxId += ",'"+mysqlCon.getSchema()+"'";
 				String cmd = "XA COMMIT " + xaTxId;
 				if (LOGGER.isDebugEnabled()) {
 					LOGGER.debug("Replay Commit execute the cmd :" + cmd + ",current host:" +
@@ -161,7 +162,7 @@ public class MultiNodeCoordinator implements ResponseHandler {
 					if (mysqlCon.batchCmdFinished())
 					{
 						String xaTxId = session.getXaTXID();
-						String cmd = "XA COMMIT " + xaTxId;
+						String cmd = "XA COMMIT " + xaTxId +",'"+mysqlCon.getSchema()+"'";
 						if (LOGGER.isDebugEnabled()) {
 							LOGGER.debug("Start execute the cmd :"+cmd+",current host:"+
 									mysqlCon.getHost()+":"+mysqlCon.getPort());
@@ -174,7 +175,7 @@ public class MultiNodeCoordinator implements ResponseHandler {
 								coordinatorLogEntry.participants[i].txState = TxState.TX_PREPARED_STATE;
 							}
 						}
-						inMemoryRepository.put(session.getXaTXID(),coordinatorLogEntry);
+						inMemoryRepository.put(xaTxId,coordinatorLogEntry);
 						fileRepository.writeCheckpoint(inMemoryRepository.getAllCoordinatorLogEntries());
 
 						//send commit
@@ -192,7 +193,7 @@ public class MultiNodeCoordinator implements ResponseHandler {
 							coordinatorLogEntry.participants[i].txState = TxState.TX_COMMITED_STATE;
 						}
 					}
-					inMemoryRepository.put(session.getXaTXID(),coordinatorLogEntry);
+					inMemoryRepository.put(xaTxId,coordinatorLogEntry);
 					fileRepository.writeCheckpoint(inMemoryRepository.getAllCoordinatorLogEntries());
 
 					//XA reset status now

--- a/src/main/java/io/mycat/backend/mysql/nio/handler/RollbackNodeHandler.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/handler/RollbackNodeHandler.java
@@ -86,9 +86,9 @@ public class RollbackNodeHandler extends MultiNodeHandler {
 				//support the XA rollback
 				if(session.getXaTXID()!=null && conn instanceof  MySQLConnection) {
 					MySQLConnection mysqlCon = (MySQLConnection) conn;
-					String xaTxId = session.getXaTXID();
+					String xaTxId = session.getXaTXID() +",'"+ mysqlCon.getSchema()+"'";
 					//exeBatch cmd issue : the 2nd package can not receive the response
-					mysqlCon.execCmd("XA END " + xaTxId + ";");
+					mysqlCon.execCmd("XA END " + xaTxId  + ";");
 					mysqlCon.execCmd("XA ROLLBACK " + xaTxId + ";");
 				}else {
 					conn.rollback();

--- a/src/main/java/io/mycat/backend/postgresql/PostgreSQLBackendConnection.java
+++ b/src/main/java/io/mycat/backend/postgresql/PostgreSQLBackendConnection.java
@@ -227,7 +227,7 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 		if (!modifiedSQLExecuted && rrn.isModifySQL()) {
 			modifiedSQLExecuted = true;
 		}
-		String xaTXID = sc.getSession2().getXaTXID();
+		String xaTXID = sc.getSession2().getXaTXID()+",'"+getSchema()+"'";
 		synAndDoExecute(xaTXID, rrn, sc.getCharsetIndex(), sc.getTxIsolation(), autocommit);
 	}
 


### PR DESCRIPTION
改进思路如下：
增加从事务id的概念
从事务id= 事务id+库名.
mycat 通过事务id 控制全局事务.
借助
XA {START|BEGIN} xid: gtrid [, bqual [, formatID ]] 的 bqual 实现.

2. 修复 没有处理 xa start  xid 响应报文的问题.
   可能导致 insert  影响行数不准确的问题.

