### PR TITLE
用户名包含 % 的情况下配置文件 dtd NMTOKEN 不通过

### DIFF
--- a/src/main/resources/schema.dtd
+++ b/src/main/resources/schema.dtd
@@ -80,7 +80,7 @@
   host NMTOKEN #REQUIRED
   url CDATA #REQUIRED
   password CDATA #REQUIRED
-  user NMTOKEN #REQUIRED
+  user CDATA #REQUIRED
   weight CDATA #IMPLIED
   usingDecrypt CDATA #IMPLIED>
 


### PR DESCRIPTION
azure MySQL db 要求用户名 必须包含 % 