### PR TITLE
增加了对MySQL Group Replication的心跳检测

### DIFF
--- a/src/main/java/io/mycat/backend/heartbeat/HeartbeatSQLJob.java
+++ b/src/main/java/io/mycat/backend/heartbeat/HeartbeatSQLJob.java
@@ -1,0 +1,25 @@
+package io.mycat.backend.heartbeat;
+
+import io.mycat.backend.BackendConnection;
+import io.mycat.backend.datasource.PhysicalDatasource;
+import io.mycat.sqlengine.EngineCtx;
+import io.mycat.sqlengine.SQLJob;
+import io.mycat.sqlengine.SQLJobHandler;
+
+public class HeartbeatSQLJob extends SQLJob {
+    public HeartbeatSQLJob(int id, String sql, String dataNode, SQLJobHandler jobHandler, EngineCtx ctx) {
+        super(id, sql, dataNode, jobHandler, ctx);
+    }
+
+    public HeartbeatSQLJob(String sql, String databaseName, SQLJobHandler jobHandler, PhysicalDatasource ds) {
+        super(sql, databaseName, jobHandler, ds);
+    }
+
+    @Override
+    public void okResponse(byte[] ok, BackendConnection conn) {
+        // 比父类少了个conn.release(); 原因是如果这里释放了链接的话，心跳包会没有数据（responseHandler为空）
+        conn.syncAndExcute();
+        doFinished(false,null);
+    }
+
+}

--- a/src/main/java/io/mycat/backend/heartbeat/MySQLDetector.java
+++ b/src/main/java/io/mycat/backend/heartbeat/MySQLDetector.java
@@ -210,7 +210,7 @@ public class MySQLDetector implements SQLQueryResultListener<SQLQueryResult<Map<
 				String channelName = resultResult.get("CHANNEL_NAME");
 				String remainingDelay = resultResult.get("REMAINING_DELAY");
 				String countTransactionsRetries = resultResult.get("COUNT_TRANSACTIONS_RETRIES");
-				if ("ON".equalsIgnoreCase(serviceState)) {
+				if ("ON".equalsIgnoreCase(serviceState) && "group_replication_applier".equalsIgnoreCase(channelName)) {
 					heartbeat.setDbSynStatus(DBHeartbeat.DB_SYN_NORMAL);
 					heartbeat.setResult(MySQLHeartbeat.OK_STATUS, this, null);
 				} else {

--- a/src/main/java/io/mycat/config/model/DataHostConfig.java
+++ b/src/main/java/io/mycat/config/model/DataHostConfig.java
@@ -43,8 +43,13 @@ public class DataHostConfig {
 	public static final int DEFAULT_SWITCH_DS = 1;
 	public static final int SYN_STATUS_SWITCH_DS = 2;
 	public static final int CLUSTER_STATUS_SWITCH_DS = 3;
+	public static final int MGR_STATUS_SWITCH_DS = 4;
     private static final Pattern pattern = Pattern.compile("\\s*show\\s+slave\\s+status\\s*",Pattern.CASE_INSENSITIVE);
     private static final Pattern patternCluster = Pattern.compile("\\s*show\\s+status\\s+like\\s+'wsrep%'",Pattern.CASE_INSENSITIVE);
+	/**
+	 * pattern for <pre>select * from performance_schema.replication_connection_status where CHANNEL_NAME='group_replication_applier'</pre>
+	 */
+	private static final Pattern patternMySQLGroupReplication = Pattern.compile("\\s*select\\s+\\*\\s+from\\s+performance_schema.replication_connection_status\\s+where\\s+channel_name\\s*=\\s*'group_replication_applier'",Pattern.CASE_INSENSITIVE);
 	private String name;
 	private int maxCon = SystemConfig.DEFAULT_POOL_SIZE;
 	private int minCon = 10;
@@ -57,6 +62,7 @@ public class DataHostConfig {
 	private String hearbeatSQL;
     private boolean isShowSlaveSql=false;
     private boolean isShowClusterSql=false;
+    private boolean isShowMySQLGroupReplicationSql=false;
 	private String connectionInitSql;
     private int slaveThreshold = -1;
 	private final int switchType;
@@ -191,6 +197,10 @@ public class DataHostConfig {
         {
         	isShowClusterSql=true;
         }
+		Matcher mysqlGroupReplicationMatcher = patternMySQLGroupReplication.matcher(heartbeatSQL);
+        if (mysqlGroupReplicationMatcher.find()) {
+        	isShowMySQLGroupReplicationSql = true;
+		}
 	}
 
 	public String getFilters() {
@@ -207,6 +217,10 @@ public class DataHostConfig {
 
 	public boolean isShowClusterSql() {
 		return this.isShowClusterSql;
+	}
+
+	public boolean isShowMySQLGroupReplicationSql() {
+		return this.isShowMySQLGroupReplicationSql;
 	}
 
 	public void setLogTime(long logTime) {

--- a/src/main/java/io/mycat/config/model/DataHostConfig.java
+++ b/src/main/java/io/mycat/config/model/DataHostConfig.java
@@ -47,9 +47,9 @@ public class DataHostConfig {
     private static final Pattern pattern = Pattern.compile("\\s*show\\s+slave\\s+status\\s*",Pattern.CASE_INSENSITIVE);
     private static final Pattern patternCluster = Pattern.compile("\\s*show\\s+status\\s+like\\s+'wsrep%'",Pattern.CASE_INSENSITIVE);
 	/**
-	 * pattern for <pre>select * from performance_schema.replication_connection_status where CHANNEL_NAME='group_replication_applier'</pre>
+	 * pattern for <pre>select * from performance_schema.replication_connection_status</pre>
 	 */
-	private static final Pattern patternMySQLGroupReplication = Pattern.compile("\\s*select\\s+\\*\\s+from\\s+performance_schema.replication_connection_status\\s+where\\s+channel_name\\s*=\\s*'group_replication_applier'",Pattern.CASE_INSENSITIVE);
+	private static final Pattern patternMySQLGroupReplication = Pattern.compile("\\s*select\\s+\\*\\s+from\\s+performance_schema\\.replication_connection_status", Pattern.CASE_INSENSITIVE);
 	private String name;
 	private int maxCon = SystemConfig.DEFAULT_POOL_SIZE;
 	private int minCon = 10;

--- a/src/main/java/io/mycat/sqlengine/MultiRowSQLQueryResultHandler.java
+++ b/src/main/java/io/mycat/sqlengine/MultiRowSQLQueryResultHandler.java
@@ -1,5 +1,6 @@
 package io.mycat.sqlengine;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +30,11 @@ public class MultiRowSQLQueryResultHandler extends OneRawSQLQueryResultHandler{
 	public boolean onRowData(String dataNode, byte[] rowData) {
 		super.onRowData(dataNode, rowData);
 		resultRows.add(getResult());
-		
+		/*
+		* 重新创建一个result对象，否则得到的结果每一行的数据都一样<p>
+		* 如果不是每次进入该方法时重新创建一个Result。那么此处获取到的result始终是同一个map，最终resultRows的所有结果都是相同的键值对（OneRawSQLQueryResultHandler会重复替换该值），因此我们需要重新创建result
+		 */
+		result = new HashMap<String, String>();
 		return false;
 	}
 

--- a/src/main/java/io/mycat/sqlengine/OneRawSQLQueryResultHandler.java
+++ b/src/main/java/io/mycat/sqlengine/OneRawSQLQueryResultHandler.java
@@ -13,7 +13,7 @@ public class OneRawSQLQueryResultHandler implements SQLJobHandler {
 	private final SQLQueryResultListener<SQLQueryResult<Map<String, String>>> callback;
 	private final String[] fetchCols;
 	private int fieldCount = 0;
-	private Map<String, String> result = new HashMap<String, String>();
+	protected Map<String, String> result = new HashMap<String, String>();
 	public OneRawSQLQueryResultHandler(String[] fetchCols,
 			SQLQueryResultListener<SQLQueryResult<Map<String, String>>> callBack) {
 

--- a/src/main/java/io/mycat/sqlengine/SQLJob.java
+++ b/src/main/java/io/mycat/sqlengine/SQLJob.java
@@ -101,7 +101,7 @@ public class SQLJob implements ResponseHandler, Runnable {
 		return finished;
 	}
 
-	private void doFinished(boolean failed,String errorMsg) {
+	protected void doFinished(boolean failed, String errorMsg) {
 		finished = true;
 		jobHandler.finished(dataNodeOrDatabase, failed,errorMsg );
 		if (ctx != null) {

--- a/src/main/java/io/mycat/statistic/DataSourceSyncRecorder.java
+++ b/src/main/java/io/mycat/statistic/DataSourceSyncRecorder.java
@@ -83,8 +83,12 @@ public class                                                                    
             		this.asynRecords.add(new Record(TimeUtil.currentTimeMillis(),wsrep_local_recv_queue_avg));
             	}
                 if(switchType==DataHostConfig.MGR_STATUS_SWITCH_DS) {//mgr
-                	double countTransactionsRetries = Double.valueOf(resultResult.get("COUNT_TRANSACTIONS_RETRIES"));
-            		this.asynRecords.add(new Record(TimeUtil.currentTimeMillis(), countTransactionsRetries));
+					String countTransactionsRetries = resultResult.get("COUNT_TRANSACTIONS_RETRIES");
+					if(countTransactionsRetries == null){
+						return;
+					}
+					Double countTransactionsRetriesValue = Double.valueOf(countTransactionsRetries);
+            		this.asynRecords.add(new Record(TimeUtil.currentTimeMillis(), countTransactionsRetriesValue));
             	}
 
                 return;

--- a/src/main/java/io/mycat/statistic/DataSourceSyncRecorder.java
+++ b/src/main/java/io/mycat/statistic/DataSourceSyncRecorder.java
@@ -82,7 +82,11 @@ public class                                                                    
                 	double wsrep_local_recv_queue_avg = Double.valueOf(resultResult.get("wsrep_local_recv_queue_avg"));
             		this.asynRecords.add(new Record(TimeUtil.currentTimeMillis(),wsrep_local_recv_queue_avg));
             	}
-            	
+                if(switchType==DataHostConfig.MGR_STATUS_SWITCH_DS) {//mgr
+                	double countTransactionsRetries = Double.valueOf(resultResult.get("COUNT_TRANSACTIONS_RETRIES"));
+            		this.asynRecords.add(new Record(TimeUtil.currentTimeMillis(), countTransactionsRetries));
+            	}
+
                 return;
             }
     	}catch(Exception e){ 


### PR DESCRIPTION
# 何为MGR
见
- https://dev.mysql.com/doc/refman/5.7/en/group-replication.html
- https://www.zhihu.com/question/53617036
# 如何判断MGR节点是否可用
任意满足以下条件，则视为该节点不可用
1. 节点状态不为`ON`：`CHANNEL_NAME=group_replication_applier`且`SERVICE_STATE!=ON`
2. 节点恢复数据状态为`ON`：`CHANNEL_NAME=group_replication_recovery`且`SERVICE_STATE=ON`

见：https://dev.mysql.com/doc/refman/5.7/en/group-replication-monitoring.html
# 如何生效
修改schema配置
1. 设置`switchType=4`。见：[DataHostConfig.java#L46](https://github.com/blademainer/Mycat-Server/blob/6e7a4eb76244162ae29a35aba3fc34200b2f78ab/src/main/java/io/mycat/config/model/DataHostConfig.java#L46)
2. 设置`heartbeat`为：`select * from performance_schema.replication_connection_status` 。见：[DataHostConfig.java#L52](https://github.com/blademainer/Mycat-Server/blob/6e7a4eb76244162ae29a35aba3fc34200b2f78ab/src/main/java/io/mycat/config/model/DataHostConfig.java#L52)
# 改动
主要改动如下：
1. 增加了HeartbeatSQLJob类，该类继承`SQLJob`并重写了`okResponse`方法，原因是测试过程中发现：如果调用了`conn.release();`，那么`MySQLConnectionHandler#handleRowPacket`时会找不到`responseHandler`，最终导致`MySQLDetector#onResult`方法接收的数据为空。请大神确认**该改动是否会带来bug**。
2. fix了`MultiRowSQLQueryResultHandler`处理多行数据的bug，见：https://github.com/MyCATApache/Mycat-Server/compare/1.6...blademainer:feature/hearbeat-mgr?expand=1#diff-3bdb5255461870f5bf4ba0ea69846639R37
3. 修改了`MySQLDetector`：
  a. 处理心跳包时采用第1个改动的`HeartbeatSQLJob`
  b. 解析心跳数据时使用`MultiRowSQLQueryResultHandler`来处理每行结果
  c. 如果是单行数据，则使用原来的心跳检测逻辑
  d. 如果是多行数据，那么使用`onMultiplyRowResult `来处理MGR心跳