### PR TITLE
修复存在多个节点结果集汇聚的情况下。查询列可能为null的问题。

### DIFF
--- a/src/main/java/io/mycat/sqlengine/mpp/DataNodeMergeManager.java
+++ b/src/main/java/io/mycat/sqlengine/mpp/DataNodeMergeManager.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 
@@ -68,6 +69,10 @@ public class DataNodeMergeManager extends AbstractDataNodeMerge {
      */
     private final  int limitStart;
     private final  int limitSize;
+    
+    private int[] mergeColsIndex;
+    private boolean hasEndFlag = false;
+    
 
     private AtomicBoolean isMiddleResultDone;
     public DataNodeMergeManager(MultiNodeQueryHandler handler, RouteResultset rrs,AtomicBoolean isMiddleResultDone) {
@@ -166,9 +171,18 @@ public class DataNodeMergeManager extends AbstractDataNodeMerge {
             /**
              * Group操作
              */
+            MergeCol[] mergColsArrays = mergCols.toArray(new MergeCol[mergCols.size()]);
             unsafeRowGrouper = new UnsafeRowGrouper(columToIndx,rrs.getGroupByCols(),
-                    mergCols.toArray(new MergeCol[mergCols.size()]),
+            		mergColsArrays,
                     rrs.getHavingCols());
+            
+            if(mergColsArrays!=null&&mergColsArrays.length>0){
+    			mergeColsIndex = new int[mergColsArrays.length];
+    			for(int i = 0;i<mergColsArrays.length;i++){
+    				mergeColsIndex[i] = mergColsArrays[i].colMeta.colIndex;
+    			}
+    		}
+            Arrays.sort(mergeColsIndex);
         }
 
 
@@ -333,6 +347,13 @@ public class DataNodeMergeManager extends AbstractDataNodeMerge {
                 }
                 if (pack == END_FLAG_PACK) {
                 	
+                	hasEndFlag = true;
+                	
+                	if(packs.peek()!=null){
+                		packs.add(pack);
+                		continue;
+                	}
+                	
                      /**
                      * 最后一个节点datenode发送了row eof packet说明了整个
                      * 分片数据全部接收完成，进而将结果集全部发给你Mycat 客户端
@@ -390,12 +411,30 @@ public class DataNodeMergeManager extends AbstractDataNodeMerge {
                 mm.readUB3();
                 mm.read();
 
+                int nullnum = 0;
                 for (int i = 0; i < fieldCount; i++) {
                     byte[] colValue = mm.readBytesWithLength();
                     if (colValue != null)
                     	unsafeRowWriter.write(i,colValue);
                     else
-                        unsafeRow.setNullAt(i);
+                    {
+            	 		if(mergeColsIndex!=null&&mergeColsIndex.length>0){
+            	 			
+            	 			if(Arrays.binarySearch(mergeColsIndex, i)<0){
+            	 				nullnum++;
+        	             	}
+            	 		}
+            	 		unsafeRow.setNullAt(i);
+                    }
+                }
+                
+                if(mergeColsIndex!=null&&mergeColsIndex.length>0){
+                	if(nullnum == (fieldCount - mergeColsIndex.length)){
+                		if(!hasEndFlag){
+                			packs.add(pack);
+                        	continue;
+                		}
+                    }
                 }
 
                 unsafeRow.setTotalSize(bufferHolder.totalSize());

--- a/src/main/java/io/mycat/sqlengine/mpp/RowDataPacketGrouper.java
+++ b/src/main/java/io/mycat/sqlengine/mpp/RowDataPacketGrouper.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+
 import io.mycat.net.mysql.RowDataPacket;
 import io.mycat.util.ByteUtil;
 import io.mycat.util.CompareUtil;
@@ -49,7 +50,9 @@ public class RowDataPacketGrouper {
 
 	private List<RowDataPacket> result = Collections.synchronizedList(new ArrayList<RowDataPacket>());
 	private final MergeCol[] mergCols;
+	private int[] mergeColsIndex;
 	private final int[] groupColumnIndexs;
+	private boolean ishanlderFirstRow = false;   //结果集汇聚时,是否已处理第一条记录.
 	private boolean isMergAvg=false;
 	private HavingCols havingCols;
 
@@ -58,6 +61,14 @@ public class RowDataPacketGrouper {
 		this.groupColumnIndexs = groupColumnIndexs;
 		this.mergCols = mergCols;
 		this.havingCols = havingCols;
+		
+		if(mergCols!=null&&mergCols.length>0){
+			mergeColsIndex = new int[mergCols.length];
+			for(int i = 0;i<mergCols.length;i++){
+				mergeColsIndex[i] = mergCols[i].colMeta.colIndex;
+			}
+			Arrays.sort(mergeColsIndex);
+		}
 	}
 
 	public List<RowDataPacket> getResult() {
@@ -207,6 +218,23 @@ public class RowDataPacketGrouper {
 		if (mergCols == null) {
 			return;
 		}
+		
+		/*
+		 * 这里进行一次判断, 在跨分片聚合的情况下,如果有一个没有记录的分片，最先返回,可能返回有null 的情况.
+		 */
+		if(!ishanlderFirstRow&&mergeColsIndex!=null&&mergeColsIndex.length>0){
+			List<byte[]> values = toRow.fieldValues;
+            for(int i=0;i<values.size();i++){
+            	if(Arrays.binarySearch(mergeColsIndex, i)>=0){
+            		continue;
+            	}
+	           if(values.get(i)==null){
+	           	   values.set(i, newRow.fieldValues.get(i));
+	           }
+            }
+            ishanlderFirstRow = true;
+		}
+		
 		for (MergeCol merg : mergCols) {
              if(merg.mergeType!=MergeCol.MERGE_AVG)
              {
@@ -220,16 +248,14 @@ public class RowDataPacketGrouper {
                  }
              }
 		}
-
-
-
-
     }
 
 	private void mergAvg(RowDataPacket toRow) {
 		if (mergCols == null) {
 			return;
 		}
+		
+		
 
 		Set<Integer> rmIndexSet = new HashSet<Integer>();
 		for (MergeCol merg : mergCols) {


### PR DESCRIPTION
例如: select id,count(k) from sbtest3;
如果 sbtest3 是分片表, 其中一个分片没有数据，在这种情况下 id列 有可能显示 null 值。