### PR TITLE
修复issues1524

### DIFF
--- a/src/main/java/io/mycat/backend/ConQueue.java
+++ b/src/main/java/io/mycat/backend/ConQueue.java
@@ -37,10 +37,12 @@ public class ConQueue {
 		this.executeCount++;
 	}
 
-	public void removeCon(BackendConnection con) {
-		if (!autoCommitCons.remove(con)) {
-			manCommitCons.remove(con);
+	public boolean removeCon(BackendConnection con) {
+		boolean removed = autoCommitCons.remove(con);
+		if (!removed) {
+			return manCommitCons.remove(con);
 		}
+		return removed;
 	}
 
 	public boolean isSameCon(BackendConnection con) {


### PR DESCRIPTION
本次出现会造成大量后端连接异常原因分析：
测试场景：数据库允许最大连接数为5，maxCon配置为10，可重现BUG
原因分析：由于connectionError与createNewConnection没有成对调用，导致totalConnection出现负数（自身引入bug）、二是因为mycat对应同一个连接，takeConn与returnConn没有成对被调用，导致activeCount出现负数，在这样的情况下，mycat一直向后端创建连接，但创建失败。