### PR TITLE
修复没有主键批量insert 语句 中带有特殊字符 ( 时, 相应的列被改写的问题

### DIFF
--- a/src/main/java/io/mycat/route/util/RouterUtil.java
+++ b/src/main/java/io/mycat/route/util/RouterUtil.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -702,7 +703,8 @@ public class RouterUtil {
         String values = origSQL.substring(valuesIndex + 6);
         
         prefix = prefix.replaceFirst("\\(", pk);
-        values = values.replaceAll("\\(",mycatSeqPrefix);
+        values = values.replaceFirst("\\(", mycatSeqPrefix);
+        values =Pattern.compile(",\\s*\\(").matcher(values).replaceAll(","+mycatSeqPrefix);
         processSQL(sc, schema,prefix+values, sqlType);
     }
 


### PR DESCRIPTION
修复没有主键批量insert 语句 中带有特殊字符 ( 时, 相应的列被改写的问题
例如
insert into sbtest1(c,k)values('ctest','()ktest'),('test2','test2'); 被改写成  insert into sbtest1(id,c,k)values(1,'ctest','(2)ktest'),(3,'test2','test2'); 