### PR TITLE
1.6.vantis

### DIFF
--- a/conf/dnindex.properties
+++ b/conf/dnindex.properties
@@ -1,5 +1,6 @@
 #update
-#Mon Apr 24 16:41:54 CST 2017
+#Mon Oct 09 12:58:57 CST 2017
+test_db=0
 dh1=0
 jdbchost=0
 dataHost2=0

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mycat</groupId>
 	<artifactId>Mycat-server</artifactId>
-	<version>1.6.5-BETA</version>
+	<version>1.6.5-release</version>
 	<packaging>jar</packaging>
 	<name>Mycat-server</name>
 	<description>The project of Mycat-server</description>
@@ -495,6 +495,14 @@
 										<property>
 											<name>set.default.REPO_DIR</name>
 											<value>lib</value>
+										</property>
+										<property>
+											<name>wrapper.logfile.maxsize</name>
+											<value>512m</value>
+										</property>
+										<property>
+											<name>wrapper.logfile.maxfiles</name>
+											<value>30</value>
 										</property>
 										<property>
 											<name>wrapper.logfile</name>

--- a/src/main/java/io/mycat/config/Versions.java
+++ b/src/main/java/io/mycat/config/Versions.java
@@ -28,11 +28,15 @@ package io.mycat.config;
  */
 public abstract class Versions {
 
-    /**协议版本**/
+    /**
+     * 协议版本
+     **/
     public static final byte PROTOCOL_VERSION = 10;
 
-    /**服务器版本**/
-    public static byte[] SERVER_VERSION = "5.6.29-mycat-1.6.5-BETA-20170424174212".getBytes();
+    /**
+     * 服务器版本
+     **/
+    public static byte[] SERVER_VERSION = "5.6.29-mycat-1.6.5-release-20170930155225".getBytes();
 
     public static void setServerVersion(String version) {
         byte[] mysqlVersionPart = version.getBytes();
@@ -42,7 +46,7 @@ public abstract class Versions {
                 break;
         }
 
-        // 生成mycat version信息
+        // 重新拼接mycat version字节数组
         byte[] newMycatVersion = new byte[mysqlVersionPart.length + SERVER_VERSION.length - startIndex];
         System.arraycopy(mysqlVersionPart, 0, newMycatVersion, 0, mysqlVersionPart.length);
         System.arraycopy(SERVER_VERSION, startIndex, newMycatVersion, mysqlVersionPart.length,

--- a/src/main/java/io/mycat/config/model/TableConfig.java
+++ b/src/main/java/io/mycat/config/model/TableConfig.java
@@ -23,283 +23,280 @@
  */
 package io.mycat.config.model;
 
-import java.util.*;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import com.alibaba.druid.sql.ast.SQLDataType;
 import com.alibaba.druid.sql.ast.statement.SQLTableElement;
 import io.mycat.config.model.rule.RuleConfig;
 import io.mycat.util.SplitUtil;
+
+import java.util.*;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * @author mycat
  */
 public class TableConfig {
-	public static final int TYPE_GLOBAL_TABLE = 1;
-	public static final int TYPE_GLOBAL_DEFAULT = 0;
-	private final String name;
-	private final String primaryKey;
-	private final boolean autoIncrement;
-	private final boolean needAddLimit;
-	private final Set<String> dbTypes;
-	private final int tableType;
-	private final ArrayList<String> dataNodes;
-	private final ArrayList<String> distTables;
-	private final RuleConfig rule;
-	private final String partitionColumn;
-	private final boolean ruleRequired;
-	private final TableConfig parentTC;
-	private final boolean childTable;
-	private final String joinKey;
-	private final String parentKey;
-	private final String locateRTableKeySql;
-	// only has one level of parent
-	private final boolean secondLevel;
-	private final boolean partionKeyIsPrimaryKey;
-	private final Random rand = new Random();
+    public static final int TYPE_GLOBAL_TABLE = 1;
+    public static final int TYPE_GLOBAL_DEFAULT = 0;
+    private final String name;
+    private final String primaryKey;
+    private final boolean autoIncrement;
+    private final boolean needAddLimit;
+    private final Set<String> dbTypes;
+    private final int tableType;
+    private final ArrayList<String> dataNodes;
+    private final ArrayList<String> distTables;
+    private final RuleConfig rule;
+    private final String partitionColumn;
+    private final boolean ruleRequired;
+    private final TableConfig parentTC;
+    private final boolean childTable;
+    private final String joinKey;
+    private final String parentKey;
+    private final String locateRTableKeySql;
+    // only has one level of parent
+    private final boolean secondLevel;
+    private final boolean partionKeyIsPrimaryKey;
+    private final Random rand = new Random();
 
-	private volatile List<SQLTableElement> tableElementList;
-	private volatile String tableStructureSQL;
-	private volatile Map<String,List<String>> dataNodeTableStructureSQLMap;
-	private ReentrantReadWriteLock reentrantReadWriteLock = new ReentrantReadWriteLock(false);
+    private volatile List<SQLTableElement> tableElementList;
+    private volatile String tableStructureSQL;
+    private volatile Map<String, List<String>> dataNodeTableStructureSQLMap;
+    private ReentrantReadWriteLock reentrantReadWriteLock = new ReentrantReadWriteLock(false);
 
 
-	public TableConfig(String name, String primaryKey, boolean autoIncrement,boolean needAddLimit, int tableType,
-			String dataNode,Set<String> dbType, RuleConfig rule, boolean ruleRequired,
-			TableConfig parentTC, boolean isChildTable, String joinKey,
-			String parentKey,String subTables) {
-		if (name == null) {
-			throw new IllegalArgumentException("table name is null");
-		} else if (dataNode == null) {
-			throw new IllegalArgumentException("dataNode name is null");
-		}
-		this.primaryKey = primaryKey;
-		this.autoIncrement = autoIncrement;
-		this.needAddLimit=needAddLimit;
-		this.tableType = tableType;
-		this.dbTypes=dbType;
-		if (ruleRequired && rule == null) {
-			throw new IllegalArgumentException("ruleRequired but rule is null");
-		}
+    public TableConfig(String name, String primaryKey, boolean autoIncrement, boolean needAddLimit, int tableType,
+                       String dataNode, Set<String> dbType, RuleConfig rule, boolean ruleRequired,
+                       TableConfig parentTC, boolean isChildTable, String joinKey,
+                       String parentKey, String subTables) {
+        if (name == null) {
+            throw new IllegalArgumentException("table name is null");
+        } else if (dataNode == null) {
+            throw new IllegalArgumentException("dataNode name is null");
+        }
+        this.primaryKey = primaryKey;
+        this.autoIncrement = autoIncrement;
+        this.needAddLimit = needAddLimit;
+        this.tableType = tableType;
+        this.dbTypes = dbType;
+        if (ruleRequired && rule == null) {
+            throw new IllegalArgumentException("ruleRequired but rule is null");
+        }
 
-		this.name = name.toUpperCase();
-		
-		String theDataNodes[] = SplitUtil.split(dataNode, ',', '$', '-');
-		if (theDataNodes == null || theDataNodes.length <= 0) {
-			throw new IllegalArgumentException("invalid table dataNodes: " + dataNode);
-		}
-		dataNodes = new ArrayList<String>(theDataNodes.length);
-		for (String dn : theDataNodes) {
-			dataNodes.add(dn);
-		}
-		
-		if(subTables!=null && !subTables.equals("")){
+        this.name = name.toUpperCase();
+
+        String theDataNodes[] = SplitUtil.split(dataNode, ',', '$', '-');
+        if (theDataNodes == null || theDataNodes.length <= 0) {
+            throw new IllegalArgumentException("invalid table dataNodes: " + dataNode);
+        }
+        dataNodes = new ArrayList<String>(theDataNodes.length);
+        for (String dn : theDataNodes) {
+            dataNodes.add(dn);
+        }
+
+        if (subTables != null && !subTables.equals("")) {
 			String sTables[] = SplitUtil.split(subTables, ',', '$', '-');
-			if (sTables == null || sTables.length <= 0) {
-				throw new IllegalArgumentException("invalid table subTables");
-			}
-			this.distTables = new ArrayList<String>(sTables.length);
-			for (String table : sTables) {
-				distTables.add(table);
-			}
-		}else{
-			this.distTables = new ArrayList<String>();
-		}	
-		
-		this.rule = rule;
-		this.partitionColumn = (rule == null) ? null : rule.getColumn();
-		partionKeyIsPrimaryKey=(partitionColumn==null)?primaryKey==null:partitionColumn.equals(primaryKey);
-		this.ruleRequired = ruleRequired;
-		this.childTable = isChildTable;
-		this.parentTC = parentTC;
-		this.joinKey = joinKey;
-		this.parentKey = parentKey;
-		if (parentTC != null) {
-			locateRTableKeySql = genLocateRootParentSQL();
-			secondLevel = (parentTC.parentTC == null);
-		} else {
-			locateRTableKeySql = null;
-			secondLevel = false;
-		}
-	}
+            if (sTables == null || sTables.length <= 0) {
+                throw new IllegalArgumentException("invalid table subTables");
+            }
+            this.distTables = new ArrayList<String>(sTables.length);
+            for (String table : sTables) {
+                distTables.add(table);
+            }
+        } else {
+            this.distTables = new ArrayList<String>();
+        }
 
-	public String getPrimaryKey() {
-		return primaryKey;
-	}
+        this.rule = rule;
+        this.partitionColumn = (rule == null) ? null : rule.getColumn();
+        partionKeyIsPrimaryKey = (partitionColumn == null) ? primaryKey == null : partitionColumn.equals(primaryKey);
+        this.ruleRequired = ruleRequired;
+        this.childTable = isChildTable;
+        this.parentTC = parentTC;
+        this.joinKey = joinKey;
+        this.parentKey = parentKey;
+        if (parentTC != null) {
+            locateRTableKeySql = genLocateRootParentSQL();
+            secondLevel = (parentTC.parentTC == null);
+        } else {
+            locateRTableKeySql = null;
+            secondLevel = false;
+        }
+    }
 
-    public Set<String> getDbTypes()
-    {
+    public String getPrimaryKey() {
+        return primaryKey;
+    }
+
+    public Set<String> getDbTypes() {
         return dbTypes;
     }
 
     public boolean isAutoIncrement() {
-		return autoIncrement;
-	}
+        return autoIncrement;
+    }
 
-	public boolean isNeedAddLimit() {
-		return needAddLimit;
-	}
+    public boolean isNeedAddLimit() {
+        return needAddLimit;
+    }
 
-	public boolean isSecondLevel() {
-		return secondLevel;
-	}
+    public boolean isSecondLevel() {
+        return secondLevel;
+    }
 
-	public String getLocateRTableKeySql() {
-		return locateRTableKeySql;
-	}
+    public String getLocateRTableKeySql() {
+        return locateRTableKeySql;
+    }
 
-	public boolean isGlobalTable() {
-		return this.tableType == TableConfig.TYPE_GLOBAL_TABLE;
-	}
+    public boolean isGlobalTable() {
+        return this.tableType == TableConfig.TYPE_GLOBAL_TABLE;
+    }
 
-	public String genLocateRootParentSQL() {
-		TableConfig tb = this;
-		StringBuilder tableSb = new StringBuilder();
-		StringBuilder condition = new StringBuilder();
-		TableConfig prevTC = null;
-		int level = 0;
-		String latestCond = null;
-		while (tb.parentTC != null) {
-			tableSb.append(tb.parentTC.name).append(',');
-			String relation = null;
-			if (level == 0) {
-				latestCond = " " + tb.parentTC.getName() + '.' + tb.parentKey
-						+ "=";
-			} else {
-				relation = tb.parentTC.getName() + '.' + tb.parentKey + '='
-						+ tb.name + '.' + tb.joinKey;
-				condition.append(relation).append(" AND ");
-			}
-			level++;
-			prevTC = tb;
-			tb = tb.parentTC;
-		}
-		String sql = "SELECT "
-				+ prevTC.parentTC.name
-				+ '.'
-				+ prevTC.parentKey
-				+ " FROM "
-				+ tableSb.substring(0, tableSb.length() - 1)
-				+ " WHERE "
-				+ ((level < 2) ? latestCond : condition.toString() + latestCond);
-		// System.out.println(this.name+" sql " + sql);
-		return sql;
+    public String genLocateRootParentSQL() {
+        TableConfig tb = this;
+        StringBuilder tableSb = new StringBuilder();
+        StringBuilder condition = new StringBuilder();
+        TableConfig prevTC = null;
+        int level = 0;
+        String latestCond = null;
+        while (tb.parentTC != null) {
+            tableSb.append(tb.parentTC.name).append(',');
+            String relation = null;
+            if (level == 0) {
+                latestCond = " " + tb.parentTC.getName() + '.' + tb.parentKey
+                        + "=";
+            } else {
+                relation = tb.parentTC.getName() + '.' + tb.parentKey + '='
+                        + tb.name + '.' + tb.joinKey;
+                condition.append(relation).append(" AND ");
+            }
+            level++;
+            prevTC = tb;
+            tb = tb.parentTC;
+        }
+        String sql = "SELECT "
+                + prevTC.parentTC.name
+                + '.'
+                + prevTC.parentKey
+                + " FROM "
+                + tableSb.substring(0, tableSb.length() - 1)
+                + " WHERE "
+                + ((level < 2) ? latestCond : condition.toString() + latestCond);
+        // System.out.println(this.name+" sql " + sql);
+        return sql;
 
-	}
+    }
 
-	public String getPartitionColumn() {
-		return partitionColumn;
-	}
+    public String getPartitionColumn() {
+        return partitionColumn;
+    }
 
-	public int getTableType() {
-		return tableType;
-	}
+    public int getTableType() {
+        return tableType;
+    }
 
-	/**
-	 * get root parent
-	 *
-	 * @return
-	 */
-	public TableConfig getRootParent() {
-		if (parentTC == null) {
-			return null;
-		}
-		TableConfig preParent = parentTC;
-		TableConfig parent = preParent.getParentTC();
+    /**
+     * get root parent
+     *
+     * @return
+     */
+    public TableConfig getRootParent() {
+        if (parentTC == null) {
+            return null;
+        }
+        TableConfig preParent = parentTC;
+        TableConfig parent = preParent.getParentTC();
 
-		while (parent != null) {
-			preParent = parent;
-			parent = parent.getParentTC();
-		}
-		return preParent;
-	}
+        while (parent != null) {
+            preParent = parent;
+            parent = parent.getParentTC();
+        }
+        return preParent;
+    }
 
-	public TableConfig getParentTC() {
-		return parentTC;
-	}
+    public TableConfig getParentTC() {
+        return parentTC;
+    }
 
-	public boolean isChildTable() {
-		return childTable;
-	}
+    public boolean isChildTable() {
+        return childTable;
+    }
 
-	public String getJoinKey() {
-		return joinKey;
-	}
+    public String getJoinKey() {
+        return joinKey;
+    }
 
-	public String getParentKey() {
-		return parentKey;
-	}
+    public String getParentKey() {
+        return parentKey;
+    }
 
-	/**
-	 * @return upper-case
-	 */
-	public String getName() {
-		return name;
-	}
+    /**
+     * @return upper-case
+     */
+    public String getName() {
+        return name;
+    }
 
-	public ArrayList<String> getDataNodes() {
-		return dataNodes;
-	}
+    public ArrayList<String> getDataNodes() {
+        return dataNodes;
+    }
 
-	public String getRandomDataNode() {
-		int index = Math.abs(rand.nextInt(Integer.MAX_VALUE)) % dataNodes.size();
-		return dataNodes.get(index);
-	}
+    public String getRandomDataNode() {
+        int index = Math.abs(rand.nextInt(Integer.MAX_VALUE)) % dataNodes.size();
+        return dataNodes.get(index);
+    }
 
-	public boolean isRuleRequired() {
-		return ruleRequired;
-	}
+    public boolean isRuleRequired() {
+        return ruleRequired;
+    }
 
-	public RuleConfig getRule() {
-		return rule;
-	}
+    public RuleConfig getRule() {
+        return rule;
+    }
 
-	public boolean primaryKeyIsPartionKey() {
-		return partionKeyIsPrimaryKey;
-	}
+    public boolean primaryKeyIsPartionKey() {
+        return partionKeyIsPrimaryKey;
+    }
 
-	public ArrayList<String> getDistTables() {
-		return this.distTables;
-	}
+    public ArrayList<String> getDistTables() {
+        return this.distTables;
+    }
 
-	public boolean isDistTable(){
-		if(this.distTables!=null && !this.distTables.isEmpty() ){
-			return true;
-		}
-		return false;
-	}
+    public boolean isDistTable() {
+        if (this.distTables != null && !this.distTables.isEmpty()) {
+            return true;
+        }
+        return false;
+    }
 
-	public List<SQLTableElement> getTableElementList() {
-		return tableElementList;
-	}
+    public List<SQLTableElement> getTableElementList() {
+        return tableElementList;
+    }
 
-	public void setTableElementList(List<SQLTableElement> tableElementList) {
-		this.tableElementList = tableElementList;
-	}
+    public void setTableElementList(List<SQLTableElement> tableElementList) {
+        this.tableElementList = tableElementList;
+    }
 
-	public ReentrantReadWriteLock getReentrantReadWriteLock() {
-		return reentrantReadWriteLock;
-	}
+    public ReentrantReadWriteLock getReentrantReadWriteLock() {
+        return reentrantReadWriteLock;
+    }
 
-	public void setReentrantReadWriteLock(ReentrantReadWriteLock reentrantReadWriteLock) {
-		this.reentrantReadWriteLock = reentrantReadWriteLock;
-	}
+    public void setReentrantReadWriteLock(ReentrantReadWriteLock reentrantReadWriteLock) {
+        this.reentrantReadWriteLock = reentrantReadWriteLock;
+    }
 
-	public String getTableStructureSQL() {
-		return tableStructureSQL;
-	}
+    public String getTableStructureSQL() {
+        return tableStructureSQL;
+    }
 
-	public void setTableStructureSQL(String tableStructureSQL) {
-		this.tableStructureSQL = tableStructureSQL;
-	}
+    public void setTableStructureSQL(String tableStructureSQL) {
+        this.tableStructureSQL = tableStructureSQL;
+    }
 
 
-	public Map<String, List<String>> getDataNodeTableStructureSQLMap() {
-		return dataNodeTableStructureSQLMap;
-	}
+    public Map<String, List<String>> getDataNodeTableStructureSQLMap() {
+        return dataNodeTableStructureSQLMap;
+    }
 
-	public void setDataNodeTableStructureSQLMap(Map<String, List<String>> dataNodeTableStructureSQLMap) {
-		this.dataNodeTableStructureSQLMap = dataNodeTableStructureSQLMap;
-	}
+    public void setDataNodeTableStructureSQLMap(Map<String, List<String>> dataNodeTableStructureSQLMap) {
+        this.dataNodeTableStructureSQLMap = dataNodeTableStructureSQLMap;
+    }
 }

--- a/src/main/java/io/mycat/net/handler/FrontendCommandHandler.java
+++ b/src/main/java/io/mycat/net/handler/FrontendCommandHandler.java
@@ -35,33 +35,27 @@ import io.mycat.statistic.CommandCount;
  *
  * @author mycat
  */
-public class FrontendCommandHandler implements NIOHandler
-{
+public class FrontendCommandHandler implements NIOHandler {
 
     protected final FrontendConnection source;
     protected final CommandCount commands;
 
-    public FrontendCommandHandler(FrontendConnection source)
-    {
+    public FrontendCommandHandler(FrontendConnection source) {
         this.source = source;
         this.commands = source.getProcessor().getCommands();
     }
 
     @Override
-    public void handle(byte[] data)
-    {
-        if(source.getLoadDataInfileHandler()!=null&&source.getLoadDataInfileHandler().isStartLoadData())
-        {
+    public void handle(byte[] data) {
+        if (source.getLoadDataInfileHandler() != null && source.getLoadDataInfileHandler().isStartLoadData()) {
             MySQLMessage mm = new MySQLMessage(data);
-            int  packetLength = mm.readUB3();
-            if(packetLength+4==data.length)
-            {
+            int packetLength = mm.readUB3();
+            if (packetLength + 4 == data.length) {
                 source.loadDataInfileData(data);
             }
             return;
         }
-        switch (data[4])
-        {
+        switch (data[4]) {
             case MySQLPacket.COM_INIT_DB:
                 commands.doInitDB();
                 source.initDB(data);
@@ -87,13 +81,13 @@ public class FrontendCommandHandler implements NIOHandler
                 source.stmtPrepare(data);
                 break;
             case MySQLPacket.COM_STMT_SEND_LONG_DATA:
-            	commands.doStmtSendLongData();
-            	source.stmtSendLongData(data);
-            	break;
+                commands.doStmtSendLongData();
+                source.stmtSendLongData(data);
+                break;
             case MySQLPacket.COM_STMT_RESET:
-            	commands.doStmtReset();
-            	source.stmtReset(data);
-            	break;
+                commands.doStmtReset();
+                source.stmtReset(data);
+                break;
             case MySQLPacket.COM_STMT_EXECUTE:
                 commands.doStmtExecute();
                 source.stmtExecute(data);
@@ -107,9 +101,9 @@ public class FrontendCommandHandler implements NIOHandler
                 source.heartbeat(data);
                 break;
             default:
-                     commands.doOther();
-                     source.writeErrMessage(ErrorCode.ER_UNKNOWN_COM_ERROR,
-                             "Unknown command");
+                commands.doOther();
+                source.writeErrMessage(ErrorCode.ER_UNKNOWN_COM_ERROR,
+                        "Unknown command");
 
         }
     }

--- a/src/main/java/io/mycat/route/RouteResultset.java
+++ b/src/main/java/io/mycat/route/RouteResultset.java
@@ -24,9 +24,6 @@
 package io.mycat.route;
 
 import com.alibaba.druid.sql.ast.SQLStatement;
-
-import io.mycat.MycatServer;
-import io.mycat.config.MycatConfig;
 import io.mycat.config.model.SchemaConfig;
 import io.mycat.route.parser.util.PageSQLUtil;
 import io.mycat.sqlengine.mpp.HavingCols;
@@ -43,8 +40,8 @@ public final class RouteResultset implements Serializable {
     private final int sqlType;
     private RouteResultsetNode[] nodes; // 路由结果节点
     private Set<String> subTables;
-    private SQLStatement sqlStatement; 
-    
+    private SQLStatement sqlStatement;
+
 
     private int limitStart;
     private boolean cacheAble;
@@ -66,17 +63,17 @@ public final class RouteResultset implements Serializable {
     //是否自动提交，此属性主要用于记录ServerConnection上的autocommit状态
     private boolean autocommit = true;
 
-    private boolean isLoadData=false;
+    private boolean isLoadData = false;
 
     //是否可以在从库运行,此属性主要供RouteResultsetNode获取
     private Boolean canRunInReadDB;
 
     // 强制走 master，可以通过 RouteResultset的属性canRunInReadDB=false
     // 传给 RouteResultsetNode 来实现，但是 强制走 slave需要增加一个属性来实现:
-    private Boolean runOnSlave = null;	// 默认null表示不施加影响
+    private Boolean runOnSlave = null;    // 默认null表示不施加影响
 
-       //key=dataNode    value=slot
-    private Map<String,Integer>   dataNodeSlotMap=new HashMap<>();
+    //key=dataNode    value=slot
+    private Map<String, Integer> dataNodeSlotMap = new HashMap<>();
 
     private boolean selectForUpdate;
 
@@ -87,9 +84,9 @@ public final class RouteResultset implements Serializable {
     public void setSelectForUpdate(boolean selectForUpdate) {
         this.selectForUpdate = selectForUpdate;
     }
-	
-	
-	 private List<String> tables;
+
+
+    private List<String> tables;
 
     public List<String> getTables() {
         return tables;
@@ -108,31 +105,28 @@ public final class RouteResultset implements Serializable {
     }
 
     public Boolean getRunOnSlave() {
-		return runOnSlave;
-	}
+        return runOnSlave;
+    }
 
-	public void setRunOnSlave(Boolean runOnSlave) {
-		this.runOnSlave = runOnSlave;
-	}
-	  private Procedure procedure;
+    public void setRunOnSlave(Boolean runOnSlave) {
+        this.runOnSlave = runOnSlave;
+    }
 
-    public Procedure getProcedure()
-    {
+    private Procedure procedure;
+
+    public Procedure getProcedure() {
         return procedure;
     }
 
-    public void setProcedure(Procedure procedure)
-    {
+    public void setProcedure(Procedure procedure) {
         this.procedure = procedure;
     }
 
-	public boolean isLoadData()
-    {
+    public boolean isLoadData() {
         return isLoadData;
     }
 
-    public void setLoadData(boolean isLoadData)
-    {
+    public void setLoadData(boolean isLoadData) {
         this.isLoadData = isLoadData;
     }
 
@@ -168,12 +162,9 @@ public final class RouteResultset implements Serializable {
 
     public void copyLimitToNodes() {
 
-        if(nodes!=null)
-        {
-            for (RouteResultsetNode node : nodes)
-            {
-                if(node.getLimitSize()==-1&&node.getLimitStart()==0)
-                {
+        if (nodes != null) {
+            for (RouteResultsetNode node : nodes) {
+                if (node.getLimitSize() == -1 && node.getLimitStart() == 0) {
                     node.setLimitStart(limitStart);
                     node.setLimitSize(limitSize);
                 }
@@ -294,11 +285,9 @@ public final class RouteResultset implements Serializable {
     }
 
     public void setNodes(RouteResultsetNode[] nodes) {
-        if(nodes!=null)
-        {
-           int nodeSize=nodes.length;
-            for (RouteResultsetNode node : nodes)
-            {
+        if (nodes != null) {
+            int nodeSize = nodes.length;
+            for (RouteResultsetNode node : nodes) {
                 node.setTotalNodeSize(nodeSize);
             }
 
@@ -327,10 +316,8 @@ public final class RouteResultset implements Serializable {
 
     public void setCallStatement(boolean callStatement) {
         this.callStatement = callStatement;
-        if(nodes!=null)
-        {
-            for (RouteResultsetNode node : nodes)
-            {
+        if (nodes != null) {
+            for (RouteResultsetNode node : nodes) {
                 node.setCallStatement(callStatement);
             }
 
@@ -338,26 +325,21 @@ public final class RouteResultset implements Serializable {
     }
 
     public void changeNodeSqlAfterAddLimit(SchemaConfig schemaConfig, String sourceDbType, String sql, int offset, int count, boolean isNeedConvert) {
-        if (nodes != null)
-        {
+        if (nodes != null) {
 
             Map<String, String> dataNodeDbTypeMap = schemaConfig.getDataNodeDbTypeMap();
             Map<String, String> sqlMapCache = new HashMap<>();
-            for (RouteResultsetNode node : nodes)
-            {
+            for (RouteResultsetNode node : nodes) {
                 String dbType = dataNodeDbTypeMap.get(node.getName());
-                if (dbType.equalsIgnoreCase("mysql")) 
-                {
+                if (dbType.equalsIgnoreCase("mysql")) {
                     node.setStatement(sql);   //mysql之前已经加好limit
-                } else if (sqlMapCache.containsKey(dbType))
-                {
+                } else if (sqlMapCache.containsKey(dbType)) {
                     node.setStatement(sqlMapCache.get(dbType));
-                } else if(isNeedConvert)
-                {
+                } else if (isNeedConvert) {
                     String nativeSql = PageSQLUtil.convertLimitToNativePageSql(dbType, sql, offset, count);
                     sqlMapCache.put(dbType, nativeSql);
                     node.setStatement(nativeSql);
-                }  else {
+                } else {
                     node.setStatement(sql);
                 }
 
@@ -385,48 +367,48 @@ public final class RouteResultset implements Serializable {
         this.canRunInReadDB = canRunInReadDB;
     }
 
-	public HavingCols getHavingCols() {
-		return (sqlMerge != null) ? sqlMerge.getHavingCols() : null;
-	}
+    public HavingCols getHavingCols() {
+        return (sqlMerge != null) ? sqlMerge.getHavingCols() : null;
+    }
 
-	public void setSubTables(Set<String> subTables) {
-		this.subTables = subTables;
-	}
+    public void setSubTables(Set<String> subTables) {
+        this.subTables = subTables;
+    }
 
-	public void setHavings(HavingCols havings) {
-		if (havings != null) {
-			createSQLMergeIfNull().setHavingCols(havings);
-		}
-	}
+    public void setHavings(HavingCols havings) {
+        if (havings != null) {
+            createSQLMergeIfNull().setHavingCols(havings);
+        }
+    }
 
-	// Added by winbill, 20160314, for having clause, Begin ==>
-	public void setHavingColsName(Object[] names) {
-		if (names != null && names.length > 0) {
-			createSQLMergeIfNull().setHavingColsName(names);
-		}
-	}
-	// Added by winbill, 20160314, for having clause, End  <==
+    // Added by winbill, 20160314, for having clause, Begin ==>
+    public void setHavingColsName(Object[] names) {
+        if (names != null && names.length > 0) {
+            createSQLMergeIfNull().setHavingColsName(names);
+        }
+    }
+    // Added by winbill, 20160314, for having clause, End  <==
 
     public SQLStatement getSqlStatement() {
-		return this.sqlStatement;
-	}
+        return this.sqlStatement;
+    }
 
-	public void setSqlStatement(SQLStatement sqlStatement) {
-		this.sqlStatement = sqlStatement;
-	}
+    public void setSqlStatement(SQLStatement sqlStatement) {
+        this.sqlStatement = sqlStatement;
+    }
 
-	public Set<String> getSubTables() {
-		return this.subTables;
-	}
-	
-	public boolean isDistTable(){
-		if(this.getSubTables()!=null && !this.getSubTables().isEmpty() ){
-			return true;
-		}
-		return false;
-	}
+    public Set<String> getSubTables() {
+        return this.subTables;
+    }
 
-	@Override
+    public boolean isDistTable() {
+        if (this.getSubTables() != null && !this.getSubTables().isEmpty()) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
     public String toString() {
         StringBuilder s = new StringBuilder();
         s.append(statement).append(", route={");

--- a/src/main/java/io/mycat/route/function/PartitionByPostfix.java
+++ b/src/main/java/io/mycat/route/function/PartitionByPostfix.java
@@ -11,8 +11,55 @@ import io.mycat.config.model.rule.RuleAlgorithm;
  * @version 1.0.0
  */
 public class PartitionByPostfix extends AbstractPartitionAlgorithm implements RuleAlgorithm {
+    private Integer firstValue;
+    private String prefix;
+    private String postfix;
+
+    @Override
+    public void init() {
+        if (null == firstValue) firstValue = 0;
+        if (null == prefix) prefix = "";
+    }
+
     @Override
     public Integer calculate(String columnValue) {
-        return Integer.parseInt(columnValue) - 1;
+        // 1. 按照 prefix 和 postfix 解析真正的序号
+        String finalValue = columnValue;
+        if (columnValue.startsWith(prefix))
+            finalValue = finalValue.substring(finalValue.indexOf(prefix) + 1, finalValue.length());
+        if (columnValue.endsWith(postfix)) finalValue = finalValue.substring(0, finalValue.lastIndexOf(postfix));
+        return Integer.parseInt(finalValue) - firstValue;
+    }
+
+    public Integer getFirst() {
+        return firstValue;
+    }
+
+    public void setFirst(Integer first) {
+        this.firstValue = first;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public Integer getFirstValue() {
+        return firstValue;
+    }
+
+    public void setFirstValue(Integer firstValue) {
+        this.firstValue = firstValue;
+    }
+
+    public String getPostfix() {
+        return postfix;
+    }
+
+    public void setPostfix(String postfix) {
+        this.postfix = postfix;
     }
 }

--- a/src/main/java/io/mycat/route/function/PartitionByPostfix.java
+++ b/src/main/java/io/mycat/route/function/PartitionByPostfix.java
@@ -1,0 +1,18 @@
+package io.mycat.route.function;
+
+import io.mycat.config.model.rule.RuleAlgorithm;
+
+/**
+ * 根据后缀分表
+ * <p>
+ * COPYRIGHT © 2001 - 2016 VOYAGE ONE GROUP INC. ALL RIGHTS RESERVED.
+ *
+ * @author vantis 2017/10/9
+ * @version 1.0.0
+ */
+public class PartitionByPostfix extends AbstractPartitionAlgorithm implements RuleAlgorithm {
+    @Override
+    public Integer calculate(String columnValue) {
+        return Integer.parseInt(columnValue) - 1;
+    }
+}

--- a/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
@@ -436,8 +436,7 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
             SQLInsertStatement insertStatement = (SQLInsertStatement) statement;
             tableSource = insertStatement.getTableSource();
             for (RouteResultsetNode node : rrs.getNodes()) {
-                SQLExprTableSource from2 = getDisTable(tableSource, node);
-                from2.setAlias(tableSource.getAlias());
+                SQLExprTableSource from2 = getSqlExprTableSource(tableSource, node);
                 insertStatement.setTableSource(from2);
                 node.setStatement(insertStatement.toString());
             }
@@ -446,8 +445,7 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
             SQLDeleteStatement deleteStatement = (SQLDeleteStatement) statement;
             tableSource = deleteStatement.getTableSource();
             for (RouteResultsetNode node : rrs.getNodes()) {
-                SQLExprTableSource from2 = getDisTable(tableSource, node);
-                from2.setAlias(tableSource.getAlias());
+                SQLExprTableSource from2 = getSqlExprTableSource(tableSource, node);
                 deleteStatement.setTableSource(from2);
                 node.setStatement(deleteStatement.toString());
             }
@@ -456,14 +454,20 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
             SQLUpdateStatement updateStatement = (SQLUpdateStatement) statement;
             tableSource = updateStatement.getTableSource();
             for (RouteResultsetNode node : rrs.getNodes()) {
-                SQLExprTableSource from2 = getDisTable(tableSource, node);
-                from2.setAlias(tableSource.getAlias());
+                SQLExprTableSource from2 = getSqlExprTableSource(tableSource, node);
                 updateStatement.setTableSource(from2);
                 node.setStatement(updateStatement.toString());
             }
         }
 
         return rrs;
+    }
+
+    private SQLExprTableSource getSqlExprTableSource(SQLTableSource tableSource, RouteResultsetNode node)
+            throws SQLSyntaxErrorException {
+        SQLExprTableSource from2 = getDisTable(tableSource, node);
+        from2.setAlias(tableSource.getAlias());
+        return from2;
     }
 
     /**

--- a/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
@@ -437,6 +437,7 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
             tableSource = insertStatement.getTableSource();
             for (RouteResultsetNode node : rrs.getNodes()) {
                 SQLExprTableSource from2 = getDisTable(tableSource, node);
+                from2.setAlias(tableSource.getAlias());
                 insertStatement.setTableSource(from2);
                 node.setStatement(insertStatement.toString());
             }
@@ -446,6 +447,7 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
             tableSource = deleteStatement.getTableSource();
             for (RouteResultsetNode node : rrs.getNodes()) {
                 SQLExprTableSource from2 = getDisTable(tableSource, node);
+                from2.setAlias(tableSource.getAlias());
                 deleteStatement.setTableSource(from2);
                 node.setStatement(deleteStatement.toString());
             }
@@ -455,6 +457,7 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
             tableSource = updateStatement.getTableSource();
             for (RouteResultsetNode node : rrs.getNodes()) {
                 SQLExprTableSource from2 = getDisTable(tableSource, node);
+                from2.setAlias(tableSource.getAlias());
                 updateStatement.setTableSource(from2);
                 node.setStatement(updateStatement.toString());
             }

--- a/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
@@ -1,36 +1,10 @@
 package io.mycat.route.impl;
 
-import java.sql.SQLNonTransientException;
-import java.sql.SQLSyntaxErrorException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLObject;
 import com.alibaba.druid.sql.ast.SQLStatement;
-import com.alibaba.druid.sql.ast.expr.SQLAllExpr;
-import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
-import com.alibaba.druid.sql.ast.expr.SQLExistsExpr;
-import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
-import com.alibaba.druid.sql.ast.expr.SQLInSubQueryExpr;
-import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
-import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
-import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
-import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
-import com.alibaba.druid.sql.ast.statement.SQLSelect;
-import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
-import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
-import com.alibaba.druid.sql.ast.statement.SQLTableSource;
-import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
+import com.alibaba.druid.sql.ast.expr.*;
+import com.alibaba.druid.sql.ast.statement.*;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlInsertStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlReplaceStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
@@ -38,7 +12,6 @@ import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
 import com.alibaba.druid.sql.parser.SQLStatementParser;
 import com.alibaba.druid.stat.TableStat.Relationship;
 import com.google.common.base.Strings;
-
 import io.mycat.MycatServer;
 import io.mycat.backend.mysql.nio.handler.MiddlerQueryResultHandler;
 import io.mycat.backend.mysql.nio.handler.MiddlerResultHandler;
@@ -51,540 +24,539 @@ import io.mycat.config.model.rule.RuleConfig;
 import io.mycat.route.RouteResultset;
 import io.mycat.route.RouteResultsetNode;
 import io.mycat.route.function.SlotFunction;
-import io.mycat.route.impl.middlerResultStrategy.BinaryOpResultHandler;
-import io.mycat.route.impl.middlerResultStrategy.InSubQueryResultHandler;
-import io.mycat.route.impl.middlerResultStrategy.RouteMiddlerReaultHandler;
-import io.mycat.route.impl.middlerResultStrategy.SQLAllResultHandler;
-import io.mycat.route.impl.middlerResultStrategy.SQLExistsResultHandler;
-import io.mycat.route.impl.middlerResultStrategy.SQLQueryResultHandler;
-import io.mycat.route.parser.druid.DruidParser;
-import io.mycat.route.parser.druid.DruidParserFactory;
-import io.mycat.route.parser.druid.DruidShardingParseInfo;
-import io.mycat.route.parser.druid.MycatSchemaStatVisitor;
-import io.mycat.route.parser.druid.MycatStatementParser;
-import io.mycat.route.parser.druid.RouteCalculateUnit;
+import io.mycat.route.impl.middlerResultStrategy.*;
+import io.mycat.route.parser.druid.*;
 import io.mycat.route.parser.util.ParseUtil;
 import io.mycat.route.util.RouterUtil;
 import io.mycat.server.NonBlockingSession;
 import io.mycat.server.ServerConnection;
 import io.mycat.server.parser.ServerParse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLNonTransientException;
+import java.sql.SQLSyntaxErrorException;
+import java.util.*;
 
 public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
-	
-	public static final Logger LOGGER = LoggerFactory.getLogger(DruidMycatRouteStrategy.class);
-	
-	private static Map<Class<?>,RouteMiddlerReaultHandler> middlerResultHandler = new HashMap<>();
-	
-	static{
-		middlerResultHandler.put(SQLQueryExpr.class, new SQLQueryResultHandler());
-		middlerResultHandler.put(SQLBinaryOpExpr.class, new BinaryOpResultHandler());
-		middlerResultHandler.put(SQLInSubQueryExpr.class, new InSubQueryResultHandler());
-		middlerResultHandler.put(SQLExistsExpr.class, new SQLExistsResultHandler());
-		middlerResultHandler.put(SQLAllExpr.class, new SQLAllResultHandler());
-	}
-	
-	
-	@Override
-	public RouteResultset routeNormalSqlWithAST(SchemaConfig schema,
-			String stmt, RouteResultset rrs,String charset,
-			LayerCachePool cachePool,int sqlType,ServerConnection sc) throws SQLNonTransientException {
-		
-		/**
-		 *  只有mysql时只支持mysql语法
-		 */
-		SQLStatementParser parser = null;
-		if (schema.isNeedSupportMultiDBType()) {
-			parser = new MycatStatementParser(stmt);
-		} else {
-			parser = new MySqlStatementParser(stmt); 
-		}
 
-		MycatSchemaStatVisitor visitor = null;
-		SQLStatement statement;
-		
-		/**
-		 * 解析出现问题统一抛SQL语法错误
-		 */
-		try {
-			statement = parser.parseStatement();
+    public static final Logger LOGGER = LoggerFactory.getLogger(DruidMycatRouteStrategy.class);
+
+    private static Map<Class<?>, RouteMiddlerReaultHandler> middlerResultHandler = new HashMap<>();
+
+    static {
+        middlerResultHandler.put(SQLQueryExpr.class, new SQLQueryResultHandler());
+        middlerResultHandler.put(SQLBinaryOpExpr.class, new BinaryOpResultHandler());
+        middlerResultHandler.put(SQLInSubQueryExpr.class, new InSubQueryResultHandler());
+        middlerResultHandler.put(SQLExistsExpr.class, new SQLExistsResultHandler());
+        middlerResultHandler.put(SQLAllExpr.class, new SQLAllResultHandler());
+    }
+
+
+    @Override
+    public RouteResultset routeNormalSqlWithAST(SchemaConfig schema,
+                                                String stmt, RouteResultset rrs, String charset,
+                                                LayerCachePool cachePool, int sqlType, ServerConnection sc) throws SQLNonTransientException {
+
+        /**
+         *  只有mysql时只支持mysql语法
+         */
+        SQLStatementParser parser = null;
+        if (schema.isNeedSupportMultiDBType()) {
+            parser = new MycatStatementParser(stmt);
+        } else {
+            parser = new MySqlStatementParser(stmt);
+        }
+
+        MycatSchemaStatVisitor visitor = null;
+        SQLStatement statement;
+
+        /**
+         * 解析出现问题统一抛SQL语法错误
+         */
+        try {
+            statement = parser.parseStatement();
             visitor = new MycatSchemaStatVisitor();
-		} catch (Exception t) {
-	        LOGGER.error("DruidMycatRouteStrategyError", t);
-			throw new SQLSyntaxErrorException(t);
-		}
+        } catch (Exception t) {
+            LOGGER.error("DruidMycatRouteStrategyError", t);
+            throw new SQLSyntaxErrorException(t);
+        }
 
-		/**
-		 * 检验unsupported statement
-		 */
-		checkUnSupportedStatement(statement);
+        /**
+         * 检验unsupported statement
+         */
+        checkUnSupportedStatement(statement);
 
-		DruidParser druidParser = DruidParserFactory.create(schema, statement, visitor);
-		druidParser.parser(schema, rrs, statement, stmt,cachePool,visitor);
-		DruidShardingParseInfo ctx=  druidParser.getCtx() ;
-		rrs.setTables(ctx.getTables());
-		
-		if(visitor.isSubqueryRelationOr()){
-			String err = "In subQuery,the or condition is not supported.";
-			LOGGER.error(err);
-			throw new SQLSyntaxErrorException(err);
-		}
-		
+        DruidParser druidParser = DruidParserFactory.create(schema, statement, visitor);
+        druidParser.parser(schema, rrs, statement, stmt, cachePool, visitor);
+        DruidShardingParseInfo ctx = druidParser.getCtx();
+        rrs.setTables(ctx.getTables());
+
+        if (visitor.isSubqueryRelationOr()) {
+            String err = "In subQuery,the or condition is not supported.";
+            LOGGER.error(err);
+            throw new SQLSyntaxErrorException(err);
+        }
+
 		/* 按照以下情况路由
-			1.2.1 可以直接路由.
+            1.2.1 可以直接路由.
        		1.2.2 两个表夸库join的sql.调用calat
        		1.2.3 需要先执行subquery 的sql.把subquery拆分出来.获取结果后,与outerquery
 		 */
-		
-		//add huangyiming 分片规则不一样的且表中带查询条件的则走Catlet
-		List<String> tables = ctx.getTables();
-		SchemaConfig schemaConf = MycatServer.getInstance().getConfig().getSchemas().get(schema.getName());
-		int index = 0;
-		RuleConfig firstRule = null;
-		boolean directRoute = true;
-		Set<String> firstDataNodes = new HashSet<String>();
-		Map<String, TableConfig> tconfigs = schemaConf==null?null:schemaConf.getTables();
-		
-		Map<String,RuleConfig> rulemap = new HashMap<>();
-		if(tconfigs!=null){	
-	        for(String tableName : tables){
-	            TableConfig tc =  tconfigs.get(tableName);
-	            if(tc == null){
-	              //add 别名中取
-	              Map<String, String> tableAliasMap = ctx.getTableAliasMap();
-	              if(tableAliasMap !=null && tableAliasMap.get(tableName) !=null){
-	                tc = schemaConf.getTables().get(tableAliasMap.get(tableName));
-	              }
-	            }
 
-	            if(index == 0){
-	            	 if(tc !=null){
-		                firstRule=  tc.getRule();
-						//没有指定分片规则时,不做处理
-		                if(firstRule==null){
-		                	continue;
-		                }
-		                firstDataNodes.addAll(tc.getDataNodes());
-		                rulemap.put(tc.getName(), firstRule);
-	            	 }
-	            }else{
-	                if(tc !=null){
-	                  //ER关系表的时候是可能存在字表中没有tablerule的情况,所以加上判断
-	                    RuleConfig ruleCfg = tc.getRule();
-	                    if(ruleCfg==null){  //没有指定分片规则时,不做处理
-	                    	continue;
-	                    }
-	                    Set<String> dataNodes = new HashSet<String>();
-	                    dataNodes.addAll(tc.getDataNodes());
-	                    rulemap.put(tc.getName(), ruleCfg);
-	                    //如果匹配规则不相同或者分片的datanode不相同则需要走子查询处理
-	                    if(firstRule!=null&&((ruleCfg !=null && !ruleCfg.getRuleAlgorithm().equals(firstRule.getRuleAlgorithm()) )||( !dataNodes.equals(firstDataNodes)))){
-	                      directRoute = false;
-	                      break;
-	                    }
-	                }
-	            }
-	            index++;
-	        }
-		} 
-		
-		RouteResultset rrsResult = rrs;
-		if(directRoute){ //直接路由
-			if(!RouterUtil.isAllGlobalTable(ctx, schemaConf)){
-				if(rulemap.size()>1&&!checkRuleField(rulemap,visitor)){
-					String err = "In case of slice table,sql have same rules,but the relationship condition is different from rule field!";
-					LOGGER.error(err);
-					throw new SQLSyntaxErrorException(err);
-				}
-			}
-			rrsResult = directRoute(rrs,ctx,schema,druidParser,statement,cachePool);
-		}else{
-			int subQuerySize = visitor.getSubQuerys().size();
-			if(subQuerySize==0&&ctx.getTables().size()==2){ //两表关联,考虑使用catlet
-			    if(!visitor.getRelationships().isEmpty()){
-			    	rrs.setCacheAble(false);
-			    	rrs.setFinishedRoute(true);
-			    	rrsResult = catletRoute(schema,ctx.getSql(),charset,sc);
-				}else{
-					rrsResult = directRoute(rrs,ctx,schema,druidParser,statement,cachePool);
-				}
-			}else if(subQuerySize==1){     //只涉及一张表的子查询,使用  MiddlerResultHandler 获取中间结果后,改写原有 sql 继续执行 TODO 后期可能会考虑多个子查询的情况.
-				SQLSelect sqlselect = visitor.getSubQuerys().iterator().next();
-				if(!visitor.getRelationships().isEmpty()){     // 当 inner query  和 outer  query  有关联条件时,暂不支持
-					String err = "In case of slice table,sql have different rules,the relationship condition is not supported.";
-					LOGGER.error(err);
-					throw new SQLSyntaxErrorException(err);
-				}else{
-					SQLSelectQuery sqlSelectQuery = sqlselect.getQuery();
-					if(((MySqlSelectQueryBlock)sqlSelectQuery).getFrom() instanceof SQLExprTableSource) {
-						rrs.setCacheAble(false);
-						rrs.setFinishedRoute(true);
-						rrsResult = middlerResultRoute(schema,charset,sqlselect,sqlType,statement,sc);
-					}
-				}
-			}else if(subQuerySize >=2){
-				String err = "In case of slice table,sql has different rules,currently only one subQuery is supported.";
-				LOGGER.error(err);
-				throw new SQLSyntaxErrorException(err);
-			}
-		}
-		return rrsResult;
-	}
-	
-	/**
-	 * 子查询中存在关联查询的情况下,检查关联字段是否是分片字段
-	 * @param rulemap
-	 * @param ships
-	 * @return
-	 */
-	private boolean checkRuleField(Map<String,RuleConfig> rulemap,MycatSchemaStatVisitor visitor){
-		
-		Set<Relationship> ships = visitor.getRelationships();
-		Iterator<Relationship> iter = ships.iterator();
-		while(iter.hasNext()){
-			Relationship ship = iter.next();
-			String lefttable = ship.getLeft().getTable().toUpperCase();
-			String righttable = ship.getRight().getTable().toUpperCase();
-			// 如果是同一个表中的关联条件,不做处理
-			if(lefttable.equals(righttable)){
-				return true;
-			}
-			RuleConfig leftconfig = rulemap.get(lefttable);
-			if(leftconfig!=null){
-				if(!leftconfig.getColumn().equals(ship.getLeft().getName().toUpperCase())){
-					return false;
-				}
-			}
-			RuleConfig rightconfig = rulemap.get(righttable);
-			if(rightconfig!=null){
-				if(!rightconfig.getColumn().equals(ship.getRight().getName().toUpperCase())){
-					return false;
-				}
-			}
-		}
-		return true;
-	}
-	
-	private RouteResultset middlerResultRoute(final SchemaConfig schema,final String charset,final SQLSelect sqlselect,
-												final int sqlType,final SQLStatement statement,final ServerConnection sc){
-		
-		final String middlesql = SQLUtils.toMySqlString(sqlselect);
-		
-    	MiddlerResultHandler<String> middlerResultHandler =  new MiddlerQueryResultHandler<>(new SecondHandler() {						 
-				@Override
-				public void doExecute(List param) {
-					sc.getSession2().setMiddlerResultHandler(null);
-					String sqls = null;
-					// 路由计算
-					RouteResultset rrs = null;
-					try {
-						
-						sqls = buildSql(statement,sqlselect,param);
-						rrs = MycatServer
-								.getInstance()
-								.getRouterservice()
-								.route(MycatServer.getInstance().getConfig().getSystem(),
-										schema, sqlType,sqls.toLowerCase(), charset,sc );
+        //add huangyiming 分片规则不一样的且表中带查询条件的则走Catlet
+        List<String> tables = ctx.getTables();
+        SchemaConfig schemaConf = MycatServer.getInstance().getConfig().getSchemas().get(schema.getName());
+        int index = 0;
+        RuleConfig firstRule = null;
+        boolean directRoute = true;
+        Set<String> firstDataNodes = new HashSet<String>();
+        Map<String, TableConfig> tconfigs = schemaConf == null ? null : schemaConf.getTables();
 
-					} catch (Exception e) {
-						StringBuilder s = new StringBuilder();
-						LOGGER.warn(s.append(this).append(sqls).toString() + " err:" + e.toString(),e);
-						String msg = e.getMessage();
-						sc.writeErrMessage(ErrorCode.ER_PARSE_ERROR, msg == null ? e.getClass().getSimpleName() : msg);
-						return;
-					}
-					NonBlockingSession noBlockSession =  new NonBlockingSession(sc.getSession2().getSource());
-					noBlockSession.setMiddlerResultHandler(null);
-					//session的预编译标示传递
-					noBlockSession.setPrepared(sc.getSession2().isPrepared());
-					if (rrs != null) {						
-						noBlockSession.setCanClose(false);
-						noBlockSession.execute(rrs, ServerParse.SELECT);
-					}
-				}
-			} );
-    	sc.getSession2().setMiddlerResultHandler(middlerResultHandler);
-    	sc.getSession2().setCanClose(false);
-    
-		// 路由计算
-		RouteResultset rrs = null;
-		try {
-			rrs = MycatServer
-					.getInstance()
-					.getRouterservice()
-					.route(MycatServer.getInstance().getConfig().getSystem(),
-							schema, ServerParse.SELECT, middlesql, charset, sc);
-	
-		} catch (Exception e) {
-			StringBuilder s = new StringBuilder();
-			LOGGER.warn(s.append(this).append(middlesql).toString() + " err:" + e.toString(),e);
-			String msg = e.getMessage();
-			sc.writeErrMessage(ErrorCode.ER_PARSE_ERROR, msg == null ? e.getClass().getSimpleName() : msg);
-			return null;
-		}
-		
-		if(rrs!=null){
-			rrs.setCacheAble(false);
-		}
-		return rrs;
-	}
-	
-	/**
-	 * 获取子查询执行结果后,改写原始sql 继续执行.
-	 * @param statement
-	 * @param sqlselect
-	 * @param param
-	 * @return
-	 */
-	private String buildSql(SQLStatement statement,SQLSelect sqlselect,List param){
+        Map<String, RuleConfig> rulemap = new HashMap<>();
+        if (tconfigs != null) {
+            for (String tableName : tables) {
+                TableConfig tc = tconfigs.get(tableName);
+                if (tc == null) {
+                    //add 别名中取
+                    Map<String, String> tableAliasMap = ctx.getTableAliasMap();
+                    if (tableAliasMap != null && tableAliasMap.get(tableName) != null) {
+                        tc = schemaConf.getTables().get(tableAliasMap.get(tableName));
+                    }
+                }
 
-		SQLObject parent = sqlselect.getParent();
-		RouteMiddlerReaultHandler handler = middlerResultHandler.get(parent.getClass());
-		if(handler==null){
-			throw new UnsupportedOperationException(parent.getClass()+" current is not supported ");
-		}
-		return handler.dohandler(statement, sqlselect, parent, param);
-	}
-	
-	/**
-	 * 两个表的情况，catlet
-	 * @param schema
-	 * @param stmt
-	 * @param charset
-	 * @param sc
-	 * @return
-	 */
-	private RouteResultset catletRoute(SchemaConfig schema,String stmt,String charset,ServerConnection sc){
-		RouteResultset rrs = null;
-		try {
-			rrs = MycatServer
-					.getInstance()
-					.getRouterservice()
-					.route(MycatServer.getInstance().getConfig().getSystem(),
-							schema, ServerParse.SELECT, "/*!mycat:catlet=io.mycat.catlets.ShareJoin */ "+stmt, charset, sc);
-			
-		}catch(Exception e){
-			
-		}
-		return rrs;
-	}
-	
-	/**
-	 *  直接结果路由
-	 * @param rrs
-	 * @param ctx
-	 * @param schema
-	 * @param druidParser
-	 * @param statement
-	 * @param cachePool
-	 * @return
-	 * @throws SQLNonTransientException
-	 */
-	private RouteResultset directRoute(RouteResultset rrs,DruidShardingParseInfo ctx,SchemaConfig schema,
-										DruidParser druidParser,SQLStatement statement,LayerCachePool cachePool) throws SQLNonTransientException{
-		
-		//改写sql：如insert语句主键自增长, 在直接结果路由的情况下,进行sql 改写处理
-		druidParser.changeSql(schema, rrs, statement,cachePool);
-		
-		/**
-		 * DruidParser 解析过程中已完成了路由的直接返回
-		 */
-		if ( rrs.isFinishedRoute() ) {
-			return rrs;
-		}
-		
-		/**
-		 * 没有from的select语句或其他
-		 */
-        if((ctx.getTables() == null || ctx.getTables().size() == 0)&&(ctx.getTableAliasMap()==null||ctx.getTableAliasMap().isEmpty()))
-        {
-		    return RouterUtil.routeToSingleNode(rrs, schema.getRandomDataNode(), druidParser.getCtx().getSql());
-		}
-
-		if(druidParser.getCtx().getRouteCalculateUnits().size() == 0) {
-			RouteCalculateUnit routeCalculateUnit = new RouteCalculateUnit();
-			druidParser.getCtx().addRouteCalculateUnit(routeCalculateUnit);
-		}
-		
-		SortedSet<RouteResultsetNode> nodeSet = new TreeSet<RouteResultsetNode>();
-		boolean isAllGlobalTable = RouterUtil.isAllGlobalTable(ctx, schema);
-		for(RouteCalculateUnit unit: druidParser.getCtx().getRouteCalculateUnits()) {
-			RouteResultset rrsTmp = RouterUtil.tryRouteForTables(schema, druidParser.getCtx(), unit, rrs, isSelect(statement), cachePool);
-			if(rrsTmp != null&&rrsTmp.getNodes()!=null) {
-				for(RouteResultsetNode node :rrsTmp.getNodes()) {
-					nodeSet.add(node);
-				}
-			}
-			if(isAllGlobalTable) {//都是全局表时只计算一遍路由
-				break;
-			}
-		}
-		
-		RouteResultsetNode[] nodes = new RouteResultsetNode[nodeSet.size()];
-		int i = 0;
-		for (RouteResultsetNode aNodeSet : nodeSet) {
-			nodes[i] = aNodeSet;
-			  if(statement instanceof MySqlInsertStatement &&ctx.getTables().size()==1&&schema.getTables().containsKey(ctx.getTables().get(0))) {
-				  RuleConfig rule = schema.getTables().get(ctx.getTables().get(0)).getRule();
-				  if(rule!=null&&  rule.getRuleAlgorithm() instanceof SlotFunction){
-					 aNodeSet.setStatement(ParseUtil.changeInsertAddSlot(aNodeSet.getStatement(),aNodeSet.getSlot()));
-				  }
-			  }
-			i++;
-		}		
-		rrs.setNodes(nodes);		
-		
-		//分表
-		/**
-		 *  subTables="t_order$1-2,t_order3"
-		 *目前分表 1.6 开始支持 幵丏 dataNode 在分表条件下只能配置一个，分表条件下不支持join。
-		 */
-		if(rrs.isDistTable()){
-			return this.routeDisTable(statement,rrs);
-		}
-		return rrs;
-	}
-	
-	private SQLExprTableSource getDisTable(SQLTableSource tableSource,RouteResultsetNode node) throws SQLSyntaxErrorException{
-		if(node.getSubTableName()==null){
-			String msg = " sub table not exists for " + node.getName() + " on " + tableSource;
-			LOGGER.error("DruidMycatRouteStrategyError " + msg);
-			throw new SQLSyntaxErrorException(msg);
-		}
-		
-		SQLIdentifierExpr sqlIdentifierExpr = new SQLIdentifierExpr();
-		sqlIdentifierExpr.setParent(tableSource.getParent());
-		sqlIdentifierExpr.setName(node.getSubTableName());
-		SQLExprTableSource from2 = new SQLExprTableSource(sqlIdentifierExpr);
-		return from2;
-	}
-	
-	private RouteResultset routeDisTable(SQLStatement statement, RouteResultset rrs) throws SQLSyntaxErrorException{
-		SQLTableSource tableSource = null;
-		if(statement instanceof SQLInsertStatement) {
-			SQLInsertStatement insertStatement = (SQLInsertStatement) statement;
-			tableSource = insertStatement.getTableSource();
-			for (RouteResultsetNode node : rrs.getNodes()) {
-				SQLExprTableSource from2 = getDisTable(tableSource, node);
-				insertStatement.setTableSource(from2);
-				node.setStatement(insertStatement.toString());
-	        }
-		}
-		if(statement instanceof SQLDeleteStatement) {
-			SQLDeleteStatement deleteStatement = (SQLDeleteStatement) statement;
-			tableSource = deleteStatement.getTableSource();
-			for (RouteResultsetNode node : rrs.getNodes()) {
-				SQLExprTableSource from2 = getDisTable(tableSource, node);
-				deleteStatement.setTableSource(from2);
-				node.setStatement(deleteStatement.toString());
-	        }
-		}
-		if(statement instanceof SQLUpdateStatement) {
-			SQLUpdateStatement updateStatement = (SQLUpdateStatement) statement;
-			tableSource = updateStatement.getTableSource();
-			for (RouteResultsetNode node : rrs.getNodes()) {
-				SQLExprTableSource from2 = getDisTable(tableSource, node);
-				updateStatement.setTableSource(from2);
-				node.setStatement(updateStatement.toString());
-	        }
-		}
-		
-		return rrs;
-	}
-
-	/**
-	 * SELECT 语句
-	 */
-    private boolean isSelect(SQLStatement statement) {
-		if(statement instanceof SQLSelectStatement) {
-			return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * 检验不支持的SQLStatement类型 ：不支持的类型直接抛SQLSyntaxErrorException异常
-	 * @param statement
-	 * @throws SQLSyntaxErrorException
-	 */
-	private void checkUnSupportedStatement(SQLStatement statement) throws SQLSyntaxErrorException {
-		//不支持replace语句
-		if(statement instanceof MySqlReplaceStatement) {
-			throw new SQLSyntaxErrorException(" ReplaceStatement can't be supported,use insert into ...on duplicate key update... instead ");
-		}
-	}
-	
-	/**
-	 * 分析 SHOW SQL
-	 */
-	@Override
-	public RouteResultset analyseShowSQL(SchemaConfig schema,
-			RouteResultset rrs, String stmt) throws SQLSyntaxErrorException {
-		
-		String upStmt = stmt.toUpperCase();
-		int tabInd = upStmt.indexOf(" TABLES");
-		if (tabInd > 0) {// show tables
-			int[] nextPost = RouterUtil.getSpecPos(upStmt, 0);
-			if (nextPost[0] > 0) {// remove db info
-				int end = RouterUtil.getSpecEndPos(upStmt, tabInd);
-				if (upStmt.indexOf(" FULL") > 0) {
-					stmt = "SHOW FULL TABLES" + stmt.substring(end);
-				} else {
-					stmt = "SHOW TABLES" + stmt.substring(end);
-				}
-			}
-          String defaultNode=  schema.getDataNode();
-            if(!Strings.isNullOrEmpty(defaultNode))
-            {
-             return    RouterUtil.routeToSingleNode(rrs, defaultNode, stmt);
+                if (index == 0) {
+                    if (tc != null) {
+                        firstRule = tc.getRule();
+                        //没有指定分片规则时,不做处理
+                        if (firstRule == null) {
+                            continue;
+                        }
+                        firstDataNodes.addAll(tc.getDataNodes());
+                        rulemap.put(tc.getName(), firstRule);
+                    }
+                } else {
+                    if (tc != null) {
+                        //ER关系表的时候是可能存在字表中没有tablerule的情况,所以加上判断
+                        RuleConfig ruleCfg = tc.getRule();
+                        if (ruleCfg == null) {  //没有指定分片规则时,不做处理
+                            continue;
+                        }
+                        Set<String> dataNodes = new HashSet<String>();
+                        dataNodes.addAll(tc.getDataNodes());
+                        rulemap.put(tc.getName(), ruleCfg);
+                        //如果匹配规则不相同或者分片的datanode不相同则需要走子查询处理
+                        if (firstRule != null && ((ruleCfg != null && !ruleCfg.getRuleAlgorithm().equals(firstRule.getRuleAlgorithm())) || (!dataNodes.equals(firstDataNodes)))) {
+                            directRoute = false;
+                            break;
+                        }
+                    }
+                }
+                index++;
             }
-			return RouterUtil.routeToMultiNode(false, rrs, schema.getMetaDataNodes(), stmt);
-		}
-		
-		/**
-		 *  show index or column
-		 */
-		int[] indx = RouterUtil.getSpecPos(upStmt, 0);
-		if (indx[0] > 0) {
-			/**
-			 *  has table
-			 */
-			int[] repPos = { indx[0] + indx[1], 0 };
-			String tableName = RouterUtil.getShowTableName(stmt, repPos);
-			/**
-			 *  IN DB pattern
-			 */
-			int[] indx2 = RouterUtil.getSpecPos(upStmt, indx[0] + indx[1] + 1);
-			if (indx2[0] > 0) {// find LIKE OR WHERE
-				repPos[1] = RouterUtil.getSpecEndPos(upStmt, indx2[0] + indx2[1]);
+        }
 
-			}
-			stmt = stmt.substring(0, indx[0]) + " FROM " + tableName + stmt.substring(repPos[1]);
-			RouterUtil.routeForTableMeta(rrs, schema, tableName, stmt);
-			return rrs;
+        RouteResultset rrsResult = rrs;
+        if (directRoute) { //直接路由
+            if (!RouterUtil.isAllGlobalTable(ctx, schemaConf)) {
+                if (rulemap.size() > 1 && !checkRuleField(rulemap, visitor)) {
+                    String err = "In case of slice table,sql have same rules,but the relationship condition is different from rule field!";
+                    LOGGER.error(err);
+                    throw new SQLSyntaxErrorException(err);
+                }
+            }
+            rrsResult = directRoute(rrs, ctx, schema, druidParser, statement, cachePool);
+        } else {
+            int subQuerySize = visitor.getSubQuerys().size();
+            if (subQuerySize == 0 && ctx.getTables().size() == 2) { //两表关联,考虑使用catlet
+                if (!visitor.getRelationships().isEmpty()) {
+                    rrs.setCacheAble(false);
+                    rrs.setFinishedRoute(true);
+                    rrsResult = catletRoute(schema, ctx.getSql(), charset, sc);
+                } else {
+                    rrsResult = directRoute(rrs, ctx, schema, druidParser, statement, cachePool);
+                }
+            } else if (subQuerySize == 1) {     //只涉及一张表的子查询,使用  MiddlerResultHandler 获取中间结果后,改写原有 sql 继续执行 TODO 后期可能会考虑多个子查询的情况.
+                SQLSelect sqlselect = visitor.getSubQuerys().iterator().next();
+                if (!visitor.getRelationships().isEmpty()) {     // 当 inner query  和 outer  query  有关联条件时,暂不支持
+                    String err = "In case of slice table,sql have different rules,the relationship condition is not supported.";
+                    LOGGER.error(err);
+                    throw new SQLSyntaxErrorException(err);
+                } else {
+                    SQLSelectQuery sqlSelectQuery = sqlselect.getQuery();
+                    if (((MySqlSelectQueryBlock) sqlSelectQuery).getFrom() instanceof SQLExprTableSource) {
+                        rrs.setCacheAble(false);
+                        rrs.setFinishedRoute(true);
+                        rrsResult = middlerResultRoute(schema, charset, sqlselect, sqlType, statement, sc);
+                    }
+                }
+            } else if (subQuerySize >= 2) {
+                String err = "In case of slice table,sql has different rules,currently only one subQuery is supported.";
+                LOGGER.error(err);
+                throw new SQLSyntaxErrorException(err);
+            }
+        }
+        return rrsResult;
+    }
 
-		}
-		
-		/**
-		 *  show create table tableName
-		 */
-		int[] createTabInd = RouterUtil.getCreateTablePos(upStmt, 0);
-		if (createTabInd[0] > 0) {
-			int tableNameIndex = createTabInd[0] + createTabInd[1];
-			if (upStmt.length() > tableNameIndex) {
-				String tableName = stmt.substring(tableNameIndex).trim();
-				int ind2 = tableName.indexOf('.');
-				if (ind2 > 0) {
-					tableName = tableName.substring(ind2 + 1);
-				}
-				RouterUtil.routeForTableMeta(rrs, schema, tableName, stmt);
-				return rrs;
-			}
-		}
+    /**
+     * 子查询中存在关联查询的情况下,检查关联字段是否是分片字段
+     *
+     * @param rulemap
+     * @param ships
+     * @return
+     */
+    private boolean checkRuleField(Map<String, RuleConfig> rulemap, MycatSchemaStatVisitor visitor) {
 
-		return RouterUtil.routeToSingleNode(rrs, schema.getRandomDataNode(), stmt);
-	}
-	
-	
+        Set<Relationship> ships = visitor.getRelationships();
+        Iterator<Relationship> iter = ships.iterator();
+        while (iter.hasNext()) {
+            Relationship ship = iter.next();
+            String lefttable = ship.getLeft().getTable().toUpperCase();
+            String righttable = ship.getRight().getTable().toUpperCase();
+            // 如果是同一个表中的关联条件,不做处理
+            if (lefttable.equals(righttable)) {
+                return true;
+            }
+            RuleConfig leftconfig = rulemap.get(lefttable);
+            if (leftconfig != null) {
+                if (!leftconfig.getColumn().equals(ship.getLeft().getName().toUpperCase())) {
+                    return false;
+                }
+            }
+            RuleConfig rightconfig = rulemap.get(righttable);
+            if (rightconfig != null) {
+                if (!rightconfig.getColumn().equals(ship.getRight().getName().toUpperCase())) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private RouteResultset middlerResultRoute(final SchemaConfig schema, final String charset, final SQLSelect sqlselect,
+                                              final int sqlType, final SQLStatement statement, final ServerConnection sc) {
+
+        final String middlesql = SQLUtils.toMySqlString(sqlselect);
+
+        MiddlerResultHandler<String> middlerResultHandler = new MiddlerQueryResultHandler<>(new SecondHandler() {
+            @Override
+            public void doExecute(List param) {
+                sc.getSession2().setMiddlerResultHandler(null);
+                String sqls = null;
+                // 路由计算
+                RouteResultset rrs = null;
+                try {
+
+                    sqls = buildSql(statement, sqlselect, param);
+                    rrs = MycatServer
+                            .getInstance()
+                            .getRouterservice()
+                            .route(MycatServer.getInstance().getConfig().getSystem(),
+                                    schema, sqlType, sqls.toLowerCase(), charset, sc);
+
+                } catch (Exception e) {
+                    StringBuilder s = new StringBuilder();
+                    LOGGER.warn(s.append(this).append(sqls).toString() + " err:" + e.toString(), e);
+                    String msg = e.getMessage();
+                    sc.writeErrMessage(ErrorCode.ER_PARSE_ERROR, msg == null ? e.getClass().getSimpleName() : msg);
+                    return;
+                }
+                NonBlockingSession noBlockSession = new NonBlockingSession(sc.getSession2().getSource());
+                noBlockSession.setMiddlerResultHandler(null);
+                //session的预编译标示传递
+                noBlockSession.setPrepared(sc.getSession2().isPrepared());
+                if (rrs != null) {
+                    noBlockSession.setCanClose(false);
+                    noBlockSession.execute(rrs, ServerParse.SELECT);
+                }
+            }
+        });
+        sc.getSession2().setMiddlerResultHandler(middlerResultHandler);
+        sc.getSession2().setCanClose(false);
+
+        // 路由计算
+        RouteResultset rrs = null;
+        try {
+            rrs = MycatServer
+                    .getInstance()
+                    .getRouterservice()
+                    .route(MycatServer.getInstance().getConfig().getSystem(),
+                            schema, ServerParse.SELECT, middlesql, charset, sc);
+
+        } catch (Exception e) {
+            StringBuilder s = new StringBuilder();
+            LOGGER.warn(s.append(this).append(middlesql).toString() + " err:" + e.toString(), e);
+            String msg = e.getMessage();
+            sc.writeErrMessage(ErrorCode.ER_PARSE_ERROR, msg == null ? e.getClass().getSimpleName() : msg);
+            return null;
+        }
+
+        if (rrs != null) {
+            rrs.setCacheAble(false);
+        }
+        return rrs;
+    }
+
+    /**
+     * 获取子查询执行结果后,改写原始sql 继续执行.
+     *
+     * @param statement
+     * @param sqlselect
+     * @param param
+     * @return
+     */
+    private String buildSql(SQLStatement statement, SQLSelect sqlselect, List param) {
+
+        SQLObject parent = sqlselect.getParent();
+        RouteMiddlerReaultHandler handler = middlerResultHandler.get(parent.getClass());
+        if (handler == null) {
+            throw new UnsupportedOperationException(parent.getClass() + " current is not supported ");
+        }
+        return handler.dohandler(statement, sqlselect, parent, param);
+    }
+
+    /**
+     * 两个表的情况，catlet
+     *
+     * @param schema
+     * @param stmt
+     * @param charset
+     * @param sc
+     * @return
+     */
+    private RouteResultset catletRoute(SchemaConfig schema, String stmt, String charset, ServerConnection sc) {
+        RouteResultset rrs = null;
+        try {
+            rrs = MycatServer
+                    .getInstance()
+                    .getRouterservice()
+                    .route(MycatServer.getInstance().getConfig().getSystem(),
+                            schema, ServerParse.SELECT, "/*!mycat:catlet=io.mycat.catlets.ShareJoin */ " + stmt, charset, sc);
+
+        } catch (Exception e) {
+
+        }
+        return rrs;
+    }
+
+    /**
+     * 直接结果路由
+     *
+     * @param rrs
+     * @param ctx
+     * @param schema
+     * @param druidParser
+     * @param statement
+     * @param cachePool
+     * @return
+     * @throws SQLNonTransientException
+     */
+    private RouteResultset directRoute(RouteResultset rrs, DruidShardingParseInfo ctx, SchemaConfig schema,
+                                       DruidParser druidParser, SQLStatement statement, LayerCachePool cachePool) throws SQLNonTransientException {
+
+        //改写sql：如insert语句主键自增长, 在直接结果路由的情况下,进行sql 改写处理
+        druidParser.changeSql(schema, rrs, statement, cachePool);
+
+        /**
+         * DruidParser 解析过程中已完成了路由的直接返回
+         */
+        if (rrs.isFinishedRoute()) {
+            return rrs;
+        }
+
+        /**
+         * 没有from的select语句或其他
+         */
+        if ((ctx.getTables() == null || ctx.getTables().size() == 0) && (ctx.getTableAliasMap() == null || ctx.getTableAliasMap().isEmpty())) {
+            return RouterUtil.routeToSingleNode(rrs, schema.getRandomDataNode(), druidParser.getCtx().getSql());
+        }
+
+        if (druidParser.getCtx().getRouteCalculateUnits().size() == 0) {
+            RouteCalculateUnit routeCalculateUnit = new RouteCalculateUnit();
+            druidParser.getCtx().addRouteCalculateUnit(routeCalculateUnit);
+        }
+
+        SortedSet<RouteResultsetNode> nodeSet = new TreeSet<RouteResultsetNode>();
+        boolean isAllGlobalTable = RouterUtil.isAllGlobalTable(ctx, schema);
+        for (RouteCalculateUnit unit : druidParser.getCtx().getRouteCalculateUnits()) {
+            RouteResultset rrsTmp = RouterUtil.tryRouteForTables(schema, druidParser.getCtx(), unit, rrs, isSelect(statement), cachePool);
+            if (rrsTmp != null && rrsTmp.getNodes() != null) {
+                for (RouteResultsetNode node : rrsTmp.getNodes()) {
+                    nodeSet.add(node);
+                }
+            }
+            if (isAllGlobalTable) {//都是全局表时只计算一遍路由
+                break;
+            }
+        }
+
+        RouteResultsetNode[] nodes = new RouteResultsetNode[nodeSet.size()];
+        int i = 0;
+        for (RouteResultsetNode aNodeSet : nodeSet) {
+            nodes[i] = aNodeSet;
+            if (statement instanceof MySqlInsertStatement && ctx.getTables().size() == 1 && schema.getTables().containsKey(ctx.getTables().get(0))) {
+                RuleConfig rule = schema.getTables().get(ctx.getTables().get(0)).getRule();
+                if (rule != null && rule.getRuleAlgorithm() instanceof SlotFunction) {
+                    aNodeSet.setStatement(ParseUtil.changeInsertAddSlot(aNodeSet.getStatement(), aNodeSet.getSlot()));
+                }
+            }
+            i++;
+        }
+        rrs.setNodes(nodes);
+
+        //分表
+        /**
+         *  subTables="t_order$1-2,t_order3"
+         *目前分表 1.6 开始支持 幵丏 dataNode 在分表条件下只能配置一个，分表条件下不支持join。
+         */
+        if (rrs.isDistTable()) {
+            return this.routeDisTable(statement, rrs);
+        }
+        return rrs;
+    }
+
+    private SQLExprTableSource getDisTable(SQLTableSource tableSource, RouteResultsetNode node) throws SQLSyntaxErrorException {
+        if (node.getSubTableName() == null) {
+            String msg = " sub table not exists for " + node.getName() + " on " + tableSource;
+            LOGGER.error("DruidMycatRouteStrategyError " + msg);
+            throw new SQLSyntaxErrorException(msg);
+        }
+
+        SQLIdentifierExpr sqlIdentifierExpr = new SQLIdentifierExpr();
+        sqlIdentifierExpr.setParent(tableSource.getParent());
+        sqlIdentifierExpr.setName(node.getSubTableName());
+        SQLExprTableSource from2 = new SQLExprTableSource(sqlIdentifierExpr);
+        return from2;
+    }
+
+    private RouteResultset routeDisTable(SQLStatement statement, RouteResultset rrs) throws SQLSyntaxErrorException {
+        SQLTableSource tableSource = null;
+        if (statement instanceof SQLInsertStatement) {
+            SQLInsertStatement insertStatement = (SQLInsertStatement) statement;
+            tableSource = insertStatement.getTableSource();
+            for (RouteResultsetNode node : rrs.getNodes()) {
+                SQLExprTableSource from2 = getDisTable(tableSource, node);
+                insertStatement.setTableSource(from2);
+                node.setStatement(insertStatement.toString());
+            }
+        }
+        if (statement instanceof SQLDeleteStatement) {
+            SQLDeleteStatement deleteStatement = (SQLDeleteStatement) statement;
+            tableSource = deleteStatement.getTableSource();
+            for (RouteResultsetNode node : rrs.getNodes()) {
+                SQLExprTableSource from2 = getDisTable(tableSource, node);
+                deleteStatement.setTableSource(from2);
+                node.setStatement(deleteStatement.toString());
+            }
+        }
+        if (statement instanceof SQLUpdateStatement) {
+            SQLUpdateStatement updateStatement = (SQLUpdateStatement) statement;
+            tableSource = updateStatement.getTableSource();
+            for (RouteResultsetNode node : rrs.getNodes()) {
+                SQLExprTableSource from2 = getDisTable(tableSource, node);
+                updateStatement.setTableSource(from2);
+                node.setStatement(updateStatement.toString());
+            }
+        }
+
+        return rrs;
+    }
+
+    /**
+     * SELECT 语句
+     */
+    private boolean isSelect(SQLStatement statement) {
+        if (statement instanceof SQLSelectStatement) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 检验不支持的SQLStatement类型 ：不支持的类型直接抛SQLSyntaxErrorException异常
+     *
+     * @param statement
+     * @throws SQLSyntaxErrorException
+     */
+    private void checkUnSupportedStatement(SQLStatement statement) throws SQLSyntaxErrorException {
+        //不支持replace语句
+        if (statement instanceof MySqlReplaceStatement) {
+            throw new SQLSyntaxErrorException(" ReplaceStatement can't be supported,use insert into ...on duplicate key update... instead ");
+        }
+    }
+
+    /**
+     * 分析 SHOW SQL
+     */
+    @Override
+    public RouteResultset analyseShowSQL(SchemaConfig schema,
+                                         RouteResultset rrs, String stmt) throws SQLSyntaxErrorException {
+
+        String upStmt = stmt.toUpperCase();
+        int tabInd = upStmt.indexOf(" TABLES");
+        if (tabInd > 0) {// show tables
+            int[] nextPost = RouterUtil.getSpecPos(upStmt, 0);
+            if (nextPost[0] > 0) {// remove db info
+                int end = RouterUtil.getSpecEndPos(upStmt, tabInd);
+                if (upStmt.indexOf(" FULL") > 0) {
+                    stmt = "SHOW FULL TABLES" + stmt.substring(end);
+                } else {
+                    stmt = "SHOW TABLES" + stmt.substring(end);
+                }
+            }
+            String defaultNode = schema.getDataNode();
+            if (!Strings.isNullOrEmpty(defaultNode)) {
+                return RouterUtil.routeToSingleNode(rrs, defaultNode, stmt);
+            }
+            return RouterUtil.routeToMultiNode(false, rrs, schema.getMetaDataNodes(), stmt);
+        }
+
+        /**
+         *  show index or column
+         */
+        int[] indx = RouterUtil.getSpecPos(upStmt, 0);
+        if (indx[0] > 0) {
+            /**
+             *  has table
+             */
+            int[] repPos = {indx[0] + indx[1], 0};
+            String tableName = RouterUtil.getShowTableName(stmt, repPos);
+            /**
+             *  IN DB pattern
+             */
+            int[] indx2 = RouterUtil.getSpecPos(upStmt, indx[0] + indx[1] + 1);
+            if (indx2[0] > 0) {// find LIKE OR WHERE
+                repPos[1] = RouterUtil.getSpecEndPos(upStmt, indx2[0] + indx2[1]);
+
+            }
+            stmt = stmt.substring(0, indx[0]) + " FROM " + tableName + stmt.substring(repPos[1]);
+            RouterUtil.routeForTableMeta(rrs, schema, tableName, stmt);
+            return rrs;
+
+        }
+
+        /**
+         *  show create table tableName
+         */
+        int[] createTabInd = RouterUtil.getCreateTablePos(upStmt, 0);
+        if (createTabInd[0] > 0) {
+            int tableNameIndex = createTabInd[0] + createTabInd[1];
+            if (upStmt.length() > tableNameIndex) {
+                String tableName = stmt.substring(tableNameIndex).trim();
+                int ind2 = tableName.indexOf('.');
+                if (ind2 > 0) {
+                    tableName = tableName.substring(ind2 + 1);
+                }
+                RouterUtil.routeForTableMeta(rrs, schema, tableName, stmt);
+                return rrs;
+            }
+        }
+
+        return RouterUtil.routeToSingleNode(rrs, schema.getRandomDataNode(), stmt);
+    }
+
+
 //	/**
 //	 * 为一个表进行条件路由
 //	 * @param schema
@@ -663,93 +635,94 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 //
 //	}
 
-	public RouteResultset routeSystemInfo(SchemaConfig schema, int sqlType,
-			String stmt, RouteResultset rrs) throws SQLSyntaxErrorException {
-		switch(sqlType){
-		case ServerParse.SHOW:// if origSQL is like show tables
-			return analyseShowSQL(schema, rrs, stmt);
-		case ServerParse.SELECT://if origSQL is like select @@
-			int index = stmt.indexOf("@@");
-			if(index > 0 && "SELECT".equals(stmt.substring(0, index).trim().toUpperCase())){
-				return analyseDoubleAtSgin(schema, rrs, stmt);
-			}
-			break;
-		case ServerParse.DESCRIBE:// if origSQL is meta SQL, such as describe table
-			int ind = stmt.indexOf(' ');
-			stmt = stmt.trim();
-			return analyseDescrSQL(schema, rrs, stmt, ind + 1);
-		}
-		return null;
-	}
-	
-	/**
-	 * 对Desc语句进行分析 返回数据路由集合
-	 * 	 * 
-	 * @param schema   				数据库名
-	 * @param rrs    				数据路由集合
-	 * @param stmt   				执行语句
-	 * @param ind    				第一个' '的位置
-	 * @return RouteResultset		(数据路由集合)
-	 * @author mycat
-	 */
-	private static RouteResultset analyseDescrSQL(SchemaConfig schema,
-			RouteResultset rrs, String stmt, int ind) {
-		
-		final String MATCHED_FEATURE = "DESCRIBE ";
-		final String MATCHED2_FEATURE = "DESC ";
-		int pos = 0;
-		while (pos < stmt.length()) {
-			char ch = stmt.charAt(pos);
-			// 忽略处理注释 /* */ BEN
-			if(ch == '/' &&  pos+4 < stmt.length() && stmt.charAt(pos+1) == '*') {
-				if(stmt.substring(pos+2).indexOf("*/") != -1) {
-					pos += stmt.substring(pos+2).indexOf("*/")+4;
-					continue;
-				} else {
-					// 不应该发生这类情况。
-					throw new IllegalArgumentException("sql 注释 语法错误");
-				}
-			} else if(ch == 'D'||ch == 'd') {
-				// 匹配 [describe ] 
-				if(pos+MATCHED_FEATURE.length() < stmt.length() && (stmt.substring(pos).toUpperCase().indexOf(MATCHED_FEATURE) != -1)) {
-					pos = pos + MATCHED_FEATURE.length();
-					break;
-				} else if(pos+MATCHED2_FEATURE.length() < stmt.length() && (stmt.substring(pos).toUpperCase().indexOf(MATCHED2_FEATURE) != -1)) {
-					pos = pos + MATCHED2_FEATURE.length();
-					break;
-				} else {
-					pos++;
-				}
-			}
-		}
-		
-		// 重置ind坐标。BEN GONG
-		ind = pos;		
-		int[] repPos = { ind, 0 };
-		String tableName = RouterUtil.getTableName(stmt, repPos);
-		
-		stmt = stmt.substring(0, ind) + tableName + stmt.substring(repPos[1]);
-		RouterUtil.routeForTableMeta(rrs, schema, tableName, stmt);
-		return rrs;
-	}
-	
-	/**
-	 * 根据执行语句判断数据路由
-	 * 
-	 * @param schema     			数据库名
-	 * @param rrs		  		 	数据路由集合
-	 * @param stmt		  	 		执行sql
-	 * @return RouteResultset		数据路由集合
-	 * @throws SQLSyntaxErrorException
-	 * @author mycat
-	 */
-	private RouteResultset analyseDoubleAtSgin(SchemaConfig schema,
-			RouteResultset rrs, String stmt) throws SQLSyntaxErrorException {		
-		String upStmt = stmt.toUpperCase();
-		int atSginInd = upStmt.indexOf(" @@");
-		if (atSginInd > 0) {
-			return RouterUtil.routeToMultiNode(false, rrs, schema.getMetaDataNodes(), stmt);
-		}
-		return RouterUtil.routeToSingleNode(rrs, schema.getRandomDataNode(), stmt);
-	}
+    public RouteResultset routeSystemInfo(SchemaConfig schema, int sqlType,
+                                          String stmt, RouteResultset rrs) throws SQLSyntaxErrorException {
+        switch (sqlType) {
+            case ServerParse.SHOW:// if origSQL is like show tables
+                return analyseShowSQL(schema, rrs, stmt);
+            case ServerParse.SELECT://if origSQL is like select @@
+                int index = stmt.indexOf("@@");
+                if (index > 0 && "SELECT".equals(stmt.substring(0, index).trim().toUpperCase())) {
+                    return analyseDoubleAtSgin(schema, rrs, stmt);
+                }
+                break;
+            case ServerParse.DESCRIBE:// if origSQL is meta SQL, such as describe table
+                int ind = stmt.indexOf(' ');
+                stmt = stmt.trim();
+                return analyseDescrSQL(schema, rrs, stmt, ind + 1);
+        }
+        return null;
+    }
+
+    /**
+     * 对Desc语句进行分析 返回数据路由集合
+     * *
+     *
+     * @param schema 数据库名
+     * @param rrs    数据路由集合
+     * @param stmt   执行语句
+     * @param ind    第一个' '的位置
+     * @return RouteResultset        (数据路由集合)
+     * @author mycat
+     */
+    private static RouteResultset analyseDescrSQL(SchemaConfig schema,
+                                                  RouteResultset rrs, String stmt, int ind) {
+
+        final String MATCHED_FEATURE = "DESCRIBE ";
+        final String MATCHED2_FEATURE = "DESC ";
+        int pos = 0;
+        while (pos < stmt.length()) {
+            char ch = stmt.charAt(pos);
+            // 忽略处理注释 /* */ BEN
+            if (ch == '/' && pos + 4 < stmt.length() && stmt.charAt(pos + 1) == '*') {
+                if (stmt.substring(pos + 2).indexOf("*/") != -1) {
+                    pos += stmt.substring(pos + 2).indexOf("*/") + 4;
+                    continue;
+                } else {
+                    // 不应该发生这类情况。
+                    throw new IllegalArgumentException("sql 注释 语法错误");
+                }
+            } else if (ch == 'D' || ch == 'd') {
+                // 匹配 [describe ]
+                if (pos + MATCHED_FEATURE.length() < stmt.length() && (stmt.substring(pos).toUpperCase().indexOf(MATCHED_FEATURE) != -1)) {
+                    pos = pos + MATCHED_FEATURE.length();
+                    break;
+                } else if (pos + MATCHED2_FEATURE.length() < stmt.length() && (stmt.substring(pos).toUpperCase().indexOf(MATCHED2_FEATURE) != -1)) {
+                    pos = pos + MATCHED2_FEATURE.length();
+                    break;
+                } else {
+                    pos++;
+                }
+            }
+        }
+
+        // 重置ind坐标。BEN GONG
+        ind = pos;
+        int[] repPos = {ind, 0};
+        String tableName = RouterUtil.getTableName(stmt, repPos);
+
+        stmt = stmt.substring(0, ind) + tableName + stmt.substring(repPos[1]);
+        RouterUtil.routeForTableMeta(rrs, schema, tableName, stmt);
+        return rrs;
+    }
+
+    /**
+     * 根据执行语句判断数据路由
+     *
+     * @param schema 数据库名
+     * @param rrs    数据路由集合
+     * @param stmt   执行sql
+     * @return RouteResultset        数据路由集合
+     * @throws SQLSyntaxErrorException
+     * @author mycat
+     */
+    private RouteResultset analyseDoubleAtSgin(SchemaConfig schema,
+                                               RouteResultset rrs, String stmt) throws SQLSyntaxErrorException {
+        String upStmt = stmt.toUpperCase();
+        int atSginInd = upStmt.indexOf(" @@");
+        if (atSginInd > 0) {
+            return RouterUtil.routeToMultiNode(false, rrs, schema.getMetaDataNodes(), stmt);
+        }
+        return RouterUtil.routeToSingleNode(rrs, schema.getRandomDataNode(), stmt);
+    }
 }

--- a/src/main/java/io/mycat/route/parser/druid/impl/DruidSelectParser.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/DruidSelectParser.java
@@ -431,6 +431,7 @@ public class DruidSelectParser extends DefaultDruidParser {
 					sqlIdentifierExpr.setParent(from);
 					sqlIdentifierExpr.setName(node.getSubTableName());
 					SQLExprTableSource from2 = new SQLExprTableSource(sqlIdentifierExpr);
+					from2.setAlias(from.getAlias());
 					mysqlSelectQuery.setFrom(from2);
 					node.setStatement(stmt.toString());
 	            }

--- a/src/main/java/io/mycat/statistic/stat/TableStatAnalyzer.java
+++ b/src/main/java/io/mycat/statistic/stat/TableStatAnalyzer.java
@@ -154,7 +154,7 @@ public class TableStatAnalyzer implements QueryResultListener {
 		public List<String> parseTableNames(String sql) {
 			final List<String> tables = new ArrayList<String>();
 		  try{			
-			
+
 			SQLStatement stmt = parseStmt(sql);
 			if (stmt instanceof MySqlReplaceStatement ) {
 				String table = ((MySqlReplaceStatement)stmt).getTableName().getSimpleName();

--- a/src/main/java/io/mycat/util/ByteUtil.java
+++ b/src/main/java/io/mycat/util/ByteUtil.java
@@ -36,55 +36,52 @@ public class ByteUtil {
      * @param b2
      * @return -1 means b1 < b2, or 0 means b1=b2 else return 1
      */
-//    public static int compareNumberByte(byte[] b1, byte[] b2) {
-//        if (b1 == null || b1.length == 0) {
-//            return -1;
-//        } else if (b2 == null || b2.length == 0) {
-//            return 1;
-//        }
-//        boolean b1IsNegative = b1[0] == 45;
-//        boolean b2IsNegative = b2[0] == 45;
-//        if (b1IsNegative != b2IsNegative) return b1IsNegative ? -1 : 1;
-//        //
-//        byte[] longB1 = getLongBytes(b1);
-//        int longB1Length = longB1.length;
-//        byte[] longB2 = getLongBytes(b2);
-//        int longB2Length = longB2.length;
-//        if (longB1.length != longB2.length) {
-//            if (b1IsNegative) return longB1.length - longB2.length;
-//            else return longB2.length - longB1.length;
-//        }
-//        int len = b1.length;
-//        int result = 0;
-//        int index = -1;
-//        for (int i = 0; i < len; i++) {
-//            int b1val = b1[i];
-//            int b2val = b2[i];
-//            if (b1val > b2val) {
-//                result = 1;
-//                index = i;
-//                break;
-//            } else if (b1val < b2val) {
-//                index = i;
-//                result = -1;
-//                break;
-//            }
-//        }
-//        if (index == 0) {
-//            // first byte compare
-//            return result;
-//        } else {
-//            if (b1.length != b2.length) {
-//
-//                int lenDelta = b1.length - b2.length;
-//                return 0 - lenDelta;
-//
-//            } else {
-//                return b1IsNegative ? 0 - result : result;
-//            }
-//        }
-//    }
     public static int compareNumberByte(byte[] b1, byte[] b2) {
+        if ((b1 == null || b1.length == 0) && b2 != null && b2.length != 0) {
+            return -1;
+        } else if (b1 == null || b1.length == 0) {
+            // 此时 b2 == null || b2.length == 0 为 true
+            return 0;
+        } else if (b2 == null || b2.length == 0) {
+            return 1;
+        }
+        boolean b1IsNegative = b1[0] == 45;
+        boolean b2IsNegative = b2[0] == 45;
+        if (b1IsNegative != b2IsNegative) return b1IsNegative ? -1 : 1;
+        //
+        byte[] longB1 = getLongBytes(b1);
+        int longB1Length = longB1.length;
+        byte[] longB2 = getLongBytes(b2);
+        int longB2Length = longB2.length;
+        if (longB1Length != longB2Length) {
+            if (b1IsNegative) return longB1.length - longB2.length;
+            else return longB2.length - longB1.length;
+        }
+        int len = longB1Length;
+        int result = 0;
+        int index = -1;
+        for (int i = 0; i < len; i++) {
+            int b1val = longB1[i];
+            int b2val = longB2[i];
+            if (b1val > b2val) {
+                result = 1;
+                index = i;
+                break;
+            } else if (b1val < b2val) {
+                index = i;
+                result = -1;
+                break;
+            }
+        }
+        if (index == 0) {
+            // first byte compare
+            return result;
+        } else {
+            return compareNumberByte2(b1, b2);
+        }
+    }
+
+    public static int compareNumberByte2(byte[] b1, byte[] b2) {
         double double1 = getDouble(b1);
         double double2 = getDouble(b2);
         double m = double1 - double2;

--- a/src/main/java/io/mycat/util/ByteUtil.java
+++ b/src/main/java/io/mycat/util/ByteUtil.java
@@ -28,321 +28,353 @@ import java.util.Date;
 
 public class ByteUtil {
 
-	/**
-	 * compare to number or dicamal ascii byte array, for number :123456 ,store
-	 * to array [1,2,3,4,5,6]
-	 * 
-	 * @param b1
-	 * @param b2
-	 * @return -1 means b1 < b2, or 0 means b1=b2 else return 1
-	 */
-	public static int compareNumberByte(byte[] b1, byte[] b2) {
-		if(b1 == null || b1.length == 0) {
-			return -1;
-		}
-		else if(b2 == null || b2.length == 0) {
-			return 1;
-		}
-		boolean isNegetive = b1[0] == 45 || b2[0] == 45;
-		if (isNegetive == false && b1.length != b2.length) {
-			return b1.length - b2.length;
-		}
-		int len = b1.length > b2.length ? b2.length : b1.length;
-		int result = 0;
-		int index = -1;
-		for (int i = 0; i < len; i++) {
-			int b1val = b1[i];
-			int b2val = b2[i];
-			if (b1val > b2val) {
-				result = 1;
-				index = i;
-				break;
-			} else if (b1val < b2val) {
-				index = i;
-				result = -1;
-				break;
-			}
-		}
-		if (index == 0) {
-			// first byte compare
-			return result;
-		} else {
-            if( b1.length != b2.length ) {
-
-                int lenDelta = b1.length - b2.length;
-                return isNegetive ? 0 - lenDelta : lenDelta;
-
-            } else {
-                return isNegetive ? 0 - result : result;
-            }
-		}
-	}
-
-	public static byte[] compareNumberArray2(byte[] b1, byte[] b2, int order) {
-		if (b1.length <= 0 && b2.length > 0) {
-			return b2;
-		}
-		if (b1.length > 0 && b2.length <= 0) {
-			return b1;
-		}
-		int len = b1.length > b2.length ? b1.length : b2.length;
-		for (int i = 0; i < len; i++) {
-			if (b1[i] != b2[i]) {
-				if (order == 1) {
-					return ((b1[i] & 0xff) - (b2[i] & 0xff)) > 0 ? b1 : b2;
-				} else {
-					return ((b1[i] & 0xff) - (b2[i] & 0xff)) > 0 ? b2 : b1;
-				}
-			}
-		}
-
-		return b1;
-	}
-
-	public static byte[] getBytes(short data) {
-		byte[] bytes = new byte[2];
-		bytes[0] = (byte) (data & 0xff);
-		bytes[1] = (byte) ((data & 0xff00) >> 8);
-		return bytes;
-	}
-
-	public static byte[] getBytes(char data) {
-		byte[] bytes = new byte[2];
-		bytes[0] = (byte) (data);
-		bytes[1] = (byte) (data >> 8);
-		return bytes;
-	}
-
-	public static byte[] getBytes(int data) {
-		byte[] bytes = new byte[4];
-		bytes[0] = (byte) (data & 0xff);
-		bytes[1] = (byte) ((data & 0xff00) >> 8);
-		bytes[2] = (byte) ((data & 0xff0000) >> 16);
-		bytes[3] = (byte) ((data & 0xff000000) >> 24);
-		return bytes;
-	}
-
-	public static byte[] getBytes(long data) {
-		byte[] bytes = new byte[8];
-		bytes[0] = (byte) (data & 0xff);
-		bytes[1] = (byte) ((data >> 8) & 0xff);
-		bytes[2] = (byte) ((data >> 16) & 0xff);
-		bytes[3] = (byte) ((data >> 24) & 0xff);
-		bytes[4] = (byte) ((data >> 32) & 0xff);
-		bytes[5] = (byte) ((data >> 40) & 0xff);
-		bytes[6] = (byte) ((data >> 48) & 0xff);
-		bytes[7] = (byte) ((data >> 56) & 0xff);
-		return bytes;
-	}
-
-	public static byte[] getBytes(float data) {
-		int intBits = Float.floatToIntBits(data);
-		return getBytes(intBits);
-	}
-
-	public static byte[] getBytes(double data) {
-		long intBits = Double.doubleToLongBits(data);
-		return getBytes(intBits);
-	}
-
-	public static byte[] getBytes(String data, String charsetName) {
-		Charset charset = Charset.forName(charsetName);
-		return data.getBytes(charset);
-	}
-
-	public static byte[] getBytes(String data) {
-		return getBytes(data, "GBK");
-	}
-
-	public static short getShort(byte[] bytes) {
-		return Short.parseShort(new String(bytes));
-//		return (short) ((0xff & bytes[0]) | (0xff00 & (bytes[1] << 8)));
-	}
-
-	public static char getChar(byte[] bytes) {
-		return (char) ((0xff & bytes[0]) | (0xff00 & (bytes[1] << 8)));
-	}
-
-	public static int getInt(byte[] bytes) {
-		return Integer.parseInt(new String(bytes));
-		// return (0xff & bytes[0]) | (0xff00 & (bytes[1] << 8)) | (0xff0000 &
-		// (bytes[2] << 16)) | (0xff000000 & (bytes[3] << 24));
-	}
-
-	public static long getLong(byte[] bytes) {
-		return Long.parseLong(new String(bytes));
-		// return(0xffL & (long)bytes[0]) | (0xff00L & ((long)bytes[1] << 8)) |
-		// (0xff0000L & ((long)bytes[2] << 16)) | (0xff000000L & ((long)bytes[3]
-		// << 24))
-		// | (0xff00000000L & ((long)bytes[4] << 32)) | (0xff0000000000L &
-		// ((long)bytes[5] << 40)) | (0xff000000000000L & ((long)bytes[6] <<
-		// 48)) | (0xff00000000000000L & ((long)bytes[7] << 56));
-	}
-
-	public static double getDouble(byte[] bytes) {
-		return Double.parseDouble(new String(bytes));
-	}
-	
-	public static float getFloat(byte[] bytes) {
-		return Float.parseFloat(new String(bytes));
-	}
-
-	public static String getString(byte[] bytes, String charsetName) {
-		return new String(bytes, Charset.forName(charsetName));
-	}
-
-	public static String getString(byte[] bytes) {
-		return getString(bytes, "UTF-8");
-	}
-
-	public static String getDate(byte[] bytes) {
-		return new String(bytes);
-	}
-	
-	public static String getTime(byte[] bytes) {
-		return new String(bytes);
-	}
-
-	public static String getTimestmap(byte[] bytes) {
-		return new String(bytes);
-	}
-	
-	public static byte[] getBytes(Date date, boolean isTime) {
-		if(isTime) {
-			return getBytesFromTime(date);
-		} else {
-			return getBytesFromDate(date);
-		}
+    /**
+     * compare to number or dicamal ascii byte array, for number :123456 ,store
+     * to array [1,2,3,4,5,6]
+     *
+     * @param b1
+     * @param b2
+     * @return -1 means b1 < b2, or 0 means b1=b2 else return 1
+     */
+//    public static int compareNumberByte(byte[] b1, byte[] b2) {
+//        if (b1 == null || b1.length == 0) {
+//            return -1;
+//        } else if (b2 == null || b2.length == 0) {
+//            return 1;
+//        }
+//        boolean b1IsNegative = b1[0] == 45;
+//        boolean b2IsNegative = b2[0] == 45;
+//        if (b1IsNegative != b2IsNegative) return b1IsNegative ? -1 : 1;
+//        //
+//        byte[] longB1 = getLongBytes(b1);
+//        int longB1Length = longB1.length;
+//        byte[] longB2 = getLongBytes(b2);
+//        int longB2Length = longB2.length;
+//        if (longB1.length != longB2.length) {
+//            if (b1IsNegative) return longB1.length - longB2.length;
+//            else return longB2.length - longB1.length;
+//        }
+//        int len = b1.length;
+//        int result = 0;
+//        int index = -1;
+//        for (int i = 0; i < len; i++) {
+//            int b1val = b1[i];
+//            int b2val = b2[i];
+//            if (b1val > b2val) {
+//                result = 1;
+//                index = i;
+//                break;
+//            } else if (b1val < b2val) {
+//                index = i;
+//                result = -1;
+//                break;
+//            }
+//        }
+//        if (index == 0) {
+//            // first byte compare
+//            return result;
+//        } else {
+//            if (b1.length != b2.length) {
+//
+//                int lenDelta = b1.length - b2.length;
+//                return 0 - lenDelta;
+//
+//            } else {
+//                return b1IsNegative ? 0 - result : result;
+//            }
+//        }
+//    }
+    public static int compareNumberByte(byte[] b1, byte[] b2) {
+        double double1 = getDouble(b1);
+        double double2 = getDouble(b2);
+        double m = double1 - double2;
+        if (m == 0) return 0;
+        else if (m > 0) return 1;
+        else if (m < 0) return -1;
+        else throw new RuntimeException("ignored");
     }
-	
-	private static byte[] getBytesFromTime(Date date) {
-		int day = 0;
-		int hour = DateUtil.getHour(date);
-		int minute = DateUtil.getMinute(date);
-    	int second = DateUtil.getSecond(date);
-    	int microSecond = DateUtil.getMicroSecond(date);
-    	byte[] bytes = null;
-    	byte[] tmp = null;
-    	if(day == 0 && hour == 0 && minute == 0
-    			&& second == 0 && microSecond == 0) {
-    		bytes = new byte[1];
-    		bytes[0] = (byte) 0;
-    	} else if(microSecond == 0) {
-    		bytes = new byte[1 + 8];
-    		bytes[0] = (byte) 8;
-    		bytes[1] = (byte) 0; // is_negative (1) -- (1 if minus, 0 for plus)
-    		tmp = getBytes(day);
-    		bytes[2] = tmp[0];
-    		bytes[3] = tmp[1];
-    		bytes[4] = tmp[2];
-    		bytes[5] = tmp[3];
-    		bytes[6] = (byte) hour;
-    		bytes[7] = (byte) minute;
-    		bytes[8] = (byte) second;
-    	} else {
-    		bytes = new byte[1 + 12];
-    		bytes[0] = (byte) 12;
-    		bytes[1] = (byte) 0; // is_negative (1) -- (1 if minus, 0 for plus)
-    		tmp = getBytes(day);
-    		bytes[2] = tmp[0];
-    		bytes[3] = tmp[1];
-    		bytes[4] = tmp[2];
-    		bytes[5] = tmp[3];
-    		bytes[6] = (byte) hour;
-    		bytes[7] = (byte) minute;
-    		bytes[8] = (byte) second;
-    		tmp = getBytes(microSecond);
-    		bytes[9] = tmp[0];
-    		bytes[10] = tmp[1];
-    		bytes[11] = tmp[2];
-    		bytes[12] = tmp[3];
-    	}
-    	return bytes;
-	}
-	
-	private static byte[] getBytesFromDate(Date date) {
-		int year = DateUtil.getYear(date);
-    	int month = DateUtil.getMonth(date);
-    	int day = DateUtil.getDay(date);
-    	int hour = DateUtil.getHour(date);
-    	int minute = DateUtil.getMinute(date);
-    	int second = DateUtil.getSecond(date);
-    	int microSecond = DateUtil.getMicroSecond(date);
-    	byte[] bytes = null;
-    	byte[] tmp = null;
-    	if(year == 0 && month == 0 && day == 0 
-    			&& hour == 0 && minute == 0 && second == 0
-    			&& microSecond == 0) {
-    		bytes = new byte[1];
-    		bytes[0] = (byte) 0;
-    	} else if(hour == 0 && minute == 0 && second == 0
-    			&& microSecond == 0) {
-    		bytes = new byte[1 + 4];
-    		bytes[0] = (byte) 4;
-    		tmp = getBytes((short) year);
-    		bytes[1] = tmp[0];
-    		bytes[2] = tmp[1];
-    		bytes[3] = (byte) month;
-    		bytes[4] = (byte) day;
-    	} else if(microSecond == 0) {
-    		bytes = new byte[1 + 7];
-    		bytes[0] = (byte) 7;
-    		tmp = getBytes((short) year);
-    		bytes[1] = tmp[0];
-    		bytes[2] = tmp[1];
-    		bytes[3] = (byte) month;
-    		bytes[4] = (byte) day;
-    		bytes[5] = (byte) hour;
-    		bytes[6] = (byte) minute;
-    		bytes[7] = (byte) second;
-    	} else {
-    		bytes = new byte[1 + 11];
-    		bytes[0] = (byte) 11;
-    		tmp = getBytes((short) year);
-    		bytes[1] = tmp[0];
-    		bytes[2] = tmp[1];
-    		bytes[3] = (byte) month;
-    		bytes[4] = (byte) day;
-    		bytes[5] = (byte) hour;
-    		bytes[6] = (byte) minute;
-    		bytes[7] = (byte) second;
-    		tmp = getBytes(microSecond);
-    		bytes[8] = tmp[0];
-    		bytes[9] = tmp[1];
-    		bytes[10] = tmp[2];
-    		bytes[11] = tmp[3];
-    	}
-    	return bytes;
-	}
-	
-	// 支持 byte dump
-	//---------------------------------------------------------------------
-	public static String dump(byte[] data, int offset, int length) {
-		
-		StringBuilder sb = new StringBuilder();
-		sb.append(" byte dump log ");
-		sb.append(System.lineSeparator());
-		sb.append(" offset ").append( offset );
-		sb.append(" length ").append( length );
-		sb.append(System.lineSeparator());
-		int lines = (length - 1) / 16 + 1;
-		for (int i = 0, pos = 0; i < lines; i++, pos += 16) {
-			sb.append(String.format("0x%04X ", i * 16));
-			for (int j = 0, pos1 = pos; j < 16; j++, pos1++) {
-				sb.append(pos1 < length ? String.format("%02X ", data[offset + pos1]) : "   ");
-			}
-			sb.append(" ");
-			for (int j = 0, pos1 = pos; j < 16; j++, pos1++) {
-				sb.append(pos1 < length ? print(data[offset + pos1]) : '.');
-			}
-			sb.append(System.lineSeparator());
-		}
-		sb.append(length).append(" bytes").append(System.lineSeparator());
-		return sb.toString();
-	}
 
-	public static char print(byte b) {
-		return (b < 32 || b > 127) ? '.' : (char) b;
-	}
+    private static byte[] getLongBytes(byte[] b1) {
+        int longB1Length = 0;
+        byte[] longB1 = new byte[0];
+        for (int i = 0; i < b1.length; i++) {
+            if (b1[i] == '.') break;
+            if (longB1Length >= longB1.length - 2) {
+                byte[] newLongB1 = new byte[longB1Length * 2 + 1];
+                System.arraycopy(longB1, 0, newLongB1, 0, longB1.length);
+                longB1 = newLongB1;
+            }
+            longB1Length++;
+            longB1[i] = b1[i];
+        }
+        return longB1;
+    }
+
+    public static byte[] compareNumberArray2(byte[] b1, byte[] b2, int order) {
+        if (b1.length <= 0 && b2.length > 0) {
+            return b2;
+        }
+        if (b1.length > 0 && b2.length <= 0) {
+            return b1;
+        }
+        int len = b1.length > b2.length ? b1.length : b2.length;
+        for (int i = 0; i < len; i++) {
+            if (b1[i] != b2[i]) {
+                if (order == 1) {
+                    return ((b1[i] & 0xff) - (b2[i] & 0xff)) > 0 ? b1 : b2;
+                } else {
+                    return ((b1[i] & 0xff) - (b2[i] & 0xff)) > 0 ? b2 : b1;
+                }
+            }
+        }
+
+        return b1;
+    }
+
+    public static byte[] getBytes(short data) {
+        byte[] bytes = new byte[2];
+        bytes[0] = (byte) (data & 0xff);
+        bytes[1] = (byte) ((data & 0xff00) >> 8);
+        return bytes;
+    }
+
+    public static byte[] getBytes(char data) {
+        byte[] bytes = new byte[2];
+        bytes[0] = (byte) (data);
+        bytes[1] = (byte) (data >> 8);
+        return bytes;
+    }
+
+    public static byte[] getBytes(int data) {
+        byte[] bytes = new byte[4];
+        bytes[0] = (byte) (data & 0xff);
+        bytes[1] = (byte) ((data & 0xff00) >> 8);
+        bytes[2] = (byte) ((data & 0xff0000) >> 16);
+        bytes[3] = (byte) ((data & 0xff000000) >> 24);
+        return bytes;
+    }
+
+    public static byte[] getBytes(long data) {
+        byte[] bytes = new byte[8];
+        bytes[0] = (byte) (data & 0xff);
+        bytes[1] = (byte) ((data >> 8) & 0xff);
+        bytes[2] = (byte) ((data >> 16) & 0xff);
+        bytes[3] = (byte) ((data >> 24) & 0xff);
+        bytes[4] = (byte) ((data >> 32) & 0xff);
+        bytes[5] = (byte) ((data >> 40) & 0xff);
+        bytes[6] = (byte) ((data >> 48) & 0xff);
+        bytes[7] = (byte) ((data >> 56) & 0xff);
+        return bytes;
+    }
+
+    public static byte[] getBytes(float data) {
+        int intBits = Float.floatToIntBits(data);
+        return getBytes(intBits);
+    }
+
+    public static byte[] getBytes(double data) {
+        long intBits = Double.doubleToLongBits(data);
+        return getBytes(intBits);
+    }
+
+    public static byte[] getBytes(String data, String charsetName) {
+        Charset charset = Charset.forName(charsetName);
+        return data.getBytes(charset);
+    }
+
+    public static byte[] getBytes(String data) {
+        return getBytes(data, "GBK");
+    }
+
+    public static short getShort(byte[] bytes) {
+        return Short.parseShort(new String(bytes));
+//		return (short) ((0xff & bytes[0]) | (0xff00 & (bytes[1] << 8)));
+    }
+
+    public static char getChar(byte[] bytes) {
+        return (char) ((0xff & bytes[0]) | (0xff00 & (bytes[1] << 8)));
+    }
+
+    public static int getInt(byte[] bytes) {
+        return Integer.parseInt(new String(bytes));
+        // return (0xff & bytes[0]) | (0xff00 & (bytes[1] << 8)) | (0xff0000 &
+        // (bytes[2] << 16)) | (0xff000000 & (bytes[3] << 24));
+    }
+
+    public static long getLong(byte[] bytes) {
+        return Long.parseLong(new String(bytes));
+        // return(0xffL & (long)bytes[0]) | (0xff00L & ((long)bytes[1] << 8)) |
+        // (0xff0000L & ((long)bytes[2] << 16)) | (0xff000000L & ((long)bytes[3]
+        // << 24))
+        // | (0xff00000000L & ((long)bytes[4] << 32)) | (0xff0000000000L &
+        // ((long)bytes[5] << 40)) | (0xff000000000000L & ((long)bytes[6] <<
+        // 48)) | (0xff00000000000000L & ((long)bytes[7] << 56));
+    }
+
+    public static double getDouble(byte[] bytes) {
+        return Double.parseDouble(new String(bytes));
+    }
+
+    public static float getFloat(byte[] bytes) {
+        return Float.parseFloat(new String(bytes));
+    }
+
+    public static String getString(byte[] bytes, String charsetName) {
+        return new String(bytes, Charset.forName(charsetName));
+    }
+
+    public static String getString(byte[] bytes) {
+        return getString(bytes, "UTF-8");
+    }
+
+    public static String getDate(byte[] bytes) {
+        return new String(bytes);
+    }
+
+    public static String getTime(byte[] bytes) {
+        return new String(bytes);
+    }
+
+    public static String getTimestmap(byte[] bytes) {
+        return new String(bytes);
+    }
+
+    public static byte[] getBytes(Date date, boolean isTime) {
+        if (isTime) {
+            return getBytesFromTime(date);
+        } else {
+            return getBytesFromDate(date);
+        }
+    }
+
+    private static byte[] getBytesFromTime(Date date) {
+        int day = 0;
+        int hour = DateUtil.getHour(date);
+        int minute = DateUtil.getMinute(date);
+        int second = DateUtil.getSecond(date);
+        int microSecond = DateUtil.getMicroSecond(date);
+        byte[] bytes = null;
+        byte[] tmp = null;
+        if (day == 0 && hour == 0 && minute == 0
+                && second == 0 && microSecond == 0) {
+            bytes = new byte[1];
+            bytes[0] = (byte) 0;
+        } else if (microSecond == 0) {
+            bytes = new byte[1 + 8];
+            bytes[0] = (byte) 8;
+            bytes[1] = (byte) 0; // is_negative (1) -- (1 if minus, 0 for plus)
+            tmp = getBytes(day);
+            bytes[2] = tmp[0];
+            bytes[3] = tmp[1];
+            bytes[4] = tmp[2];
+            bytes[5] = tmp[3];
+            bytes[6] = (byte) hour;
+            bytes[7] = (byte) minute;
+            bytes[8] = (byte) second;
+        } else {
+            bytes = new byte[1 + 12];
+            bytes[0] = (byte) 12;
+            bytes[1] = (byte) 0; // is_negative (1) -- (1 if minus, 0 for plus)
+            tmp = getBytes(day);
+            bytes[2] = tmp[0];
+            bytes[3] = tmp[1];
+            bytes[4] = tmp[2];
+            bytes[5] = tmp[3];
+            bytes[6] = (byte) hour;
+            bytes[7] = (byte) minute;
+            bytes[8] = (byte) second;
+            tmp = getBytes(microSecond);
+            bytes[9] = tmp[0];
+            bytes[10] = tmp[1];
+            bytes[11] = tmp[2];
+            bytes[12] = tmp[3];
+        }
+        return bytes;
+    }
+
+    private static byte[] getBytesFromDate(Date date) {
+        int year = DateUtil.getYear(date);
+        int month = DateUtil.getMonth(date);
+        int day = DateUtil.getDay(date);
+        int hour = DateUtil.getHour(date);
+        int minute = DateUtil.getMinute(date);
+        int second = DateUtil.getSecond(date);
+        int microSecond = DateUtil.getMicroSecond(date);
+        byte[] bytes = null;
+        byte[] tmp = null;
+        if (year == 0 && month == 0 && day == 0
+                && hour == 0 && minute == 0 && second == 0
+                && microSecond == 0) {
+            bytes = new byte[1];
+            bytes[0] = (byte) 0;
+        } else if (hour == 0 && minute == 0 && second == 0
+                && microSecond == 0) {
+            bytes = new byte[1 + 4];
+            bytes[0] = (byte) 4;
+            tmp = getBytes((short) year);
+            bytes[1] = tmp[0];
+            bytes[2] = tmp[1];
+            bytes[3] = (byte) month;
+            bytes[4] = (byte) day;
+        } else if (microSecond == 0) {
+            bytes = new byte[1 + 7];
+            bytes[0] = (byte) 7;
+            tmp = getBytes((short) year);
+            bytes[1] = tmp[0];
+            bytes[2] = tmp[1];
+            bytes[3] = (byte) month;
+            bytes[4] = (byte) day;
+            bytes[5] = (byte) hour;
+            bytes[6] = (byte) minute;
+            bytes[7] = (byte) second;
+        } else {
+            bytes = new byte[1 + 11];
+            bytes[0] = (byte) 11;
+            tmp = getBytes((short) year);
+            bytes[1] = tmp[0];
+            bytes[2] = tmp[1];
+            bytes[3] = (byte) month;
+            bytes[4] = (byte) day;
+            bytes[5] = (byte) hour;
+            bytes[6] = (byte) minute;
+            bytes[7] = (byte) second;
+            tmp = getBytes(microSecond);
+            bytes[8] = tmp[0];
+            bytes[9] = tmp[1];
+            bytes[10] = tmp[2];
+            bytes[11] = tmp[3];
+        }
+        return bytes;
+    }
+
+    // 支持 byte dump
+    //---------------------------------------------------------------------
+    public static String dump(byte[] data, int offset, int length) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(" byte dump log ");
+        sb.append(System.lineSeparator());
+        sb.append(" offset ").append(offset);
+        sb.append(" length ").append(length);
+        sb.append(System.lineSeparator());
+        int lines = (length - 1) / 16 + 1;
+        for (int i = 0, pos = 0; i < lines; i++, pos += 16) {
+            sb.append(String.format("0x%04X ", i * 16));
+            for (int j = 0, pos1 = pos; j < 16; j++, pos1++) {
+                sb.append(pos1 < length ? String.format("%02X ", data[offset + pos1]) : "   ");
+            }
+            sb.append(" ");
+            for (int j = 0, pos1 = pos; j < 16; j++, pos1++) {
+                sb.append(pos1 < length ? print(data[offset + pos1]) : '.');
+            }
+            sb.append(System.lineSeparator());
+        }
+        sb.append(length).append(" bytes").append(System.lineSeparator());
+        return sb.toString();
+    }
+
+    public static char print(byte b) {
+        return (b < 32 || b > 127) ? '.' : (char) b;
+    }
 
 }

--- a/src/main/java/io/mycat/util/ByteUtil.java
+++ b/src/main/java/io/mycat/util/ByteUtil.java
@@ -45,24 +45,32 @@ public class ByteUtil {
         } else if (b2 == null || b2.length == 0) {
             return 1;
         }
+        // 判断正负
         boolean b1IsNegative = b1[0] == 45;
         boolean b2IsNegative = b2[0] == 45;
         if (b1IsNegative != b2IsNegative) return b1IsNegative ? -1 : 1;
-        //
+        // 只比较整数部分
         byte[] longB1 = getLongBytes(b1);
         int longB1Length = longB1.length;
         byte[] longB2 = getLongBytes(b2);
         int longB2Length = longB2.length;
+        // 位数不同
         if (longB1Length != longB2Length) {
-            if (b1IsNegative) return longB1.length - longB2.length;
+            if (!b1IsNegative) return longB1.length - longB2.length;
             else return longB2.length - longB1.length;
         }
-        int len = longB1Length;
+        // 位数相同 比较每一位的大小
         int result = 0;
         int index = -1;
-        for (int i = 0; i < len; i++) {
-            int b1val = longB1[i];
-            int b2val = longB2[i];
+        int length = b1.length;
+        if (b1.length < b2.length) length = b2.length;
+        for (int i = 0; i < length; i++) {
+            int b1val = 48; // '0'
+            int b2val = 48; // '0'
+            if (i < b1.length)
+                b1val = b1[i];
+            if (i < b2.length)
+                b2val = b2[i];
             if (b1val > b2val) {
                 result = 1;
                 index = i;
@@ -76,9 +84,13 @@ public class ByteUtil {
         if (index == 0) {
             // first byte compare
             return result;
-        } else {
-            return compareNumberByte2(b1, b2);
-        }
+        } else if (index == -1 && b1.length == b2.length) {
+            // 每一位都一样
+            return 0;
+        } else if (b1IsNegative) {
+            // 两个数是负数 比较结果求反
+            return 0 - result;
+        } else return result;
     }
 
     public static int compareNumberByte2(byte[] b1, byte[] b2) {

--- a/src/main/java/io/mycat/util/SplitUtil.java
+++ b/src/main/java/io/mycat/util/SplitUtil.java
@@ -23,6 +23,8 @@
  */
 package io.mycat.util;
 
+import com.sun.javafx.binding.StringFormatter;
+
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -229,23 +231,35 @@ public class SplitUtil {
         } else {
             String[] s = split(src, c1, true);
             String[] scope = split(s[1], c2, true);
+            int integerLength = scope[0].length();
             int min = Integer.parseInt(scope[0]);
             int max = Integer.parseInt(scope[scope.length - 1]);
             if (c3 == '0') {
                 for (int x = min; x <= max; x++) {
-                    list.add(new StringBuilder(s[0]).append(x).toString());
+                    String splitString = buildSubString(integerLength, x);
+                    list.add(s[0] + splitString);
                 }
             } else if (c4 == '0') {
                 for (int x = min; x <= max; x++) {
-                    list.add(new StringBuilder(s[0]).append(c3).append(x).toString());
+                    String splitString = buildSubString(integerLength, x);
+                    list.add(s[0] + c3 + splitString);
                 }
             } else {
                 for (int x = min; x <= max; x++) {
-                    list.add(new StringBuilder(s[0]).append(c3).append(x).append(c4).toString());
+                    String splitString = buildSubString(integerLength, x);
+                    list.add(s[0] + c3 + splitString + c4);
                 }
             }
         }
         return list.toArray(new String[list.size()]);
+    }
+
+    private static String buildSubString(int integerLength, int x) {
+        String splitString;
+        if (integerLength <= 1)
+            splitString = String.valueOf(x);
+        else splitString = String.format("%0" + integerLength + "d", x);
+        return splitString;
     }
 
     public static String[] split(String src, char fi, char se, char th) {

--- a/src/main/resources/rule.xml
+++ b/src/main/resources/rule.xml
@@ -108,6 +108,12 @@
 	</function>
 
     <function name="func2" class="io.mycat.route.function.PartitionByPostfix">
+		<!-- 在 subTables 里配置的连续表名中 第一个表对应的分表 ID 值 -->
+		<property name="firstValue">1</property>
+		<!-- 该分表列值的固定前缀 -->
+		<property name="prefix">c</property>
+		<!-- 该分表列值的固定后缀 -->
+		<property name="postfix">d</property>
     </function>
 	<!-- <function name="latestMonth" -->
 	<!-- class="io.mycat.route.function.LatestMonthPartion"> -->

--- a/src/main/resources/rule.xml
+++ b/src/main/resources/rule.xml
@@ -9,76 +9,76 @@
 	under the License. -->
 <!DOCTYPE mycat:rule SYSTEM "rule.dtd">
 <mycat:rule xmlns:mycat="http://io.mycat/">
-	<tableRule name="sharding-by-channel-id">
+	<tableRule name="rule1">
 		<rule>
-			<columns>channel_id</columns>
-			<algorithm>func2</algorithm>
+			<columns>id</columns>
+			<algorithm>func1</algorithm>
 		</rule>
 	</tableRule>
 
-	<!-- <tableRule name="rule2"> -->
-	<!-- <rule> -->
-	<!-- <columns>user_id</columns> -->
-	<!-- <algorithm>func1</algorithm> -->
-	<!-- </rule> -->
-	<!-- </tableRule> -->
+	<tableRule name="rule2">
+		<rule>
+			<columns>user_id</columns>
+			<algorithm>func1</algorithm>
+		</rule>
+	</tableRule>
 
-	<!-- <tableRule name="sharding-by-intfile"> -->
-	<!-- <rule> -->
-	<!-- <columns>sharding_id</columns> -->
-	<!-- <algorithm>hash-int</algorithm> -->
-	<!-- </rule> -->
-	<!-- </tableRule> -->
+	<tableRule name="sharding-by-intfile">
+		<rule>
+			<columns>sharding_id</columns>
+			<algorithm>hash-int</algorithm>
+		</rule>
+	</tableRule>
     <tableRule name="auto-sharding-long">
         <rule>
-            <columns>channel_id</columns>
+			<columns>id</columns>
             <algorithm>rang-long</algorithm>
         </rule>
     </tableRule>
-    <!-- <tableRule name="mod-long"> -->
-	<!-- <rule> -->
-	<!-- <columns>id</columns> -->
-	<!-- <algorithm>mod-long</algorithm> -->
-	<!-- </rule> -->
-	<!-- </tableRule> -->
-	<!-- <tableRule name="sharding-by-murmur"> -->
-	<!-- <rule> -->
-	<!-- <columns>id</columns> -->
-	<!-- <algorithm>murmur</algorithm> -->
-	<!-- </rule> -->
-	<!-- </tableRule> -->
-	<!-- <tableRule name="crc32slot"> -->
-	<!-- <rule> -->
-	<!-- <columns>id</columns> -->
-	<!-- <algorithm>crc32slot</algorithm> -->
-	<!-- </rule> -->
-	<!-- </tableRule> -->
-	<!-- <tableRule name="sharding-by-month"> -->
-	<!-- <rule> -->
-	<!-- <columns>create_time</columns> -->
-	<!-- <algorithm>partbymonth</algorithm> -->
-	<!-- </rule> -->
-	<!-- </tableRule> -->
-	<!-- <tableRule name="latest-month-calldate"> -->
-	<!-- <rule> -->
-	<!-- <columns>calldate</columns> -->
-	<!-- <algorithm>latestMonth</algorithm> -->
-	<!-- </rule> -->
-	<!-- </tableRule> -->
+	<tableRule name="mod-long">
+		<rule>
+			<columns>id</columns>
+			<algorithm>mod-long</algorithm>
+		</rule>
+	</tableRule>
+	<tableRule name="sharding-by-murmur">
+		<rule>
+			<columns>id</columns>
+			<algorithm>murmur</algorithm>
+		</rule>
+	</tableRule>
+	<tableRule name="crc32slot">
+		<rule>
+			<columns>id</columns>
+			<algorithm>crc32slot</algorithm>
+		</rule>
+	</tableRule>
+	<tableRule name="sharding-by-month">
+		<rule>
+			<columns>create_time</columns>
+			<algorithm>partbymonth</algorithm>
+		</rule>
+	</tableRule>
+	<tableRule name="latest-month-calldate">
+		<rule>
+			<columns>calldate</columns>
+			<algorithm>latestMonth</algorithm>
+		</rule>
+	</tableRule>
 
-	<!-- <tableRule name="auto-sharding-rang-mod"> -->
-	<!-- <rule> -->
-	<!-- <columns>id</columns> -->
-	<!-- <algorithm>rang-mod</algorithm> -->
-	<!-- </rule> -->
-	<!-- </tableRule> -->
+	<tableRule name="auto-sharding-rang-mod">
+		<rule>
+			<columns>id</columns>
+			<algorithm>rang-mod</algorithm>
+		</rule>
+	</tableRule>
 
-	<!-- <tableRule name="jch"> -->
-	<!-- <rule> -->
-	<!-- <columns>id</columns> -->
-	<!-- <algorithm>jump-consistent-hash</algorithm> -->
-	<!-- </rule> -->
-	<!-- </tableRule> -->
+	<tableRule name="jch">
+		<rule>
+			<columns>id</columns>
+			<algorithm>jump-consistent-hash</algorithm>
+		</rule>
+	</tableRule>
 
 	<function name="murmur"
 			  class="io.mycat.route.function.PartitionByMurmurHash">
@@ -107,29 +107,25 @@
 		<property name="count">3</property>
 	</function>
 
-    <function name="func2" class="io.mycat.route.function.PartitionByPostfix">
-		<!-- 在 subTables 里配置的连续表名中 第一个表对应的分表 ID 值 -->
-		<property name="firstValue">1</property>
-		<!-- 该分表列值的固定前缀 -->
-		<property name="prefix">c</property>
-		<!-- 该分表列值的固定后缀 -->
-		<property name="postfix">d</property>
+	<function name="func1" class="io.mycat.route.function.PartitionByLong">
+		<property name="partitionCount">8</property>
+		<property name="partitionLength">128</property>
     </function>
-	<!-- <function name="latestMonth" -->
-	<!-- class="io.mycat.route.function.LatestMonthPartion"> -->
-	<!-- <property name="splitOneDay">24</property> -->
-	<!-- </function> -->
-	<!-- <function name="partbymonth" -->
-	<!-- class="io.mycat.route.function.PartitionByMonth"> -->
-	<!-- <property name="dateFormat">yyyy-MM-dd</property> -->
-	<!-- <property name="sBeginDate">2015-01-01</property> -->
-	<!-- </function> -->
+	<function name="latestMonth"
+		class="io.mycat.route.function.LatestMonthPartion">
+		<property name="splitOneDay">24</property>
+	</function>
+	<function name="partbymonth"
+		class="io.mycat.route.function.PartitionByMonth">
+		<property name="dateFormat">yyyy-MM-dd</property>
+		<property name="sBeginDate">2015-01-01</property>
+	</function>
 
-	<!-- <function name="rang-mod" class="io.mycat.route.function.PartitionByRangeMod"> -->
-	<!-- <property name="mapFile">partition-range-mod.txt</property> -->
-	<!-- </function> -->
+	<function name="rang-mod" class="io.mycat.route.function.PartitionByRangeMod">
+        	<property name="mapFile">partition-range-mod.txt</property>
+	</function>
 
-	<!-- <function name="jump-consistent-hash" class="io.mycat.route.function.PartitionByJumpConsistentHash"> -->
-	<!-- <property name="totalBuckets">3</property> -->
-	<!-- </function> -->
+	<function name="jump-consistent-hash" class="io.mycat.route.function.PartitionByJumpConsistentHash">
+		<property name="totalBuckets">3</property>
+	</function>
 </mycat:rule>

--- a/src/main/resources/rule.xml
+++ b/src/main/resources/rule.xml
@@ -9,84 +9,84 @@
 	under the License. -->
 <!DOCTYPE mycat:rule SYSTEM "rule.dtd">
 <mycat:rule xmlns:mycat="http://io.mycat/">
-	<tableRule name="rule1">
+	<tableRule name="sharding-by-channel-id">
 		<rule>
-			<columns>id</columns>
-			<algorithm>func1</algorithm>
+			<columns>channel_id</columns>
+			<algorithm>func2</algorithm>
 		</rule>
 	</tableRule>
 
-	<tableRule name="rule2">
-		<rule>
-			<columns>user_id</columns>
-			<algorithm>func1</algorithm>
-		</rule>
-	</tableRule>
+	<!-- <tableRule name="rule2"> -->
+	<!-- <rule> -->
+	<!-- <columns>user_id</columns> -->
+	<!-- <algorithm>func1</algorithm> -->
+	<!-- </rule> -->
+	<!-- </tableRule> -->
 
-	<tableRule name="sharding-by-intfile">
-		<rule>
-			<columns>sharding_id</columns>
-			<algorithm>hash-int</algorithm>
-		</rule>
-	</tableRule>
-	<tableRule name="auto-sharding-long">
-		<rule>
-			<columns>id</columns>
-			<algorithm>rang-long</algorithm>
-		</rule>
-	</tableRule>
-	<tableRule name="mod-long">
-		<rule>
-			<columns>id</columns>
-			<algorithm>mod-long</algorithm>
-		</rule>
-	</tableRule>
-	<tableRule name="sharding-by-murmur">
-		<rule>
-			<columns>id</columns>
-			<algorithm>murmur</algorithm>
-		</rule>
-	</tableRule>
-	<tableRule name="crc32slot">
-		<rule>
-			<columns>id</columns>
-			<algorithm>crc32slot</algorithm>
-		</rule>
-	</tableRule>
-	<tableRule name="sharding-by-month">
-		<rule>
-			<columns>create_time</columns>
-			<algorithm>partbymonth</algorithm>
-		</rule>
-	</tableRule>
-	<tableRule name="latest-month-calldate">
-		<rule>
-			<columns>calldate</columns>
-			<algorithm>latestMonth</algorithm>
-		</rule>
-	</tableRule>
-	
-	<tableRule name="auto-sharding-rang-mod">
-		<rule>
-			<columns>id</columns>
-			<algorithm>rang-mod</algorithm>
-		</rule>
-	</tableRule>
-	
-	<tableRule name="jch">
-		<rule>
-			<columns>id</columns>
-			<algorithm>jump-consistent-hash</algorithm>
-		</rule>
-	</tableRule>
+	<!-- <tableRule name="sharding-by-intfile"> -->
+	<!-- <rule> -->
+	<!-- <columns>sharding_id</columns> -->
+	<!-- <algorithm>hash-int</algorithm> -->
+	<!-- </rule> -->
+	<!-- </tableRule> -->
+    <tableRule name="auto-sharding-long">
+        <rule>
+            <columns>channel_id</columns>
+            <algorithm>rang-long</algorithm>
+        </rule>
+    </tableRule>
+    <!-- <tableRule name="mod-long"> -->
+	<!-- <rule> -->
+	<!-- <columns>id</columns> -->
+	<!-- <algorithm>mod-long</algorithm> -->
+	<!-- </rule> -->
+	<!-- </tableRule> -->
+	<!-- <tableRule name="sharding-by-murmur"> -->
+	<!-- <rule> -->
+	<!-- <columns>id</columns> -->
+	<!-- <algorithm>murmur</algorithm> -->
+	<!-- </rule> -->
+	<!-- </tableRule> -->
+	<!-- <tableRule name="crc32slot"> -->
+	<!-- <rule> -->
+	<!-- <columns>id</columns> -->
+	<!-- <algorithm>crc32slot</algorithm> -->
+	<!-- </rule> -->
+	<!-- </tableRule> -->
+	<!-- <tableRule name="sharding-by-month"> -->
+	<!-- <rule> -->
+	<!-- <columns>create_time</columns> -->
+	<!-- <algorithm>partbymonth</algorithm> -->
+	<!-- </rule> -->
+	<!-- </tableRule> -->
+	<!-- <tableRule name="latest-month-calldate"> -->
+	<!-- <rule> -->
+	<!-- <columns>calldate</columns> -->
+	<!-- <algorithm>latestMonth</algorithm> -->
+	<!-- </rule> -->
+	<!-- </tableRule> -->
+
+	<!-- <tableRule name="auto-sharding-rang-mod"> -->
+	<!-- <rule> -->
+	<!-- <columns>id</columns> -->
+	<!-- <algorithm>rang-mod</algorithm> -->
+	<!-- </rule> -->
+	<!-- </tableRule> -->
+
+	<!-- <tableRule name="jch"> -->
+	<!-- <rule> -->
+	<!-- <columns>id</columns> -->
+	<!-- <algorithm>jump-consistent-hash</algorithm> -->
+	<!-- </rule> -->
+	<!-- </tableRule> -->
 
 	<function name="murmur"
-		class="io.mycat.route.function.PartitionByMurmurHash">
+			  class="io.mycat.route.function.PartitionByMurmurHash">
 		<property name="seed">0</property><!-- 默认是0 -->
 		<property name="count">2</property><!-- 要分片的数据库节点数量，必须指定，否则没法分片 -->
 		<property name="virtualBucketTimes">160</property><!-- 一个实际的数据库节点被映射为这么多虚拟节点，默认是160倍，也就是虚拟节点数是物理节点数的160倍 -->
 		<!-- <property name="weightMapFile">weightMapFile</property> 节点的权重，没有指定权重的节点默认是1。以properties文件的格式填写，以从0开始到count-1的整数值也就是节点索引为key，以节点权重值为值。所有权重值必须是正整数，否则以1代替 -->
-		<!-- <property name="bucketMapPath">/etc/mycat/bucketMapPath</property> 
+		<!-- <property name="bucketMapPath">/etc/mycat/bucketMapPath</property>
 			用于测试时观察各物理节点与虚拟节点的分布情况，如果指定了这个属性，会把虚拟节点的murmur hash值与物理节点的映射按行输出到这个文件，没有默认值，如果不指定，就不会输出任何东西 -->
 	</function>
 
@@ -95,11 +95,11 @@
 		<property name="count">2</property><!-- 要分片的数据库节点数量，必须指定，否则没法分片 -->
 	</function>
 	<function name="hash-int"
-		class="io.mycat.route.function.PartitionByFileMap">
+			  class="io.mycat.route.function.PartitionByFileMap">
 		<property name="mapFile">partition-hash-int.txt</property>
 	</function>
 	<function name="rang-long"
-		class="io.mycat.route.function.AutoPartitionByLong">
+			  class="io.mycat.route.function.AutoPartitionByLong">
 		<property name="mapFile">autopartition-long.txt</property>
 	</function>
 	<function name="mod-long" class="io.mycat.route.function.PartitionByMod">
@@ -107,25 +107,23 @@
 		<property name="count">3</property>
 	</function>
 
-	<function name="func1" class="io.mycat.route.function.PartitionByLong">
-		<property name="partitionCount">8</property>
-		<property name="partitionLength">128</property>
-	</function>
-	<function name="latestMonth"
-		class="io.mycat.route.function.LatestMonthPartion">
-		<property name="splitOneDay">24</property>
-	</function>
-	<function name="partbymonth"
-		class="io.mycat.route.function.PartitionByMonth">
-		<property name="dateFormat">yyyy-MM-dd</property>
-		<property name="sBeginDate">2015-01-01</property>
-	</function>
-	
-	<function name="rang-mod" class="io.mycat.route.function.PartitionByRangeMod">
-        	<property name="mapFile">partition-range-mod.txt</property>
-	</function>
-	
-	<function name="jump-consistent-hash" class="io.mycat.route.function.PartitionByJumpConsistentHash">
-		<property name="totalBuckets">3</property>
-	</function>
+    <function name="func2" class="io.mycat.route.function.PartitionByPostfix">
+    </function>
+	<!-- <function name="latestMonth" -->
+	<!-- class="io.mycat.route.function.LatestMonthPartion"> -->
+	<!-- <property name="splitOneDay">24</property> -->
+	<!-- </function> -->
+	<!-- <function name="partbymonth" -->
+	<!-- class="io.mycat.route.function.PartitionByMonth"> -->
+	<!-- <property name="dateFormat">yyyy-MM-dd</property> -->
+	<!-- <property name="sBeginDate">2015-01-01</property> -->
+	<!-- </function> -->
+
+	<!-- <function name="rang-mod" class="io.mycat.route.function.PartitionByRangeMod"> -->
+	<!-- <property name="mapFile">partition-range-mod.txt</property> -->
+	<!-- </function> -->
+
+	<!-- <function name="jump-consistent-hash" class="io.mycat.route.function.PartitionByJumpConsistentHash"> -->
+	<!-- <property name="totalBuckets">3</property> -->
+	<!-- </function> -->
 </mycat:rule>

--- a/src/main/resources/schema.xml
+++ b/src/main/resources/schema.xml
@@ -2,57 +2,55 @@
 <!DOCTYPE mycat:schema SYSTEM "schema.dtd">
 <mycat:schema xmlns:mycat="http://io.mycat/">
 
-	<schema name="voyageone_wms" checkSQLschema="false" sqlMaxLimit="100">
+	<schema name="TESTDB" checkSQLschema="false" sqlMaxLimit="100">
 		<!-- auto sharding by id (long) -->
-		<!-- <table name="travelrecord" dataNode="dn1,dn2,dn3" rule="auto-sharding-long" /> -->
+		<table name="travelrecord" dataNode="dn1,dn2,dn3" rule="auto-sharding-long" />
 
 		<!-- global table is auto cloned to all defined data nodes ,so can join
 			with any table whose sharding node is in the same data node -->
-		<!-- <table name="company" primaryKey="ID" type="global" dataNode="dn1,dn2,dn3" /> -->
-		<!-- <table name="goods" primaryKey="ID" type="global" dataNode="dn1,dn2" /> -->
+		<table name="company" primaryKey="ID" type="global" dataNode="dn1,dn2,dn3" />
+		<table name="goods" primaryKey="ID" type="global" dataNode="dn1,dn2" />
 		<!-- random sharding using mod sharind rule -->
-		<!-- <table name="hotnews" primaryKey="ID" autoIncrement="true" dataNode="dn1,dn2,dn3" -->
-		<!-- rule="mod-long" /> -->
+		<table name="hotnews" primaryKey="ID" autoIncrement="true" dataNode="dn1,dn2,dn3"
+			   rule="mod-long" />
 		<!-- <table name="dual" primaryKey="ID" dataNode="dnx,dnoracle2" type="global"
 			needAddLimit="false"/> <table name="worker" primaryKey="ID" dataNode="jdbc_dn1,jdbc_dn2,jdbc_dn3"
 			rule="mod-long" /> -->
-		<!-- <table name="employee" primaryKey="ID" dataNode="dn1,dn2" -->
-		<!-- rule="sharding-by-intfile" /> -->
-		<!-- <table name="customer" primaryKey="ID" dataNode="dn1,dn2" -->
-		<!-- rule="sharding-by-intfile"> -->
-		<!-- <childTable name="orders" primaryKey="ID" joinKey="customer_id" -->
-		<!-- parentKey="id"> -->
-		<!-- <childTable name="order_items" joinKey="order_id" -->
-		<!-- parentKey="id" /> -->
-		<!-- </childTable> -->
-		<!-- <childTable name="customer_addr" primaryKey="ID" joinKey="customer_id" -->
-		<!-- parentKey="id" /> -->
-        <table name="wms_bt_channel_stock" primaryKey="id" dataNode="dn1"
-               rule="sharding-by-channel-id" subTables="wms_bt_channel_stock_c$001-009">
+		<table name="employee" primaryKey="ID" dataNode="dn1,dn2"
+			   rule="sharding-by-intfile" />
+		<table name="customer" primaryKey="ID" dataNode="dn1,dn2"
+			   rule="sharding-by-intfile">
+			<childTable name="orders" primaryKey="ID" joinKey="customer_id"
+						parentKey="id">
+				<childTable name="order_items" joinKey="order_id"
+							parentKey="id" />
+			</childTable>
+			<childTable name="customer_addr" primaryKey="ID" joinKey="customer_id"
+						parentKey="id" />
         </table>
 		<!-- <table name="oc_call" primaryKey="ID" dataNode="dn1$0-743" rule="latest-month-calldate"
 			/> -->
 	</schema>
 	<!-- <dataNode name="dn1$0-743" dataHost="localhost1" database="db$0-743"
 		/> -->
-	<dataNode name="dn1" dataHost="test_db" database="voyageone_wms" />
-	<!-- 	<dataNode name="dn2" dataHost="localhost1" database="db2" />
-        <dataNode name="dn3" dataHost="localhost1" database="db3" /> -->
+	<dataNode name="dn1" dataHost="localhost1" database="db1" />
+	<dataNode name="dn2" dataHost="localhost1" database="db2" />
+	<dataNode name="dn3" dataHost="localhost1" database="db3" />
 	<!--<dataNode name="dn4" dataHost="sequoiadb1" database="SAMPLE" />
 	 <dataNode name="jdbc_dn1" dataHost="jdbchost" database="db1" />
 	<dataNode	name="jdbc_dn2" dataHost="jdbchost" database="db2" />
 	<dataNode name="jdbc_dn3" 	dataHost="jdbchost" database="db3" /> -->
-	<dataHost name="test_db" maxCon="1000" minCon="10" balance="0"
+	<dataHost name="localhost1" maxCon="1000" minCon="10" balance="0"
 			  writeType="0" dbType="mysql" dbDriver="native" switchType="1"  slaveThreshold="100">
 		<heartbeat>select user()</heartbeat>
 		<!-- can have multi write hosts -->
-		<writeHost host="test_write_host_db" url="10.0.0.83:3306" user="root"
-				   password="sneakerhead">
+		<writeHost host="hostM1" url="localhost:3306" user="root"
+				   password="123456">
 			<!-- can have multi read hosts -->
-			<!-- <readHost host="test_host_db" url="10.0.0.83:3306" user="root" password="sneakerhead" /> -->
+			<readHost host="hostS2" url="192.168.1.200:3306" user="root" password="xxx" />
 		</writeHost>
-		<!-- 		<writeHost host="hostS1" url="localhost:3316" user="root"
-                           password="123456" /> -->
+		<writeHost host="hostS1" url="localhost:3316" user="root"
+				   password="123456" />
 		<!-- <writeHost host="hostM2" url="localhost:3316" user="root" password="123456"/> -->
 	</dataHost>
 	<!--

--- a/src/main/resources/schema.xml
+++ b/src/main/resources/schema.xml
@@ -2,55 +2,57 @@
 <!DOCTYPE mycat:schema SYSTEM "schema.dtd">
 <mycat:schema xmlns:mycat="http://io.mycat/">
 
-	<schema name="TESTDB" checkSQLschema="false" sqlMaxLimit="100">
+	<schema name="voyageone_wms" checkSQLschema="false" sqlMaxLimit="100">
 		<!-- auto sharding by id (long) -->
-		<table name="travelrecord" dataNode="dn1,dn2,dn3" rule="auto-sharding-long" />
+		<!-- <table name="travelrecord" dataNode="dn1,dn2,dn3" rule="auto-sharding-long" /> -->
 
 		<!-- global table is auto cloned to all defined data nodes ,so can join
 			with any table whose sharding node is in the same data node -->
-		<table name="company" primaryKey="ID" type="global" dataNode="dn1,dn2,dn3" />
-		<table name="goods" primaryKey="ID" type="global" dataNode="dn1,dn2" />
+		<!-- <table name="company" primaryKey="ID" type="global" dataNode="dn1,dn2,dn3" /> -->
+		<!-- <table name="goods" primaryKey="ID" type="global" dataNode="dn1,dn2" /> -->
 		<!-- random sharding using mod sharind rule -->
-		<table name="hotnews" primaryKey="ID" autoIncrement="true" dataNode="dn1,dn2,dn3"
-			   rule="mod-long" />
+		<!-- <table name="hotnews" primaryKey="ID" autoIncrement="true" dataNode="dn1,dn2,dn3" -->
+		<!-- rule="mod-long" /> -->
 		<!-- <table name="dual" primaryKey="ID" dataNode="dnx,dnoracle2" type="global"
 			needAddLimit="false"/> <table name="worker" primaryKey="ID" dataNode="jdbc_dn1,jdbc_dn2,jdbc_dn3"
 			rule="mod-long" /> -->
-		<table name="employee" primaryKey="ID" dataNode="dn1,dn2"
-			   rule="sharding-by-intfile" />
-		<table name="customer" primaryKey="ID" dataNode="dn1,dn2"
-			   rule="sharding-by-intfile">
-			<childTable name="orders" primaryKey="ID" joinKey="customer_id"
-						parentKey="id">
-				<childTable name="order_items" joinKey="order_id"
-							parentKey="id" />
-			</childTable>
-			<childTable name="customer_addr" primaryKey="ID" joinKey="customer_id"
-						parentKey="id" />
-		</table>
+		<!-- <table name="employee" primaryKey="ID" dataNode="dn1,dn2" -->
+		<!-- rule="sharding-by-intfile" /> -->
+		<!-- <table name="customer" primaryKey="ID" dataNode="dn1,dn2" -->
+		<!-- rule="sharding-by-intfile"> -->
+		<!-- <childTable name="orders" primaryKey="ID" joinKey="customer_id" -->
+		<!-- parentKey="id"> -->
+		<!-- <childTable name="order_items" joinKey="order_id" -->
+		<!-- parentKey="id" /> -->
+		<!-- </childTable> -->
+		<!-- <childTable name="customer_addr" primaryKey="ID" joinKey="customer_id" -->
+		<!-- parentKey="id" /> -->
+        <table name="wms_bt_channel_stock" primaryKey="id" dataNode="dn1"
+               rule="sharding-by-channel-id" subTables="wms_bt_channel_stock_c$001-009">
+        </table>
 		<!-- <table name="oc_call" primaryKey="ID" dataNode="dn1$0-743" rule="latest-month-calldate"
 			/> -->
 	</schema>
 	<!-- <dataNode name="dn1$0-743" dataHost="localhost1" database="db$0-743"
 		/> -->
-	<dataNode name="dn1" dataHost="localhost1" database="db1" />
-	<dataNode name="dn2" dataHost="localhost1" database="db2" />
-	<dataNode name="dn3" dataHost="localhost1" database="db3" />
+	<dataNode name="dn1" dataHost="test_db" database="voyageone_wms" />
+	<!-- 	<dataNode name="dn2" dataHost="localhost1" database="db2" />
+        <dataNode name="dn3" dataHost="localhost1" database="db3" /> -->
 	<!--<dataNode name="dn4" dataHost="sequoiadb1" database="SAMPLE" />
 	 <dataNode name="jdbc_dn1" dataHost="jdbchost" database="db1" />
 	<dataNode	name="jdbc_dn2" dataHost="jdbchost" database="db2" />
 	<dataNode name="jdbc_dn3" 	dataHost="jdbchost" database="db3" /> -->
-	<dataHost name="localhost1" maxCon="1000" minCon="10" balance="0"
+	<dataHost name="test_db" maxCon="1000" minCon="10" balance="0"
 			  writeType="0" dbType="mysql" dbDriver="native" switchType="1"  slaveThreshold="100">
 		<heartbeat>select user()</heartbeat>
 		<!-- can have multi write hosts -->
-		<writeHost host="hostM1" url="localhost:3306" user="root"
-				   password="123456">
+		<writeHost host="test_write_host_db" url="10.0.0.83:3306" user="root"
+				   password="sneakerhead">
 			<!-- can have multi read hosts -->
-			<readHost host="hostS2" url="192.168.1.200:3306" user="root" password="xxx" />
+			<!-- <readHost host="test_host_db" url="10.0.0.83:3306" user="root" password="sneakerhead" /> -->
 		</writeHost>
-		<writeHost host="hostS1" url="localhost:3316" user="root"
-				   password="123456" />
+		<!-- 		<writeHost host="hostS1" url="localhost:3316" user="root"
+                           password="123456" /> -->
 		<!-- <writeHost host="hostM2" url="localhost:3316" user="root" password="123456"/> -->
 	</dataHost>
 	<!--

--- a/src/main/resources/server.xml
+++ b/src/main/resources/server.xml
@@ -10,20 +10,18 @@
 <!DOCTYPE mycat:server SYSTEM "server.dtd">
 <mycat:server xmlns:mycat="http://io.mycat/">
 	<system>
-	<property name="nonePasswordLogin">0</property> <!-- 0为需要密码登陆、1为不需要密码登陆 ,默认为0，设置为1则需要指定默认账户-->
-	<property name="useHandshakeV10">1</property>
-	<property name="useSqlStat">0</property>  <!-- 1为开启实时统计、0为关闭 -->
-	<property name="useGlobleTableCheck">0</property>  <!-- 1为开启全加班一致性检测、0为关闭 -->
+		<property name="useSqlStat">0</property>  <!-- 1为开启实时统计、0为关闭 -->
+		<property name="useGlobleTableCheck">0</property>  <!-- 1为开启全加班一致性检测、0为关闭 -->
 
 		<property name="sequnceHandlerType">2</property>
-      <!--  <property name="useCompression">1</property>--> <!--1为开启mysql压缩协议-->
-        <!--  <property name="fakeMySQLVersion">5.6.20</property>--> <!--设置模拟的MySQL版本号-->
-	<!-- <property name="processorBufferChunk">40960</property> -->
-	<!-- 
-	<property name="processors">1</property> 
-	<property name="processorExecutor">32</property> 
-	 -->
-        <!--默认为type 0: DirectByteBufferPool | type 1 ByteBufferArena | type 2 NettyBufferPool -->
+		<!--  <property name="useCompression">1</property>--> <!--1为开启mysql压缩协议-->
+		<!--  <property name="fakeMySQLVersion">5.6.20</property>--> <!--设置模拟的MySQL版本号-->
+		<!-- <property name="processorBufferChunk">40960</property> -->
+		<!--
+        <property name="processors">1</property>
+        <property name="processorExecutor">32</property>
+         -->
+		<!--默认为type 0: DirectByteBufferPool | type 1 ByteBufferArena-->
 		<property name="processorBufferPoolType">0</property>
 		<!--默认是65535 64K 用于sql解析时最大文本长度 -->
 		<!--<property name="maxStringLiteralLength">65535</property>-->
@@ -32,21 +30,21 @@
 		<!--<property name="frontSocketNoDelay">1</property>-->
 		<!--<property name="processorExecutor">16</property>-->
 		<!--
-			<property name="serverPort">8066</property> <property name="managerPort">9066</property> 
-			<property name="idleTimeout">300000</property> <property name="bindIp">0.0.0.0</property> 
+			<property name="serverPort">8066</property> <property name="managerPort">9066</property>
+			<property name="idleTimeout">300000</property> <property name="bindIp">0.0.0.0</property>
 			<property name="frontWriteQueueSize">4096</property> <property name="processors">32</property> -->
 		<!--分布式事务开关，0为不过滤分布式事务，1为过滤分布式事务（如果分布式事务内只涉及全局表，则不过滤），2为不过滤分布式事务,但是记录分布式事务日志-->
 		<property name="handleDistributedTransactions">0</property>
-		
-			<!--
-			off heap for merge/order/group/limit      1开启   0关闭
-		-->
+
+		<!--
+        off heap for merge/order/group/limit      1开启   0关闭
+    -->
 		<property name="useOffHeapForMerge">1</property>
 
 		<!--
 			单位为m
 		-->
-        <property name="memoryPageSize">64k</property>
+		<property name="memoryPageSize">1m</property>
 
 		<!--
 			单位为k
@@ -64,49 +62,39 @@
 		<!--是否采用zookeeper协调切换  -->
 		<property name="useZKSwitch">true</property>
 
-		<!-- XA Recovery Log日志路径 -->
-		<!--<property name="XARecoveryLogBaseDir">./</property>-->
-
-		<!-- XA Recovery Log日志名称 -->
-		<!--<property name="XARecoveryLogBaseName">tmlog</property>-->
 
 	</system>
-	
+
 	<!-- 全局SQL防火墙设置 -->
-	<!--白名单可以使用通配符%或着*-->
-	<!--例如<host host="127.0.0.*" user="root"/>-->
-	<!--例如<host host="127.0.*" user="root"/>-->
-	<!--例如<host host="127.*" user="root"/>-->
-	<!--例如<host host="1*7.*" user="root"/>-->
-	<!--这些配置情况下对于127.0.0.1都能以root账户登录-->
 	<!--
 	<firewall>
 	   <whitehost>
-	      <host host="1*7.0.0.*" user="root"/>
+	      <host host="127.0.0.1" user="mycat"/>
+	      <host host="127.0.0.2" user="mycat"/>
 	   </whitehost>
        <blacklist check="false">
        </blacklist>
 	</firewall>
 	-->
 
-	<user name="root" defaultAccount="true">
-		<property name="password">123456</property>
-		<property name="schemas">TESTDB</property>
-		
+	<user name="root">
+		<property name="password">sneakerhead</property>
+		<property name="schemas">voyageone_wms</property>
+
 		<!-- 表级 DML 权限设置 -->
-		<!-- 		
+		<!--
 		<privileges check="false">
 			<schema name="TESTDB" dml="0110" >
 				<table name="tb01" dml="0000"></table>
 				<table name="tb02" dml="1111"></table>
 			</schema>
-		</privileges>		
+		</privileges>
 		 -->
 	</user>
 
 	<user name="user">
-		<property name="password">user</property>
-		<property name="schemas">TESTDB</property>
+		<property name="password">sneakerhead</property>
+		<property name="schemas">voyageone_wms</property>
 		<property name="readOnly">true</property>
 	</user>
 

--- a/src/main/resources/server.xml
+++ b/src/main/resources/server.xml
@@ -10,6 +10,8 @@
 <!DOCTYPE mycat:server SYSTEM "server.dtd">
 <mycat:server xmlns:mycat="http://io.mycat/">
 	<system>
+	<property name="nonePasswordLogin">0</property> <!-- 0为需要密码登陆、1为不需要密码登陆 ,默认为0，设置为1则需要指定默认账户-->
+	<property name="useHandshakeV10">1</property>
 		<property name="useSqlStat">0</property>  <!-- 1为开启实时统计、0为关闭 -->
 		<property name="useGlobleTableCheck">0</property>  <!-- 1为开启全加班一致性检测、0为关闭 -->
 
@@ -21,7 +23,7 @@
         <property name="processors">1</property>
         <property name="processorExecutor">32</property>
          -->
-		<!--默认为type 0: DirectByteBufferPool | type 1 ByteBufferArena-->
+        <!--默认为type 0: DirectByteBufferPool | type 1 ByteBufferArena | type 2 NettyBufferPool -->
 		<property name="processorBufferPoolType">0</property>
 		<!--默认是65535 64K 用于sql解析时最大文本长度 -->
 		<!--<property name="maxStringLiteralLength">65535</property>-->
@@ -44,7 +46,7 @@
 		<!--
 			单位为m
 		-->
-		<property name="memoryPageSize">1m</property>
+        <property name="memoryPageSize">64k</property>
 
 		<!--
 			单位为k
@@ -60,26 +62,36 @@
 
 
 		<!--是否采用zookeeper协调切换  -->
-		<property name="useZKSwitch">false</property>
+		<property name="useZKSwitch">true</property>
 
+		<!-- XA Recovery Log日志路径 -->
+		<!--<property name="XARecoveryLogBaseDir">./</property>-->
+
+		<!-- XA Recovery Log日志名称 -->
+		<!--<property name="XARecoveryLogBaseName">tmlog</property>-->
 
 	</system>
 
 	<!-- 全局SQL防火墙设置 -->
+	<!--白名单可以使用通配符%或着*-->
+	<!--例如<host host="127.0.0.*" user="root"/>-->
+	<!--例如<host host="127.0.*" user="root"/>-->
+	<!--例如<host host="127.*" user="root"/>-->
+	<!--例如<host host="1*7.*" user="root"/>-->
+	<!--这些配置情况下对于127.0.0.1都能以root账户登录-->
 	<!--
 	<firewall>
 	   <whitehost>
-	      <host host="127.0.0.1" user="mycat"/>
-	      <host host="127.0.0.2" user="mycat"/>
+	      <host host="1*7.0.0.*" user="root"/>
 	   </whitehost>
        <blacklist check="false">
        </blacklist>
 	</firewall>
 	-->
 
-	<user name="root">
-		<property name="password">sneakerhead</property>
-		<property name="schemas">voyageone_wms</property>
+	<user name="root" defaultAccount="true">
+		<property name="password">123456</property>
+		<property name="schemas">TESTDB</property>
 
 		<!-- 表级 DML 权限设置 -->
 		<!--
@@ -93,8 +105,8 @@
 	</user>
 
 	<user name="user">
-		<property name="password">sneakerhead</property>
-		<property name="schemas">voyageone_wms</property>
+		<property name="password">user</property>
+		<property name="schemas">TESTDB</property>
 		<property name="readOnly">true</property>
 	</user>
 

--- a/src/test/java/io/mycat/mpp/TestSorter.java
+++ b/src/test/java/io/mycat/mpp/TestSorter.java
@@ -28,6 +28,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestSorter {
+    byte[] b1;
+    byte[] b2;
 
     @Test
     public void testDecimal() {
@@ -57,7 +59,9 @@ public class TestSorter {
         b1 = "0".getBytes();
         b2 = "1".getBytes();
         Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) < 0);
-
+    }
+    @Test
+    public void testNumberCompare2() {
         b1 = "10".getBytes();
         b2 = "1".getBytes();
         Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) > 0);
@@ -66,6 +70,9 @@ public class TestSorter {
         b2 = "100.0".getBytes();
         Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) == 0);
 
+    }
+    @Test
+    public void testNumberCompare4() {
         b1 = "100.000".getBytes();
         b2 = "100.0".getBytes();
         Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) == 0);
@@ -74,6 +81,10 @@ public class TestSorter {
         b2 = "-100.0".getBytes();
         Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) == 0);
 
+    }
+
+    @Test
+    public void testNumberCompare6() {
         b1 = "-100.001".getBytes();
         b2 = "-100.0".getBytes();
         Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) < 0);

--- a/src/test/java/io/mycat/mpp/TestSorter.java
+++ b/src/test/java/io/mycat/mpp/TestSorter.java
@@ -23,84 +23,83 @@
  */
 package io.mycat.mpp;
 
+import io.mycat.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.mycat.util.ByteUtil;
-
 public class TestSorter {
 
-	@Test
-	public void testDecimal() {
-		String d1 = "-1223.000";
-		byte[] d1b = d1.getBytes();
-		Assert.assertEquals(true, -1223.0 == ByteUtil.getDouble(d1b));
-		d1b = "-99999.890".getBytes();
-		Assert.assertEquals(true, -99999.890 == ByteUtil.getDouble(d1b));
-		// 221346.000
-		byte[] data2 = new byte[] { 50, 50, 49, 51, 52, 54, 46, 48, 48, 48 };
-		Assert.assertEquals(true, 221346.000 == ByteUtil.getDouble(data2));
-		// 1234567890
-		byte[] data3 = new byte[] { 49, 50, 51, 52, 53, 54, 55, 56, 57, 48 };
-		Assert.assertEquals(true, 1234567890 == ByteUtil.getInt(data3));
+    @Test
+    public void testDecimal() {
+        String d1 = "-1223.000";
+        byte[] d1b = d1.getBytes();
+        Assert.assertEquals(true, -1223.0 == ByteUtil.getDouble(d1b));
+        d1b = "-99999.890".getBytes();
+        Assert.assertEquals(true, -99999.890 == ByteUtil.getDouble(d1b));
+        // 221346.000
+        byte[] data2 = new byte[]{50, 50, 49, 51, 52, 54, 46, 48, 48, 48};
+        Assert.assertEquals(true, 221346.000 == ByteUtil.getDouble(data2));
+        // 1234567890
+        byte[] data3 = new byte[]{49, 50, 51, 52, 53, 54, 55, 56, 57, 48};
+        Assert.assertEquals(true, 1234567890 == ByteUtil.getInt(data3));
 
-		// 0123456789
-		byte[] data4 = new byte[] { 48, 49, 50, 51, 52, 53, 54, 55, 56, 57 };
-		Assert.assertEquals(true, 123456789 == ByteUtil.getInt(data4));
-	}
+        // 0123456789
+        byte[] data4 = new byte[]{48, 49, 50, 51, 52, 53, 54, 55, 56, 57};
+        Assert.assertEquals(true, 123456789 == ByteUtil.getInt(data4));
+    }
 
-	@Test
-	public void testNumberCompare() {
-		byte[] b1 = "0".getBytes();
-		byte[] b2 = "0".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) == 0);
+    @Test
+    public void testNumberCompare() {
+        byte[] b1 = "0".getBytes();
+        byte[] b2 = "0".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) == 0);
 
-		b1 = "0".getBytes();
-		b2 = "1".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)< 0);
-		
-		b1 = "10".getBytes();
-		b2 = "1".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)> 0);
-		
-		b1 = "100.0".getBytes();
-		b2 = "100.0".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)==0);
-		
-		b1 = "100.000".getBytes();
-		b2 = "100.0".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)>0);
-		
-		b1 = "-100.000".getBytes();
-		b2 = "-100.0".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)<0);
-		
-		b1 = "-100.001".getBytes();
-		b2 = "-100.0".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)<0);
-		
-		b1 = "-100.001".getBytes();
-		b2 = "100.0".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)<0);
-		
-		b1 = "90".getBytes();
-		b2 = "10000".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)<0);
-		b1 = "-90".getBytes();
-		b2 = "-10000".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)>0);
-		
-		b1 = "98".getBytes();
-		b2 = "98000".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)<0);
-		
-		b1 = "-98".getBytes();
-		b2= "-98000".getBytes();
-		Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)>0);
-		
-		b1="12002585786".getBytes();
-        b2="12002585785".getBytes();
-        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2)>0);
+        b1 = "0".getBytes();
+        b2 = "1".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) < 0);
 
-	}
+        b1 = "10".getBytes();
+        b2 = "1".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) > 0);
+
+        b1 = "100.0".getBytes();
+        b2 = "100.0".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) == 0);
+
+        b1 = "100.000".getBytes();
+        b2 = "100.0".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) == 0);
+
+        b1 = "-100.000".getBytes();
+        b2 = "-100.0".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) == 0);
+
+        b1 = "-100.001".getBytes();
+        b2 = "-100.0".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) < 0);
+
+        b1 = "-100.001".getBytes();
+        b2 = "100.0".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) < 0);
+
+        b1 = "90".getBytes();
+        b2 = "10000".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) < 0);
+        b1 = "-90".getBytes();
+        b2 = "-10000".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) > 0);
+
+        b1 = "98".getBytes();
+        b2 = "98000".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) < 0);
+
+        b1 = "-98".getBytes();
+        b2 = "-98000".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) > 0);
+
+        b1 = "12002585786".getBytes();
+        b2 = "12002585785".getBytes();
+        Assert.assertEquals(true, ByteUtil.compareNumberByte(b1, b2) > 0);
+
+    }
 }

--- a/src/test/java/io/mycat/util/ByteUtilTest.java
+++ b/src/test/java/io/mycat/util/ByteUtilTest.java
@@ -1,0 +1,22 @@
+package io.mycat.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * <p>
+ * COPYRIGHT © 2001 - 2016 VOYAGE ONE GROUP INC. ALL RIGHTS RESERVED.
+ *
+ * @author vantis 2017/9/29
+ * @version 1.0.0
+ */
+public class ByteUtilTest {
+    @Test
+    public void compareNumberByte() throws Exception {
+        byte[] b1 = {'1', '.', '2'};
+        byte[] b2 = {'1', '2', '2'};
+        int i = ByteUtil.compareNumberByte(b1, b2);
+    }
+
+}

--- a/src/test/java/io/mycat/util/SplitUtilTest.java
+++ b/src/test/java/io/mycat/util/SplitUtilTest.java
@@ -82,4 +82,10 @@ public class SplitUtilTest {
         Assert.assertEquals("offer[3]", dest[3]);
     }
 
+    @Test
+    public void test5() {
+        String src = "wms_bt_channel_stock_c$00-999";
+        String [] dest = SplitUtil.split(src, ',', '$', '-');
+        Assert.assertEquals(1000, dest.length);
+    }
 }

--- a/version.txt
+++ b/version.txt
@@ -1,6 +1,6 @@
-BuildTime  2017-04-24 09:41:48
-GitVersion   36626e4d819c30da8e281594758559ec13f00679
-MavenVersion 1.6.5-BETA
+BuildTime  2017-09-30 07:52:21
+GitVersion   8cf5282e639acc09a84612397f1de07459e3b5bf
+MavenVersion 1.6.5-release
 GitUrl https://github.com/MyCATApache/Mycat-Server.git
 MyCatSite http://www.mycat.org.cn
 QQGroup 106088787


### PR DESCRIPTION
小幅修改

1. 增强了单库分表规则的支持 现在支持 `$000-999` 这种规定3位数格式的后缀支持
```xml
<table name="wms_bt_channel_stock" primaryKey="id" dataNode="dn1"
               rule="sharding-by-channel-id" subTables="wms_bt_channel_stock_c$001-009">
        </table>
```
将映射 `wms_bt_channel_stock_c001`, `wms_bt_channel_stock_c002`, ... `wms_bt_channel_stock_c009` 表

2. fixed #336
3. 修正了单库分表对别名的支持
  现在类似
```sql
SELECT t.*
FROM wms_bt_channel_stock t;
```
不会报未知的表 t 的错误了