### PR TITLE
修复mycat连接数超出配置的maxCons属性bug

### DIFF
--- a/src/main/java/io/mycat/backend/datasource/PhysicalDatasource.java
+++ b/src/main/java/io/mycat/backend/datasource/PhysicalDatasource.java
@@ -39,21 +39,15 @@ import io.mycat.config.model.DataHostConfig;
 import io.mycat.util.TimeUtil;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.xml.internal.bind.v2.model.core.ID;
 
 public abstract class PhysicalDatasource {
 	

--- a/src/main/java/io/mycat/backend/datasource/PhysicalDatasource.java
+++ b/src/main/java/io/mycat/backend/datasource/PhysicalDatasource.java
@@ -45,12 +45,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.sun.xml.internal.bind.v2.model.core.ID;
 
 public abstract class PhysicalDatasource {
 	
@@ -79,17 +82,11 @@ public abstract class PhysicalDatasource {
 	 *   @see https://github.com/MyCATApache/Mycat-Server/issues/1524
 	 *   
 	 */
-	
-	// 获取连接超时时间，超过该时间后，才抛出超过最大连接数量,默认为30秒，初次修改未做出可配置的，@todo 待优化
-	public static final int GET_CONNECTION_TIMEOUT = 30;
-	// 连接 保护锁
-	private ReentrantLock lock = new ReentrantLock();
-	private Condition noActiveConnWait = lock.newCondition();
 	// 当前活动连接
-	private int activeCount;
+	private volatile AtomicInteger activeCount = new AtomicInteger(0);
 	
 	// 当前存活的总连接数,为什么不直接使用activeCount,主要是因为连接的创建是异步完成的
-	private int totalConnections;
+	private volatile AtomicInteger totalConnection = new AtomicInteger(0);
 	
 
 	
@@ -193,6 +190,22 @@ public abstract class PhysicalDatasource {
 		}
 		return total;
 	}
+	
+	/**
+	 * 该方法也不是非常精确，因为该操作也不是一个原子操作,相对getIdleCount高效与准确一些
+	 * @return
+	 */
+	public int getIdleCountSafe() {
+		return getTotalConnectionsSafe() - getActiveCountSafe();
+	}
+	
+	/**
+	 * 是否需要继续关闭空闲连接
+	 * @return
+	 */
+	private boolean needCloseIdleConnection() {
+		return getIdleCountSafe() > hostConfig.getMinCon();
+	}
 
 	private boolean validSchema(String schema) {
 		String theSchema = schema;
@@ -279,8 +292,8 @@ public abstract class PhysicalDatasource {
 
 		// check if there has timeouted heatbeat cons
 		conHeartBeatHanler.abandTimeOuttedConns();
-		int idleCons = getIdleCount();
-		int activeCons = this.getActiveCount();
+		int idleCons = getIdleCountSafe();
+		int activeCons = this.getActiveCountSafe();
 		int createCount = (hostConfig.getMinCon() - idleCons) / 3;
 		// create if idle too little
 		if ((createCount > 0) && (idleCons + activeCons < size)
@@ -289,7 +302,7 @@ public abstract class PhysicalDatasource {
 		} else if (idleCons > hostConfig.getMinCon()) {
 			closeByIdleMany(idleCons - hostConfig.getMinCon());
 		} else {
-			int activeCount = this.getActiveCount();
+			int activeCount = this.getActiveCountSafe();
 			if (activeCount > size) {
 				StringBuilder s = new StringBuilder();
 				s.append(Alarms.DEFAULT).append("DATASOURCE EXCEED [name=")
@@ -300,23 +313,57 @@ public abstract class PhysicalDatasource {
 		}
 	}
 
+	/**
+	 * 
+	 * @param ildeCloseCount
+	 * 首先，从已创建的连接中选择本次心跳需要关闭的空闲连接数（由当前连接连接数-减去配置的最小连接数。
+	 * 然后依次关闭这些连接。由于连接空闲心跳检测与业务是同时并发的，在心跳关闭阶段，可能有连接被使用，导致需要关闭的空闲连接数减少.
+	 * 
+	 * 所以每次关闭新连接时，先判断当前空闲连接数是否大于配置的最少空闲连接，如果为否，则结束本次关闭空闲连接操作。
+	 * 该方法修改之前：
+	 *      首先从ConnMap中获取 ildeCloseCount 个连接，然后关闭；在关闭中，可能又有连接被使用，导致可能多关闭一些链接，
+	 *      导致相对频繁的创建新连接和关闭连接
+	 *      
+	 * 该方法修改之后：
+	 *     ildeCloseCount 为预期要关闭的连接
+	 *     使用循环操作，首先在关闭之前，先再一次判断是否需要关闭连接，然后每次从ConnMap中获取一个空闲连接，然后进行关闭
+	 * edit by dingw at 2017.06.16
+	 */
 	private void closeByIdleMany(int ildeCloseCount) {
 		LOGGER.info("too many ilde cons ,close some for datasouce  " + name);
-		List<BackendConnection> readyCloseCons = new ArrayList<BackendConnection>(
-				ildeCloseCount);
-		for (ConQueue queue : conMap.getAllConQueue()) {
-			readyCloseCons.addAll(queue.getIdleConsToClose(ildeCloseCount));
-			if (readyCloseCons.size() >= ildeCloseCount) {
+		
+		Iterator<ConQueue> conQueueIt = conMap.getAllConQueue().iterator();
+		ConQueue queue = null;
+		if(conQueueIt.hasNext()) {
+			queue = conQueueIt.next();
+		}
+		
+		for(int i = 0; i < ildeCloseCount; i ++ ) {
+			
+			if(!needCloseIdleConnection() || queue == null) {
+				break; //如果当时空闲连接数没有超过最小配置连接数，则结束本次连接关闭
+			}
+			
+			LOGGER.info("cur conns:" + getTotalConnectionsSafe() );
+			
+			BackendConnection idleCon = queue.takeIdleCon(false);
+			
+			while(idleCon == null && conQueueIt.hasNext()) {
+				queue = conQueueIt.next();
+				idleCon = queue.takeIdleCon(false);
+			}
+			
+			if(idleCon == null) { 
 				break;
 			}
-		}
-
-		for (BackendConnection idleCon : readyCloseCons) {
-			if (idleCon.isBorrowed()) {
+			
+			if (idleCon.isBorrowed() ) {
 				LOGGER.warn("find idle con is using " + idleCon);
 			}
 			idleCon.close("too many idle con");
+			
 		}
+		
 	}
 
 	private void createByIdleLitte(int idleCons, int createCount) {
@@ -330,7 +377,7 @@ public abstract class PhysicalDatasource {
 
 		final String[] schemas = dbPool.getSchemas();
 		for (int i = 0; i < createCount; i++) {
-			if (this.getActiveCount() + this.getIdleCount() >= size) {
+			if (exceedMaxConnections()) {
 				break;
 			}
 			try {
@@ -348,52 +395,7 @@ public abstract class PhysicalDatasource {
 		return this.conMap.getActiveCountForDs(this);
 	}
 	
-	public void decrementActiveCountSafe() {
-		try {
-			lock.lock();
-			this.activeCount -- ;
-			noActiveConnWait.signal();
-		} finally {
-			lock.unlock();
-		}
-	}
 	
-	public void incrementActiveCountSafe() {
-		try {
-			lock.lock();
-			this.activeCount ++ ;
-		} finally {
-			lock.unlock();
-		}
-	}
-	
-	public int getActiveCountSafe() {
-		try {
-			lock.lock();
-			return this.activeCount;
-		} finally {
-			lock.unlock();
-		}
-	}
-	
-	public int getTotalConnectionsSafe() {
-		try {
-			lock.lock();
-			return this.totalConnections;
-		} finally {
-			lock.unlock();
-		}
-	}
-	
-	public void decrementTotalConnectionsSafe() {
-		try {
-			lock.lock();
-			this.totalConnections --;
-			noActiveConnWait.signal();
-		} finally {
-			lock.unlock();
-		}
-	}
 
 	public void clearCons(String reason) {
 		this.conMap.clearConnections(reason, this);
@@ -479,41 +481,21 @@ public abstract class PhysicalDatasource {
 			return;	
 			
 		} else { // this.getActiveCount并不是线程安全的（严格上说该方法获取数量不准确），
-			
-			try {
-				lock.lock();
-				
-				if(this.totalConnections + 1 <= size) {
+			int curTotalConnection = this.totalConnection.get();
+			while(curTotalConnection + 1 <= size) {
+				if (this.totalConnection.compareAndSet(curTotalConnection, curTotalConnection + 1)) {
 					LOGGER.info("no ilde connection in pool,create new connection for "	+ this.name + " of schema " + schema);
-					this.totalConnections ++;
 					createNewConnection(handler, attachment, schema);
 					return;
-				} 
-				
-				// 等待一定时间
-				long beginWaitTime = System.currentTimeMillis();
-				noActiveConnWait.await(GET_CONNECTION_TIMEOUT, TimeUnit.SECONDS);
-				
-				if( System.currentTimeMillis() - beginWaitTime <  GET_CONNECTION_TIMEOUT * 1000 ) { // 非超时退出
-					//再次尝试获取连接
-					con = this.conMap.tryTakeCon(schema, autocommit);
-					if (con != null) {
-						//如果不为空，则绑定对应前端请求的handler
-						takeCon(con, handler, attachment, schema);
-						return;	
-					}
 				}
 				
-				LOGGER.error("the max activeConnnections size can not be max than maxconnections");
-				throw new IOException("the max activeConnnections size can not be max than maxconnections");
+				curTotalConnection = this.totalConnection.get(); //CAS更新失败，则重新判断当前连接是否超过最大连接数
 				
-			} catch (InterruptedException e) {
-				LOGGER.error("the max activeConnnections size can not be max than maxconnections,has hanppen InterruptedException");
-				throw new IOException("the max activeConnnections size can not be max than maxconnections,has hanppen InterruptedException");
-				
-			} finally {
-				lock.unlock();
 			}
+			
+			// 如果后端连接不足，立即失败,故直接抛出连接数超过最大连接异常
+			LOGGER.error("the max activeConnnections size can not be max than maxconnections:" + curTotalConnection);
+			throw new IOException("the max activeConnnections size can not be max than maxconnections:" + curTotalConnection);
 			
 //			int activeCons = this.getActiveCount();// 当前最大活动连接
 //			if (activeCons + 1 > size) {// 下一个连接大于最大连接数
@@ -524,6 +506,38 @@ public abstract class PhysicalDatasource {
 //				createNewConnection(handler, attachment, schema);
 //			}
 		}
+	}
+	
+	/**
+	 * 是否超过最大连接数
+	 * @return
+	 */
+	private boolean exceedMaxConnections() {
+		return this.totalConnection.get() + 1 > size;
+	}
+	
+	public int decrementActiveCountSafe() {
+		return this.activeCount.decrementAndGet();
+	}
+	
+	public int incrementActiveCountSafe() {
+		return this.activeCount.incrementAndGet();
+	}
+	
+	public int getActiveCountSafe() {
+		return this.activeCount.get();
+	}
+	
+	public int getTotalConnectionsSafe() {
+		return this.totalConnection.get();
+	}
+	
+	public int decrementTotalConnectionsSafe() {
+		return this.totalConnection.decrementAndGet();
+	}
+	
+	public int incrementTotalConnectionSafe() {
+		return this.activeCount.incrementAndGet();
 	}
 
 	private void returnCon(BackendConnection c) {


### PR DESCRIPTION
https://github.com/MyCATApache/Mycat-Server/issues/1524
BUG分析：
    在从连接池中获取不到连接后，会判断当前池中的活跃连接数是否超过允许的最大连接数，如果没有超过则创建一个新的连接，这个过程在多线程环境下存在明显的问题，导致会创建超过配置的最大连接数。
修复思路：
1、引入锁保护连接池中已存在的连接，活跃连接。
2、引入一个超时机制，如果连接池的连接数已达到最大连接数后，有在获取连接的地方等待一段时间（目前默认为30s）,如果30S后还是没有可用连接，将报超过最大连接数。

是否写单元测试： 无

测试措施：
代码修复后，运行mycat服务器，然后写了一个查询案例：代码地址：http://git.oschina.net/zhcsoft/StudyDemo,测试URL:/StudyDemo/demo/testSelectOrder.do?uid=8A5EA76282C644A18267C07E8BC380F0,对该接口进行压力测试，让mycat连接不断创建，然后空闲后关闭连接，整个过程未见异常。






