### PR TITLE
修复因前端连接register失败导致bytebuffer泄露的bug

### DIFF
--- a/src/main/java/io/mycat/net/AbstractConnection.java
+++ b/src/main/java/io/mycat/net/AbstractConnection.java
@@ -515,6 +515,10 @@ public abstract class AbstractConnection implements NIOConnection {
 			if (reason.contains("connection,reason:java.net.ConnectException")) {
 				throw new RuntimeException(" errr");
 			}
+		} else {
+		    // make sure cleanup again
+		    // Fix issue#1616
+		    this.cleanup();
 		}
 	}
 


### PR DESCRIPTION
详见issue#1616: https://github.com/MyCATApache/Mycat-Server/issues/1616