### PR TITLE
添加JDBC链接方式中使用io.mycat.catlets.ShareJoin 进行跨库JOIN时的不支持问题

### DIFF
--- a/src/main/java/io/mycat/buffer/MyCatMemoryAllocator.java
+++ b/src/main/java/io/mycat/buffer/MyCatMemoryAllocator.java
@@ -64,7 +64,8 @@ public class MyCatMemoryAllocator implements ByteBufAllocator {
                 maxOrder,
                 512,
                 256,
-                64);
+                64,
+                true);
 
 
         /**for 5.0.x

--- a/src/main/java/io/mycat/buffer/MyCatMemoryAllocator.java
+++ b/src/main/java/io/mycat/buffer/MyCatMemoryAllocator.java
@@ -64,8 +64,7 @@ public class MyCatMemoryAllocator implements ByteBufAllocator {
                 maxOrder,
                 512,
                 256,
-                64,
-                true);
+                64);
 
 
         /**for 5.0.x

--- a/src/main/java/io/mycat/catlets/TableFilter.java
+++ b/src/main/java/io/mycat/catlets/TableFilter.java
@@ -354,7 +354,7 @@ public class TableFilter {
 		}	
 		if (parent==null){
         	if ((rowCount>0)&& (offset>0)){
-        		sql+=" limit"+offset+","+rowCount;
+        		sql+=" limit "+offset+","+rowCount;
         	}
         	else {
         		if (rowCount>0){


### PR DESCRIPTION
1）添加JDBC链接方式中使用io.mycat.catlets.ShareJoin 进行跨库JOIN时的不支持问题
2）添加mongodb数据库的in运算符的支持


mysql> select * from city;
+----+-------------+-----------+-------------+
| id | province_id | city_name | description |
+----+-------------+-----------+-------------+
|  3 |           1 | 廊坊      | 1           |
|  1 |           1 | 沧州      | 1           |
|  2 |           1 | 保定      | 3           |
+----+-------------+-----------+-------------+
3 rows in set (0.08 sec)

mysql> select * from mongodb;
+--------------------------+-------+------+
| _id                      | name  | age  |
+--------------------------+-------+------+
| 59e018fd370841ac1c9a22a1 | zhang |   10 |
| 1                        | zhang |   10 |
| 2                        | li    |   20 |
| 3                        | wang  |   20 |
| 4                        | li    |   20 |
+--------------------------+-------+------+
5 rows in set (0.02 sec)

mysql> /*!mycat:catlet=io.mycat.catlets.ShareJoin */select city.id,city.city_name,mongodb.name from city,mongodb where city.id=mongodb._id;
+----+-----------+-------+
| id | city_name | name  |
+----+-----------+-------+
|  1 | 沧州      | zhang |
|  2 | 保定      | li    |
|  3 | 廊坊      | wang  |
+----+-----------+-------+
3 rows in set (0.02 sec)