### PR TITLE
修复 子查询中存在关联查询的情况下,检查关联字段是否是分片字段 的问题

### DIFF
--- a/src/main/java/io/mycat/config/model/SystemConfig.java
+++ b/src/main/java/io/mycat/config/model/SystemConfig.java
@@ -152,6 +152,8 @@ public final class SystemConfig {
 	private int mycatNodeId=1;
 	private int useCompression =0;	
 	private int useSqlStat = 1;
+	//子查询中存在关联查询的情况下,检查关联字段中是否有分片字段 .默认 false
+	private boolean subqueryRelationshipCheck = false;
 	
 	// 是否使用HandshakeV10Packet来与client进行通讯, 1:是 , 0:否(使用HandshakePacket)
 	// 使用HandshakeV10Packet为的是兼容高版本的jdbc驱动, 后期稳定下来考虑全部采用HandshakeV10Packet来通讯
@@ -944,6 +946,14 @@ public final class SystemConfig {
 
 	public void setNonePasswordLogin(int nonePasswordLogin) {
 		this.nonePasswordLogin = nonePasswordLogin;
+	}
+
+	public boolean isSubqueryRelationshipCheck() {
+		return subqueryRelationshipCheck;
+	}
+
+	public void setSubqueryRelationshipCheck(boolean subqueryRelationshipCheck) {
+		this.subqueryRelationshipCheck = subqueryRelationshipCheck;
 	}
 	
 	

--- a/src/main/resources/server.xml
+++ b/src/main/resources/server.xml
@@ -16,6 +16,7 @@
 	<property name="useGlobleTableCheck">0</property>  <!-- 1为开启全加班一致性检测、0为关闭 -->
 
 		<property name="sequnceHandlerType">2</property>
+	<property name="subqueryRelationshipCheck">false</property> <!-- 子查询中存在关联查询的情况下,检查关联字段中是否有分片字段 .默认 false -->
       <!--  <property name="useCompression">1</property>--> <!--1为开启mysql压缩协议-->
         <!--  <property name="fakeMySQLVersion">5.6.20</property>--> <!--设置模拟的MySQL版本号-->
 	<!-- <property name="processorBufferChunk">40960</property> -->


### PR DESCRIPTION
1. 修复 子查询中存在关联查询的情况下,检查关联字段是否是分片字段 的问题。 
   修改为 检查 关联条件中是否有 分片字段。
2. 增加 子查询中存在关联查询的情况下,检查关联字段中是否有分片字段 .默认 false。
   通过在server.xml 中增加以下配置项开启
`<property name="subqueryRelationshipCheck">true</property>`