### PR TITLE
解决单库分表策略当sql中包含别名报:Unknown column 'alias.field' in 'field list'

### DIFF
--- a/src/main/java/io/mycat/route/parser/druid/impl/DruidSelectParser.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/DruidSelectParser.java
@@ -431,6 +431,7 @@ public class DruidSelectParser extends DefaultDruidParser {
 					sqlIdentifierExpr.setParent(from);
 					sqlIdentifierExpr.setName(node.getSubTableName());
 					SQLExprTableSource from2 = new SQLExprTableSource(sqlIdentifierExpr);
+					from2.setAlias(from.getAlias());
 					mysqlSelectQuery.setFrom(from2);
 					node.setStatement(stmt.toString());
 	            }


### PR DESCRIPTION
我们的schema.xml如下：
<?xml version="1.0"?>
<!DOCTYPE mycat:schema SYSTEM "schema.dtd">
<mycat:schema xmlns:mycat="http://io.mycat/">
    <schema name="snaker_test2" checkSQLschema="false" sqlMaxLimit="100">
        <table name="wf_hist_order" subTables="wf_hist_order$1-3" dataNode="snakerNode" rule="sharding-by-month"/>
    </schema>
    <dataNode name="snakerNode" dataHost="snaker" database="snaker_test2"/>
    <dataHost name="snaker" maxCon="1000" minCon="10" balance="0"
              writeType="0" dbType="mysql" dbDriver="native" switchType="1" slaveThreshold="100">
        <heartbeat>select user()</heartbeat>
        <writeHost host="snaker_w" url="192.168.101.131:3306" user="zlz"
                   password="ppmoney"/>
    </dataHost>
</mycat:schema>

我们使用了单库分表策略，执行sql:
SELECT a.id, a.process_Id FROM wf_hist_order a

报错： [Err] 1105 - Unknown column 'a.id' in 'field list'

经查，是DruidSelectParser类changeSql方法在改写sql时忘记把表的别名也改写。
