### PR TITLE
子查询完善.及批量插入问题修复

### DIFF
--- a/src/main/java/io/mycat/MycatServer.java
+++ b/src/main/java/io/mycat/MycatServer.java
@@ -125,7 +125,7 @@ public class MycatServer {
 	private volatile int channelIndex = 0;
 
 	//全局序列号
-	private final MyCATSequnceProcessor sequnceProcessor = new MyCATSequnceProcessor();
+//	private final MyCATSequnceProcessor sequnceProcessor = new MyCATSequnceProcessor();
 	private final DynaClassLoader catletClassLoader;
 	private final SQLInterceptor sqlInterceptor;
 	private volatile int nextProcessor;
@@ -234,7 +234,7 @@ public class MycatServer {
 	}
 
 	public MyCATSequnceProcessor getSequnceProcessor() {
-		return sequnceProcessor;
+		return MyCATSequnceProcessor.getInstance();
 	}
 
 	public SQLInterceptor getSqlInterceptor() {

--- a/src/main/java/io/mycat/route/MyCATSequnceProcessor.java
+++ b/src/main/java/io/mycat/route/MyCATSequnceProcessor.java
@@ -1,66 +1,36 @@
 package io.mycat.route;
 
-import java.nio.ByteBuffer;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.mycat.MycatServer;
 import io.mycat.config.ErrorCode;
-import io.mycat.net.mysql.EOFPacket;
-import io.mycat.net.mysql.FieldPacket;
-import io.mycat.net.mysql.ResultSetHeaderPacket;
-import io.mycat.net.mysql.RowDataPacket;
 import io.mycat.route.parser.druid.DruidSequenceHandler;
-import io.mycat.server.ServerConnection;
-import io.mycat.util.StringUtil;
 
 public class MyCATSequnceProcessor {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MyCATSequnceProcessor.class);
-	private LinkedBlockingQueue<SessionSQLPair> seqSQLQueue = new LinkedBlockingQueue<SessionSQLPair>();
-	private volatile boolean running=true;
 	
-	public MyCATSequnceProcessor() {
-		new ExecuteThread().start();
+	//使用Druid解析器实现sequence处理  @兵临城下
+	private static final DruidSequenceHandler sequenceHandler = new DruidSequenceHandler(MycatServer
+			.getInstance().getConfig().getSystem().getSequnceHandlerType());
+	
+	private static class InnerMyCATSequnceProcessor{
+		private static MyCATSequnceProcessor INSTANCE = new MyCATSequnceProcessor();
+	}
+	
+	public static MyCATSequnceProcessor getInstance(){
+		return InnerMyCATSequnceProcessor.INSTANCE;
+	}
+	
+	private MyCATSequnceProcessor() {
 	}
 
-	public void addNewSql(SessionSQLPair pair) {
-		seqSQLQueue.add(pair);
-	}
-
-	private void outRawData(ServerConnection sc,String value) {
-		byte packetId = 0;
-		int fieldCount = 1;
-		ByteBuffer byteBuf = sc.allocate();
-		ResultSetHeaderPacket headerPkg = new ResultSetHeaderPacket();
-		headerPkg.fieldCount = fieldCount;
-		headerPkg.packetId = ++packetId;
-
-		byteBuf = headerPkg.write(byteBuf, sc, true);
-		FieldPacket fieldPkg = new FieldPacket();
-		fieldPkg.packetId = ++packetId;
-		fieldPkg.name = StringUtil.encode("SEQUNCE", sc.getCharset());
-		byteBuf = fieldPkg.write(byteBuf, sc, true);
-
-		EOFPacket eofPckg = new EOFPacket();
-		eofPckg.packetId = ++packetId;
-		byteBuf = eofPckg.write(byteBuf, sc, true);
-
-		RowDataPacket rowDataPkg = new RowDataPacket(fieldCount);
-		rowDataPkg.packetId = ++packetId;
-		rowDataPkg.add(StringUtil.encode(value, sc.getCharset()));
-		byteBuf = rowDataPkg.write(byteBuf, sc, true);
-		// write last eof
-		EOFPacket lastEof = new EOFPacket();
-		lastEof.packetId = ++packetId;
-		byteBuf = lastEof.write(byteBuf, sc, true);
-
-		// write buffer
-		sc.write(byteBuf);
-	}
-
-	private void executeSeq(SessionSQLPair pair) {
+	/**
+	 *  锁的粒度控制到序列级别.一个序列一把锁.
+	 *  如果是 db 方式, 可以 给 mycat_sequence表的 name 列 加索引.可以借助mysql 行级锁 提高并发 
+	 * @param pair
+	 */
+	public void executeSeq(SessionSQLPair pair) {
 		try {
 			/*// @micmiu 扩展NodeToString实现自定义全局序列号
 			NodeToString strHandler = new ExtNodeToString4SEQ(MycatServer
@@ -77,10 +47,6 @@ public class MyCATSequnceProcessor {
 				return;
 			}*/
 			
-			//使用Druid解析器实现sequence处理  @兵临城下
-			DruidSequenceHandler sequenceHandler = new DruidSequenceHandler(MycatServer
-					.getInstance().getConfig().getSystem().getSequnceHandlerType());
-			
 			String charset = pair.session.getSource().getCharset();
 			String executeSql = sequenceHandler.getExecuteSql(pair.sql,charset == null ? "utf-8":charset);
 			
@@ -89,30 +55,6 @@ public class MyCATSequnceProcessor {
 			LOGGER.error("MyCATSequenceProcessor.executeSeq(SesionSQLPair)",e);
 			pair.session.getSource().writeErrMessage(ErrorCode.ER_YES,"mycat sequnce err." + e);
 			return;
-		}
-	}
-	
-	public void shutdown(){
-		running=false;
-	}
-	
-	class ExecuteThread extends Thread {
-		
-		public ExecuteThread() {
-			setDaemon(true); // 设置为后台线程,防止throw RuntimeExecption进程仍然存在的问题
-		}
-		
-		public void run() {
-			while (running) {
-				try {
-					SessionSQLPair pair=seqSQLQueue.poll(100,TimeUnit.MILLISECONDS);
-					if(pair!=null){
-						executeSeq(pair);
-					}
-				} catch (Exception e) {
-					LOGGER.warn("MyCATSequenceProcessor$ExecutorThread",e);
-				}
-			}
 		}
 	}
 }

--- a/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
@@ -1,7 +1,9 @@
 package io.mycat.route.impl;
 
+import java.security.InvalidParameterException;
 import java.sql.SQLNonTransientException;
 import java.sql.SQLSyntaxErrorException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -13,29 +15,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.alibaba.druid.sql.SQLUtils;
-import com.alibaba.druid.sql.ast.SQLExpr;
-import com.alibaba.druid.sql.ast.SQLExprImpl;
 import com.alibaba.druid.sql.ast.SQLObject;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.expr.SQLAllExpr;
-import com.alibaba.druid.sql.ast.expr.SQLAnyExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
-import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
 import com.alibaba.druid.sql.ast.expr.SQLExistsExpr;
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
-import com.alibaba.druid.sql.ast.expr.SQLInListExpr;
 import com.alibaba.druid.sql.ast.expr.SQLInSubQueryExpr;
-import com.alibaba.druid.sql.ast.expr.SQLListExpr;
-import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
 import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
-import com.alibaba.druid.sql.ast.expr.SQLSomeExpr;
 import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
 import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelect;
-import com.alibaba.druid.sql.ast.statement.SQLSelectGroupByClause;
-import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
-import com.alibaba.druid.sql.ast.statement.SQLSelectOrderByItem;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import com.alibaba.druid.sql.ast.statement.SQLTableSource;
@@ -59,6 +50,12 @@ import io.mycat.config.model.rule.RuleConfig;
 import io.mycat.route.RouteResultset;
 import io.mycat.route.RouteResultsetNode;
 import io.mycat.route.function.SlotFunction;
+import io.mycat.route.impl.middlerResultStrategy.BinaryOpResultHandler;
+import io.mycat.route.impl.middlerResultStrategy.InSubQueryResultHandler;
+import io.mycat.route.impl.middlerResultStrategy.RouteMiddlerReaultHandler;
+import io.mycat.route.impl.middlerResultStrategy.SQLAllResultHandler;
+import io.mycat.route.impl.middlerResultStrategy.SQLExistsResultHandler;
+import io.mycat.route.impl.middlerResultStrategy.SQLQueryResultHandler;
 import io.mycat.route.parser.druid.DruidParser;
 import io.mycat.route.parser.druid.DruidParserFactory;
 import io.mycat.route.parser.druid.DruidShardingParseInfo;
@@ -74,6 +71,17 @@ import io.mycat.server.parser.ServerParse;
 public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 	
 	public static final Logger LOGGER = LoggerFactory.getLogger(DruidMycatRouteStrategy.class);
+	
+	private static Map<Class<?>,RouteMiddlerReaultHandler> middlerResultHandler = new HashMap<>();
+	
+	static{
+		middlerResultHandler.put(SQLQueryExpr.class, new SQLQueryResultHandler());
+		middlerResultHandler.put(SQLBinaryOpExpr.class, new BinaryOpResultHandler());
+		middlerResultHandler.put(SQLInSubQueryExpr.class, new InSubQueryResultHandler());
+		middlerResultHandler.put(SQLExistsExpr.class, new SQLExistsResultHandler());
+		middlerResultHandler.put(SQLAllExpr.class, new SQLAllResultHandler());
+	}
+	
 	
 	@Override
 	public RouteResultset routeNormalSqlWithAST(SchemaConfig schema,
@@ -170,18 +178,14 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 		}else{
 			int subQuerySize = visitor.getSubQuerys().size();
 			if(subQuerySize==0&&ctx.getTables().size()==2){ //两表关联,考虑使用catlet
-			    if(ctx.getVisitor().getConditions() !=null && ctx.getVisitor().getConditions().size()>0){
+			    if(!visitor.getRelationships().isEmpty()){
 			    	rrs.setCacheAble(false);
 			    	return catletRoute(schema,ctx.getSql(),charset,sc);
 				}
 			}else if(subQuerySize==1){     //只涉及一张表的子查询,使用  MiddlerResultHandler 获取中间结果后,改写原有 sql 继续执行 TODO 后期可能会考虑多个子查询的情况.
 				SQLSelect sqlselect = visitor.getSubQuerys().iterator().next();
-				if(sqlselect.getParent() instanceof SQLExistsExpr
-					||!visitor.getRelationships().isEmpty()
-					||sqlselect.getParent() instanceof SQLSomeExpr  /* 如果 some,all,any 没有被改写 直接路由  */
-					||sqlselect.getParent() instanceof SQLAllExpr
-					||sqlselect.getParent() instanceof SQLAnyExpr){
-					return directRoute(rrs,ctx,schema,druidParser,statement,cachePool);
+				if(!visitor.getRelationships().isEmpty()){     // 当 inner query  和 outer  query  有关联条件时,暂不支持
+					throw new UnsupportedOperationException("In case of slice table,sql have different rules,the relationship condition is not supported.");
 				}else{
 					SQLSelectQuery sqlSelectQuery = sqlselect.getQuery();
 					if(((MySqlSelectQueryBlock)sqlSelectQuery).getFrom() instanceof SQLExprTableSource) {
@@ -189,6 +193,8 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 						return middlerResultRoute(schema,charset,sqlselect,sqlType,statement,sc);
 					}
 				}
+			}else if(subQuerySize >=2){
+				throw new UnsupportedOperationException("In case of slice table,sql has different rules,currently only one subQuery is supported.");
 			}
 		}
 		return directRoute(rrs,ctx,schema,druidParser,statement,cachePool);
@@ -266,168 +272,14 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 	 * @return
 	 */
 	private String buildSql(SQLStatement statement,SQLSelect sqlselect,List param){
-		
-		SQLObject parent = sqlselect.getParent();
-		if(param.isEmpty()){
-			 param.add(new SQLCharExpr(""));
-		}
-		if(parent instanceof SQLInSubQueryExpr){
-			SQLExprImpl inlistExpr = null;
-			if(null==param||param.isEmpty()){
-				inlistExpr = getEmptyExpr(parent);
-			}else{
-				inlistExpr = new SQLInListExpr();
-				((SQLInListExpr)inlistExpr).setTargetList(param);
-				((SQLInListExpr)inlistExpr).setExpr(((SQLInSubQueryExpr)parent).getExpr());
-				((SQLInListExpr)inlistExpr).setNot(((SQLInSubQueryExpr)parent).isNot());
-				((SQLInListExpr)inlistExpr).setParent(sqlselect.getParent());
-			}
-			if(parent.getParent() instanceof MySqlSelectQueryBlock){
-				((MySqlSelectQueryBlock)parent.getParent()).setWhere(inlistExpr);
-			}else if(parent.getParent() instanceof SQLBinaryOpExpr){
-				SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)parent.getParent());
-				if(pp.getLeft().equals(parent)){
-					pp.setLeft(inlistExpr);
-				}else if(pp.getRight().equals(parent)){
-					pp.setRight(inlistExpr);
-				}
-			}
-		}else if(parent instanceof SQLBinaryOpExpr){
-			SQLBinaryOpExpr pp = (SQLBinaryOpExpr)parent;
-			if(pp.getLeft() instanceof SQLQueryExpr){
-				SQLQueryExpr left = (SQLQueryExpr)pp.getLeft();
-				if(left.getSubQuery().equals(sqlselect)){
-					SQLExprImpl listExpr = null;
-					if(null==param||param.isEmpty()){
-						listExpr = getEmptyExpr(parent);
-					}else{
-						listExpr = new SQLListExpr();
-						listExpr.setParent(left.getParent());
-						((SQLListExpr)listExpr).getItems().addAll(param);
-					}
-					pp.setLeft(listExpr);
-				}
-			}else if(pp.getRight() instanceof SQLQueryExpr){
-				SQLQueryExpr right = (SQLQueryExpr)pp.getRight();
-				if(right.getSubQuery().equals(sqlselect)){
-					SQLExprImpl listExpr = null;
-					if(null==param||param.isEmpty()){
-						listExpr = getEmptyExpr(parent);
-					}else{
-						listExpr = new SQLListExpr();
-						listExpr.setParent(right.getParent());
-						((SQLListExpr)listExpr).getItems().addAll(param);
-					}
-					pp.setRight(listExpr);
-					
-				}
-			}else if(pp.getLeft() instanceof SQLInSubQueryExpr){
-				SQLInSubQueryExpr left = (SQLInSubQueryExpr)pp.getLeft();
-				if(left.getSubQuery().equals(sqlselect)){
-					SQLExprImpl inlistExpr = null;
-					if(null==param||param.isEmpty()){
-						inlistExpr = getEmptyExpr(parent);
-					}else{
-						inlistExpr = new SQLInListExpr();
-						((SQLInListExpr)inlistExpr).setTargetList(param);
-						((SQLInListExpr)inlistExpr).setExpr(pp.getRight());
-						((SQLInListExpr)inlistExpr).setNot(left.isNot());
-						((SQLInListExpr)inlistExpr).setParent(left.getParent());
-					}
-					pp.setLeft(inlistExpr);
-				}
-			}else if(pp.getRight() instanceof SQLInSubQueryExpr){
-				SQLInSubQueryExpr right = (SQLInSubQueryExpr)pp.getRight();
-				if(right.getSubQuery().equals(sqlselect)){
-					SQLExprImpl listExpr = null;
-					if(null==param||param.isEmpty()){
-						listExpr = getEmptyExpr(parent);
-					}else{
-						listExpr = new SQLListExpr();
-						((SQLListExpr)listExpr).getItems().addAll(param);
-					}
-					pp.setRight(listExpr);
-					
-				}
-			}
-		}else if(parent instanceof SQLQueryExpr){
-			if(parent.getParent() instanceof SQLBinaryOpExpr){
-				SQLBinaryOpExpr pp = (SQLBinaryOpExpr)parent.getParent();
-				SQLExprImpl listExpr = null;
-				if(null==param||param.isEmpty()){
-					listExpr = getEmptyExpr(parent);
-				}else{
-					listExpr = new SQLListExpr();
-					((SQLListExpr)listExpr).getItems().addAll(param);
-				}
-				if(pp.getLeft().equals(parent)){
-					pp.setLeft(listExpr);
-				}else if(pp.getRight().equals(parent)){
-					pp.setRight(listExpr);
-				}
-			}else if(parent.getParent() instanceof SQLSelectItem){
-				SQLSelectItem pp = (SQLSelectItem)parent.getParent();
-				SQLExprImpl listExpr = null;
-				if(null==param||param.isEmpty()){
-					listExpr = getEmptyExpr(parent);
-				}else{
-					listExpr = new SQLListExpr();
-					((SQLListExpr)listExpr).getItems().addAll(param);
-				}
-				pp.setExpr(listExpr);
-			}else if(parent.getParent() instanceof SQLSelectGroupByClause){
-				SQLSelectGroupByClause pp = (SQLSelectGroupByClause)parent.getParent();
-				
-				List<SQLExpr> items = pp.getItems();
-				for(int i=0;i<items.size();i++){
-					SQLExpr expr = items.get(i);
-					if(expr instanceof SQLQueryExpr 
-							&&((SQLQueryExpr)expr).getSubQuery().equals(sqlselect)){
-						
-						SQLExprImpl listExpr = null;
-						if(null==param||param.isEmpty()){
-							listExpr = getEmptyExpr(parent);
-						}else{
-							listExpr = new SQLListExpr();
-							((SQLListExpr)listExpr).getItems().addAll(param);
-						}
-						items.set(i, listExpr);
-					}
-				}
-			}else if(parent.getParent() instanceof SQLSelectOrderByItem){
-				SQLSelectOrderByItem orderItem = (SQLSelectOrderByItem)parent.getParent();
-				SQLExprImpl listExpr = null;
-				if(null==param||param.isEmpty()){
-					listExpr = getEmptyExpr(parent);
-				}else{
-					listExpr = new SQLListExpr();
-					((SQLListExpr)listExpr).getItems().addAll(param);
-				}
-				listExpr.setParent(orderItem);
-				orderItem.setExpr(listExpr);
-			}else if(parent.getParent() instanceof MySqlSelectQueryBlock){
-				MySqlSelectQueryBlock query = (MySqlSelectQueryBlock)parent.getParent();
-				// select * from subtest1 a where (select 1 from subtest3); 这种情况会进入到当前分支.
-				// 改写为   select * from subtest1 a where (1); 或  select * from subtest1 a where (null);
-				SQLExprImpl listExpr = null;
-				if(null==param||param.isEmpty()){
-					listExpr = getEmptyExpr(parent);
-				}else{
-					listExpr = new SQLListExpr();
-					((SQLListExpr)listExpr).getItems().addAll(param);
-				}
-				listExpr.setParent(query);
-				query.setWhere(listExpr);
-			}
 
+		SQLObject parent = sqlselect.getParent();
+		RouteMiddlerReaultHandler handler = middlerResultHandler.get(parent.getClass());
+		if(handler==null){
+			throw new UnsupportedOperationException(parent.getClass()+" current is not supported ");
 		}
-		return statement.toString();
+		return handler.dohandler(statement, sqlselect, parent, param);
 	}
-	
-	private SQLExprImpl getEmptyExpr(SQLObject parent){
-		return new SQLNullExpr();
-	}
-	
 	
 	/**
 	 * 两个表的情况，catlet

--- a/src/main/java/io/mycat/route/impl/middlerResultStrategy/BinaryOpResultHandler.java
+++ b/src/main/java/io/mycat/route/impl/middlerResultStrategy/BinaryOpResultHandler.java
@@ -1,0 +1,81 @@
+package io.mycat.route.impl.middlerResultStrategy;
+
+import java.util.List;
+
+import com.alibaba.druid.sql.ast.SQLExprImpl;
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLInListExpr;
+import com.alibaba.druid.sql.ast.expr.SQLInSubQueryExpr;
+import com.alibaba.druid.sql.ast.expr.SQLListExpr;
+import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelect;
+
+public class BinaryOpResultHandler implements RouteMiddlerReaultHandler {
+
+	@Override
+	public String dohandler(SQLStatement statement, SQLSelect sqlselect, SQLObject parent, List param) {
+		
+		SQLBinaryOpExpr pp = (SQLBinaryOpExpr)parent;
+		if(pp.getLeft() instanceof SQLQueryExpr){
+			SQLQueryExpr left = (SQLQueryExpr)pp.getLeft();
+			if(left.getSubQuery().equals(sqlselect)){
+				SQLExprImpl listExpr = null;
+				if(null==param||param.isEmpty()){
+					listExpr = new SQLNullExpr();
+				}else{
+					listExpr = new SQLListExpr();
+					listExpr.setParent(left.getParent());
+					((SQLListExpr)listExpr).getItems().addAll(param);
+				}
+				pp.setLeft(listExpr);
+			}
+		}else if(pp.getRight() instanceof SQLQueryExpr){
+			SQLQueryExpr right = (SQLQueryExpr)pp.getRight();
+			if(right.getSubQuery().equals(sqlselect)){
+				SQLExprImpl listExpr = null;
+				if(null==param||param.isEmpty()){
+					listExpr = new SQLNullExpr();
+				}else{
+					listExpr = new SQLListExpr();
+					listExpr.setParent(right.getParent());
+					((SQLListExpr)listExpr).getItems().addAll(param);
+				}
+				pp.setRight(listExpr);
+				
+			}
+		}else if(pp.getLeft() instanceof SQLInSubQueryExpr){
+			SQLInSubQueryExpr left = (SQLInSubQueryExpr)pp.getLeft();
+			if(left.getSubQuery().equals(sqlselect)){
+				SQLExprImpl inlistExpr = null;
+				if(null==param||param.isEmpty()){
+					inlistExpr = new SQLNullExpr();
+				}else{
+					inlistExpr = new SQLInListExpr();
+					((SQLInListExpr)inlistExpr).setTargetList(param);
+					((SQLInListExpr)inlistExpr).setExpr(pp.getRight());
+					((SQLInListExpr)inlistExpr).setNot(left.isNot());
+					((SQLInListExpr)inlistExpr).setParent(left.getParent());
+				}
+				pp.setLeft(inlistExpr);
+			}
+		}else if(pp.getRight() instanceof SQLInSubQueryExpr){
+			SQLInSubQueryExpr right = (SQLInSubQueryExpr)pp.getRight();
+			if(right.getSubQuery().equals(sqlselect)){
+				SQLExprImpl listExpr = null;
+				if(null==param||param.isEmpty()){
+					listExpr = new SQLNullExpr();
+				}else{
+					listExpr = new SQLListExpr();
+					((SQLListExpr)listExpr).getItems().addAll(param);
+				}
+				pp.setRight(listExpr);
+				
+			}
+		}
+		return statement.toString();
+	}
+
+}

--- a/src/main/java/io/mycat/route/impl/middlerResultStrategy/InSubQueryResultHandler.java
+++ b/src/main/java/io/mycat/route/impl/middlerResultStrategy/InSubQueryResultHandler.java
@@ -1,0 +1,43 @@
+package io.mycat.route.impl.middlerResultStrategy;
+
+import java.util.List;
+
+import com.alibaba.druid.sql.ast.SQLExprImpl;
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLInListExpr;
+import com.alibaba.druid.sql.ast.expr.SQLInSubQueryExpr;
+import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelect;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+
+
+public class InSubQueryResultHandler implements RouteMiddlerReaultHandler {
+	
+	@Override
+	public String dohandler(SQLStatement statement,SQLSelect sqlselect,SQLObject parent,List param) {
+		SQLExprImpl inlistExpr = null;
+		if(null==param||param.isEmpty()){
+			inlistExpr = new SQLNullExpr();
+		}else{
+			inlistExpr = new SQLInListExpr();
+			((SQLInListExpr)inlistExpr).setTargetList(param);
+			((SQLInListExpr)inlistExpr).setExpr(((SQLInSubQueryExpr)parent).getExpr());
+			((SQLInListExpr)inlistExpr).setNot(((SQLInSubQueryExpr)parent).isNot());
+			((SQLInListExpr)inlistExpr).setParent(sqlselect.getParent());
+		}
+		if(parent.getParent() instanceof MySqlSelectQueryBlock){
+			((MySqlSelectQueryBlock)parent.getParent()).setWhere(inlistExpr);
+		}else if(parent.getParent() instanceof SQLBinaryOpExpr){
+			SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)parent.getParent());
+			if(pp.getLeft().equals(parent)){
+				pp.setLeft(inlistExpr);
+			}else if(pp.getRight().equals(parent)){
+				pp.setRight(inlistExpr);
+			}
+		}
+		return statement.toString();
+	}
+
+}

--- a/src/main/java/io/mycat/route/impl/middlerResultStrategy/RouteMiddlerReaultHandler.java
+++ b/src/main/java/io/mycat/route/impl/middlerResultStrategy/RouteMiddlerReaultHandler.java
@@ -1,0 +1,20 @@
+package io.mycat.route.impl.middlerResultStrategy;
+
+import java.util.List;
+
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLSelect;
+
+public interface RouteMiddlerReaultHandler {
+	
+	/**
+	 * 处理中间结果
+	 * @param statement
+	 * @param sqlselect
+	 * @param param
+	 * @return
+	 */
+	String dohandler(SQLStatement statement,SQLSelect sqlselect,SQLObject parent,List param);
+
+}

--- a/src/main/java/io/mycat/route/impl/middlerResultStrategy/SQLAllResultHandler.java
+++ b/src/main/java/io/mycat/route/impl/middlerResultStrategy/SQLAllResultHandler.java
@@ -1,0 +1,79 @@
+package io.mycat.route.impl.middlerResultStrategy;
+
+import java.util.List;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLExprImpl;
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
+import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
+import com.alibaba.druid.sql.ast.expr.SQLValuableExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelect;
+
+/**
+ * 对于 = 
+	select * from test where id = all (select id from mytab where xxx)   --->
+	改写后 sql为   all: select * from test where id = val1 and id = val2 …
+ * @author lyj
+ *
+ */
+public class SQLAllResultHandler implements RouteMiddlerReaultHandler{
+
+	@Override
+	public String dohandler(SQLStatement statement, SQLSelect sqlselect, SQLObject parent, List param) {
+		if(parent.getParent() instanceof SQLBinaryOpExpr){
+			
+			SQLExprImpl inlistExpr = null;
+			if(null==param||param.isEmpty()){
+				inlistExpr = new SQLNullExpr();
+				SQLBinaryOpExpr xp = (SQLBinaryOpExpr)parent.getParent();
+				xp.setOperator(SQLBinaryOperator.Is);
+				if(xp.getRight().equals(parent)){
+					xp.setRight(inlistExpr);
+				}else if(xp.getLeft().equals(parent)){
+					xp.setLeft(inlistExpr);
+				}
+			}else{
+				int len = param.size();
+				
+				SQLBinaryOpExpr xp = (SQLBinaryOpExpr)parent.getParent();
+				SQLExpr left = null;
+				if(xp.getRight().equals(parent)){
+					left = xp.getLeft();
+				}else if(xp.getLeft().equals(parent)){
+					left = xp.getRight();
+				}
+								
+				SQLBinaryOpExpr p = xp;
+				for(int i=0;i<len;i++){
+					if(i<(len-1)){
+						
+						SQLBinaryOpExpr rightop = new SQLBinaryOpExpr();
+						rightop.setOperator(SQLBinaryOperator.Equality);
+						SQLValuableExpr expr = (SQLValuableExpr) param.get(i);
+						rightop.setRight(expr);
+						rightop.setParent(p);
+						rightop.setLeft(left);
+						p.setRight(rightop);
+						p.setOperator(SQLBinaryOperator.BooleanAnd);
+						
+						SQLBinaryOpExpr lefeop = new SQLBinaryOpExpr();
+						lefeop.setParent(p);
+						lefeop.setOperator(SQLBinaryOperator.Equality);
+						p.setLeft(lefeop);
+						p = (SQLBinaryOpExpr) p.getLeft();
+					}else{
+						p.setLeft(left);
+						p.setOperator(SQLBinaryOperator.Equality);
+						SQLValuableExpr expr = (SQLValuableExpr) param.get(i);
+						p.setRight(expr);
+					}
+				}
+			}
+		}
+		return statement.toString();
+	}
+
+}

--- a/src/main/java/io/mycat/route/impl/middlerResultStrategy/SQLExistsResultHandler.java
+++ b/src/main/java/io/mycat/route/impl/middlerResultStrategy/SQLExistsResultHandler.java
@@ -1,0 +1,45 @@
+package io.mycat.route.impl.middlerResultStrategy;
+
+import java.util.List;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelect;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+
+/**
+ * 对于 EXISTS/NOT EXISTS, 判断subquery结果集是否为空。
+ * @author lyj
+ *
+ */
+public class SQLExistsResultHandler implements RouteMiddlerReaultHandler {
+
+	@Override
+	public String dohandler(SQLStatement statement, SQLSelect sqlselect, SQLObject parent, List param) {
+		SQLExpr se = null;
+		
+		if(param==null||param.isEmpty()){
+			se = new SQLNullExpr();
+		}else{
+			se = (SQLExpr) param.get(0);
+		}
+		
+		if(parent.getParent() instanceof MySqlSelectQueryBlock){
+			MySqlSelectQueryBlock msqb = (MySqlSelectQueryBlock)parent.getParent();
+			msqb.setWhere(se);
+		}else if(parent.getParent() instanceof SQLBinaryOpExpr){
+			SQLBinaryOpExpr sbqe=(SQLBinaryOpExpr)parent.getParent();
+			
+			if(sbqe.getLeft().equals(parent)){
+				sbqe.setLeft(se);
+			}else{
+				sbqe.setRight(se);
+			}
+		}
+		return statement.toString();
+	}
+
+}

--- a/src/main/java/io/mycat/route/impl/middlerResultStrategy/SQLQueryResultHandler.java
+++ b/src/main/java/io/mycat/route/impl/middlerResultStrategy/SQLQueryResultHandler.java
@@ -1,0 +1,94 @@
+package io.mycat.route.impl.middlerResultStrategy;
+
+import java.util.List;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLExprImpl;
+import com.alibaba.druid.sql.ast.SQLObject;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLListExpr;
+import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelect;
+import com.alibaba.druid.sql.ast.statement.SQLSelectGroupByClause;
+import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
+import com.alibaba.druid.sql.ast.statement.SQLSelectOrderByItem;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+
+public class SQLQueryResultHandler implements RouteMiddlerReaultHandler {
+
+	@Override
+	public String dohandler(SQLStatement statement, SQLSelect sqlselect, SQLObject parent, List param) {
+		if(parent.getParent() instanceof SQLBinaryOpExpr){
+			SQLBinaryOpExpr pp = (SQLBinaryOpExpr)parent.getParent();
+			SQLExprImpl listExpr = null;
+			if(null==param||param.isEmpty()){
+				listExpr = new SQLNullExpr();
+			}else{
+				listExpr = new SQLListExpr();
+				((SQLListExpr)listExpr).getItems().addAll(param);
+			}
+			if(pp.getLeft().equals(parent)){
+				pp.setLeft(listExpr);
+			}else if(pp.getRight().equals(parent)){
+				pp.setRight(listExpr);
+			}
+		}else if(parent.getParent() instanceof SQLSelectItem){
+			SQLSelectItem pp = (SQLSelectItem)parent.getParent();
+			SQLExprImpl listExpr = null;
+			if(null==param||param.isEmpty()){
+				listExpr = new SQLNullExpr();
+			}else{
+				listExpr = new SQLListExpr();
+				((SQLListExpr)listExpr).getItems().addAll(param);
+			}
+			pp.setExpr(listExpr);
+		}else if(parent.getParent() instanceof SQLSelectGroupByClause){
+			SQLSelectGroupByClause pp = (SQLSelectGroupByClause)parent.getParent();
+			
+			List<SQLExpr> items = pp.getItems();
+			for(int i=0;i<items.size();i++){
+				SQLExpr expr = items.get(i);
+				if(expr instanceof SQLQueryExpr 
+						&&((SQLQueryExpr)expr).getSubQuery().equals(sqlselect)){
+					
+					SQLExprImpl listExpr = null;
+					if(null==param||param.isEmpty()){
+						listExpr = new SQLNullExpr();
+					}else{
+						listExpr = new SQLListExpr();
+						((SQLListExpr)listExpr).getItems().addAll(param);
+					}
+					items.set(i, listExpr);
+				}
+			}
+		}else if(parent.getParent() instanceof SQLSelectOrderByItem){
+			SQLSelectOrderByItem orderItem = (SQLSelectOrderByItem)parent.getParent();
+			SQLExprImpl listExpr = null;
+			if(null==param||param.isEmpty()){
+				listExpr = new SQLNullExpr();
+			}else{
+				listExpr = new SQLListExpr();
+				((SQLListExpr)listExpr).getItems().addAll(param);
+			}
+			listExpr.setParent(orderItem);
+			orderItem.setExpr(listExpr);
+		}else if(parent.getParent() instanceof MySqlSelectQueryBlock){
+			MySqlSelectQueryBlock query = (MySqlSelectQueryBlock)parent.getParent();
+			// select * from subtest1 a where (select 1 from subtest3); 这种情况会进入到当前分支.
+			// 改写为   select * from subtest1 a where (1); 或  select * from subtest1 a where (null);
+			SQLExprImpl listExpr = null;
+			if(null==param||param.isEmpty()){
+				listExpr = new SQLNullExpr();
+			}else{
+				listExpr = new SQLListExpr();
+				((SQLListExpr)listExpr).getItems().addAll(param);
+			}
+			listExpr.setParent(query);
+			query.setWhere(listExpr);
+		}
+		return statement.toString();
+	}
+
+}

--- a/src/main/java/io/mycat/route/parser/druid/DruidSequenceHandler.java
+++ b/src/main/java/io/mycat/route/parser/druid/DruidSequenceHandler.java
@@ -78,7 +78,7 @@ public class DruidSequenceHandler {
                 	matcher = pattern.matcher(executeSql);
                 	while(matcher.find()){            
                 		long value = sequenceHandler.nextId(tableName.toUpperCase());
-                        executeSql = executeSql.replaceFirst(matcher.group(1), Long.toString(value));
+                        executeSql = executeSql.replaceFirst(matcher.group(1), " "+Long.toString(value));
                     }
 				} finally {
 					lock.unlock();

--- a/src/main/java/io/mycat/route/parser/druid/DruidSequenceHandler.java
+++ b/src/main/java/io/mycat/route/parser/druid/DruidSequenceHandler.java
@@ -1,12 +1,20 @@
 package io.mycat.route.parser.druid;
 
-import io.mycat.MycatServer;
-import io.mycat.config.model.SystemConfig;
-import io.mycat.route.sequence.handler.*;
-
 import java.io.UnsupportedEncodingException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import io.mycat.MycatServer;
+import io.mycat.config.model.SystemConfig;
+import io.mycat.route.sequence.handler.DistributedSequenceHandler;
+import io.mycat.route.sequence.handler.IncrSequenceMySQLHandler;
+import io.mycat.route.sequence.handler.IncrSequencePropHandler;
+import io.mycat.route.sequence.handler.IncrSequenceTimeHandler;
+import io.mycat.route.sequence.handler.IncrSequenceZKHandler;
+import io.mycat.route.sequence.handler.SequenceHandler;
 
 /**
  * 使用Druid解析器实现对Sequence处理
@@ -16,6 +24,11 @@ import java.util.regex.Pattern;
  */
 public class DruidSequenceHandler {
     private final SequenceHandler sequenceHandler;
+    
+    /**
+     * 分段锁
+     */
+    private final static Map<String,ReentrantLock> segmentLock = new ConcurrentHashMap<>();
 
     /**
      * 获取MYCAT SEQ的匹配语句
@@ -54,21 +67,44 @@ public class DruidSequenceHandler {
      * @throws UnsupportedEncodingException
      */
     public String getExecuteSql(String sql, String charset) throws UnsupportedEncodingException {
-        String executeSql = null;
+    	String executeSql = sql;
         if (null != sql && !"".equals(sql)) {
-            //sql不能转大写，因为sql可能是insert语句会把values也给转换了
-            // 获取表名。
-            Matcher matcher = pattern.matcher(sql);
-            if (matcher.find()) {
-                String tableName = matcher.group(2);
-                long value = sequenceHandler.nextId(tableName.toUpperCase());
-
-                // 将MATCHED_FEATURE+表名替换成序列号。
-                executeSql = sql.replace(matcher.group(1), " " + value);
+            Matcher matcher = pattern.matcher(executeSql);
+            if(matcher.find()){
+            	String tableName = matcher.group(2);
+                ReentrantLock lock = getSegLock(tableName);
+                lock.lock();
+                try {
+                	matcher = pattern.matcher(executeSql);
+                	while(matcher.find()){            
+                		long value = sequenceHandler.nextId(tableName.toUpperCase());
+                        executeSql = executeSql.replaceFirst(matcher.group(1), Long.toString(value));
+                    }
+				} finally {
+					lock.unlock();
+				}
             }
-
         }
         return executeSql;
+    }
+    
+    /*
+     * 获取分段锁 
+     * @param name
+     * @return
+     */
+    private ReentrantLock getSegLock(String name){
+    	ReentrantLock lock = segmentLock.get(name);
+    	if(lock==null){
+    		synchronized (segmentLock) {
+    			lock = segmentLock.get(name);
+				if(lock==null){
+					lock = new ReentrantLock();
+					segmentLock.put(name, lock);
+				}
+			}
+    	}
+    	return lock;
     }
 
 

--- a/src/main/java/io/mycat/route/parser/druid/MycatSchemaStatVisitor.java
+++ b/src/main/java/io/mycat/route/parser/druid/MycatSchemaStatVisitor.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 import com.alibaba.druid.sql.ast.SQLCommentHint;
 import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLExprImpl;
 import com.alibaba.druid.sql.ast.SQLName;
 import com.alibaba.druid.sql.ast.SQLObject;
 import com.alibaba.druid.sql.ast.expr.SQLAggregateExpr;
@@ -289,6 +290,14 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
         return "";
     }
     
+    private void setSubQueryRelationOrFlag(SQLExprImpl x){
+    	MycatSubQueryVisitor subQueryVisitor = new MycatSubQueryVisitor();
+    	x.accept(subQueryVisitor);
+    	if(subQueryVisitor.isRelationOr()){
+    		subqueryRelationOr = true;
+    	}
+    }
+    
     /*
      * 子查询
      * (non-Javadoc)
@@ -296,6 +305,7 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLQueryExpr x) {
+    	setSubQueryRelationOrFlag(x);
     	addSubQuerys(x.getSubQuery());
     	return super.visit(x);
     }
@@ -315,6 +325,7 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLExistsExpr x) {
+    	setSubQueryRelationOrFlag(x);
     	addSubQuerys(x.getSubQuery());
     	return super.visit(x);
     }
@@ -331,6 +342,7 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLInSubQueryExpr x) {
+    	setSubQueryRelationOrFlag(x);
     	addSubQuerys(x.getSubQuery());
     	return super.visit(x);
     }
@@ -346,7 +358,9 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      *          other  不改写
      */    
     @Override
-    public boolean visit(SQLAllExpr x) {    	
+    public boolean visit(SQLAllExpr x) {
+    	setSubQueryRelationOrFlag(x);
+    	
     	List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
     	SQLExpr sexpr = itemlist.get(0).getExpr();
     	
@@ -449,7 +463,10 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      *    other  不改写
      */
     @Override
-    public boolean visit(SQLSomeExpr x) {   	
+    public boolean visit(SQLSomeExpr x) {
+    	
+    	setSubQueryRelationOrFlag(x);
+    	
     	List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
     	SQLExpr sexpr = itemlist.get(0).getExpr();
     	
@@ -581,6 +598,9 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLAnyExpr x) {
+    	
+    	setSubQueryRelationOrFlag(x);
+    	
     	List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
     	SQLExpr sexpr = itemlist.get(0).getExpr();
     	

--- a/src/main/java/io/mycat/route/parser/druid/MycatSubQueryVisitor.java
+++ b/src/main/java/io/mycat/route/parser/druid/MycatSubQueryVisitor.java
@@ -1,0 +1,44 @@
+package io.mycat.route.parser.druid;
+
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlSchemaStatVisitor;
+
+/**
+ * 子查询访问器
+ */
+public class MycatSubQueryVisitor extends MySqlSchemaStatVisitor{
+	
+	private boolean relationOr;
+	
+	@Override
+	public boolean visit(SQLBinaryOpExpr x) {
+
+		switch (x.getOperator()) {
+	            case Equality:
+	            case LessThanOrEqualOrGreaterThan:
+	            case GreaterThan:
+	            case GreaterThanOrEqual:
+	            case LessThan:
+	            case LessThanOrEqual:
+	            case NotLessThan:
+	            case LessThanOrGreater:
+   			 	case NotEqual:
+   			 	case NotGreaterThan:	            	
+	                break;
+	            case BooleanOr:
+	            	relationOr = true;
+	            	break;
+	            case Like:
+	            case NotLike:
+	            default:
+	                break;
+	        }
+	        return true;
+	}
+
+	public boolean isRelationOr() {
+		return relationOr;
+	}
+	
+	
+}

--- a/src/main/java/io/mycat/route/parser/druid/impl/DefaultDruidParser.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/DefaultDruidParser.java
@@ -120,11 +120,6 @@ public class DefaultDruidParser implements DruidParser {
 				if(((MySqlSelectQueryBlock)query).isForUpdate()){
 					rrs.setSelectForUpdate(true);
 				}
-				
-				if(visitor.isHasChange()){	// 在解析的过程中子查询被改写了.需要更新ctx.
-					ctx.setSql(stmt.toString());
-					rrs.setStatement(ctx.getSql());
-				}
 			}
 		}
 
@@ -135,6 +130,11 @@ public class DefaultDruidParser implements DruidParser {
 			mergedConditionList = visitor.splitConditions();
 		} else {//不包含OR语句
 			mergedConditionList.add(visitor.getConditions());
+		}
+		
+		if(visitor.isHasChange()){	// 在解析的过程中子查询被改写了.需要更新ctx.
+			ctx.setSql(stmt.toString());
+			rrs.setStatement(ctx.getSql());
 		}
 		
 		if(visitor.getAliasMap() != null) {

--- a/src/main/java/io/mycat/route/util/RouterUtil.java
+++ b/src/main/java/io/mycat/route/util/RouterUtil.java
@@ -553,20 +553,17 @@ public class RouterUtil {
 
 	public static void processSQL(ServerConnection sc,SchemaConfig schema,String sql,int sqlType){
 //		int sequenceHandlerType = MycatServer.getInstance().getConfig().getSystem().getSequnceHandlerType();
-		SessionSQLPair sessionSQLPair = new SessionSQLPair(sc.getSession2(), schema, sql, sqlType);
-//		if(sequenceHandlerType == 3 || sequenceHandlerType == 4){
-//			DruidSequenceHandler sequenceHandler = new DruidSequenceHandler(MycatServer
-//					.getInstance().getConfig().getSystem().getSequnceHandlerType());
-//			String charset = sessionSQLPair.session.getSource().getCharset();
-//			String executeSql = null;
-//			try {
-//				executeSql = sequenceHandler.getExecuteSql(sessionSQLPair.sql,charset == null ? "utf-8":charset);
-//			} catch (UnsupportedEncodingException e) {
-//				LOGGER.error("UnsupportedEncodingException!");
-//			}
-//			sessionSQLPair.session.getSource().routeEndExecuteSQL(executeSql, sessionSQLPair.type,sessionSQLPair.schema);
-//		} else {
-			MycatServer.getInstance().getSequnceProcessor().addNewSql(sessionSQLPair);
+		final SessionSQLPair sessionSQLPair = new SessionSQLPair(sc.getSession2(), schema, sql, sqlType);
+//      modify by yanjunli  序列获取修改为多线程方式。使用分段锁方式,一个序列一把锁。  begin		
+//		MycatServer.getInstance().getSequnceProcessor().addNewSql(sessionSQLPair);
+		LOGGER.warn("prefix+values ===" + sql);
+        MycatServer.getInstance().getBusinessExecutor().execute(new Runnable() {
+				@Override
+				public void run() {
+					MycatServer.getInstance().getSequnceProcessor().executeSeq(sessionSQLPair);
+				}
+		 });
+//      modify   序列获取修改为多线程方式。使用分段锁方式,一个序列一把锁。  end
 //		}
 	}
 
@@ -638,10 +635,7 @@ public class RouterUtil {
 		//如果主键不在插入语句的fields中，则需要进一步处理
 		boolean processedInsert=!isPKInFields(origSQL,primaryKey,firstLeftBracketIndex,firstRightBracketIndex);
 		if(processedInsert){
-			List<String> insertSQLs = handleBatchInsert(origSQL, valuesIndex);
-			for(String insertSQL:insertSQLs) {
-				processInsert(sc, schema, sqlType, insertSQL, tableName, primaryKey, firstLeftBracketIndex + 1, insertSQL.indexOf('(', firstRightBracketIndex) + 1);
-			}
+			handleBatchInsert(sc, schema, sqlType,origSQL, valuesIndex,tableName,primaryKey);
 		}
 		return processedInsert;
 	}
@@ -690,39 +684,27 @@ public class RouterUtil {
 		}
 		return handledSQLs;
 	}
-
-
-	private static void processInsert(ServerConnection sc, SchemaConfig schema, int sqlType, String origSQL,
-			String tableName, String primaryKey, int afterFirstLeftBracketIndex, int afterLastLeftBracketIndex) {
-		/**
-		 * 对于主键不在插入语句的fields中的SQL，需要改写。比如hotnews主键为id，插入语句为：
-		 * insert into hotnews(title) values('aaa');
-		 * 需要改写成：
-		 * insert into hotnews(id, title) values(next value for MYCATSEQ_hotnews,'aaa');
- 		 */
-		int primaryKeyLength = primaryKey.length();
-		int insertSegOffset = afterFirstLeftBracketIndex;
-		String mycatSeqPrefix = "next value for MYCATSEQ_";
-		int mycatSeqPrefixLength = mycatSeqPrefix.length();
-		int tableNameLength = tableName.length();
-
-		char[] newSQLBuf = new char[origSQL.length() + primaryKeyLength + mycatSeqPrefixLength + tableNameLength + 2];
-		origSQL.getChars(0, afterFirstLeftBracketIndex, newSQLBuf, 0);
-		primaryKey.getChars(0, primaryKeyLength, newSQLBuf, insertSegOffset);
-		insertSegOffset += primaryKeyLength;
-		newSQLBuf[insertSegOffset] = ',';
-		insertSegOffset++;
-		origSQL.getChars(afterFirstLeftBracketIndex, afterLastLeftBracketIndex, newSQLBuf, insertSegOffset);
-		insertSegOffset += afterLastLeftBracketIndex - afterFirstLeftBracketIndex;
-		mycatSeqPrefix.getChars(0, mycatSeqPrefixLength, newSQLBuf, insertSegOffset);
-		insertSegOffset += mycatSeqPrefixLength;
-		tableName.getChars(0, tableNameLength, newSQLBuf, insertSegOffset);
-		insertSegOffset += tableNameLength;
-		newSQLBuf[insertSegOffset] = ',';
-		insertSegOffset++;
-		origSQL.getChars(afterLastLeftBracketIndex, origSQL.length(), newSQLBuf, insertSegOffset);
-		processSQL(sc, schema, new String(newSQLBuf), sqlType);
-	}
+	
+	  /**
+	  * 对于主键不在插入语句的fields中的SQL，需要改写。比如hotnews主键为id，插入语句为：
+	  * insert into hotnews(title) values('aaa');
+	  * 需要改写成：
+	  * insert into hotnews(id, title) values(next value for MYCATSEQ_hotnews,'aaa');
+	  */
+    public static void handleBatchInsert(ServerConnection sc, SchemaConfig schema,
+            int sqlType,String origSQL, int valuesIndex,String tableName, String primaryKey) {
+    	
+    	final String pk = "\\("+primaryKey+",";
+        final String mycatSeqPrefix = "(next value for MYCATSEQ_"+tableName.toUpperCase()+",";
+    	
+    	/*"VALUES".length() ==6 */
+        String prefix = origSQL.substring(0, valuesIndex + 6);
+        String values = origSQL.substring(valuesIndex + 6);
+        
+        prefix = prefix.replaceFirst("\\(", pk);
+        values = values.replaceAll("\\(",mycatSeqPrefix);
+        processSQL(sc, schema,prefix+values, sqlType);
+    }
 
 	public static RouteResultset routeToMultiNode(boolean cache,RouteResultset rrs, Collection<String> dataNodes, String stmt) {
 		RouteResultsetNode[] nodes = new RouteResultsetNode[dataNodes.size()];


### PR DESCRIPTION
1. 对于 EXISTS/NOT EXISTS, 判断subquery结果集是否为空即可.
2. 对于 = all 的子查询, 改写为 id = 1 and id = 2 .....
3. 增加对 两个表分片规则和节点都一样，关联字段是分片字段 情况下的子查询的支持.

4.批量插入使用自动生成主键方式时,影响行数不正确.偶尔返回给客户端多个OK报文. 导致客户端显示异常的问题。
5.批量插入显式指定mycat序列方式时,生成重复主键问题。
6. 优化 mycat 获取序列号锁粒度。优化思路为 mycat 批量插入获取序列号时,交给 BusinessExecutor 去处理. 在获取序列号时,每个表一把锁。通过降低锁粒度的方式 提高并发。类似于分段锁的概念。
优化后,如果是DB 方式,可以给 mycat_sequence name 列.加上索引 进一步提高并发.

