### PR TITLE
解决mycat-sql解析过程中子查询和条件组合运算采用笛卡尔积导致内存急剧上升mycat假死的问题

### DIFF
--- a/src/main/java/io/mycat/route/parser/druid/DruidParserFactory.java
+++ b/src/main/java/io/mycat/route/parser/druid/DruidParserFactory.java
@@ -83,7 +83,12 @@ public class DruidParserFactory
     {
         DruidParser parser=null;
         //先解出表，判断表所在db的类型，再根据不同db类型返回不同的解析
-        List<String> tables = parseTables(statement, visitor);
+        /**
+         * 不能直接使用visitor变量，防止污染后续sql解析
+         * @author SvenAugustus
+         */
+        SchemaStatVisitor _visitor = SchemaStatVisitorFactory.create(schema);
+        List<String> tables = parseTables(statement, _visitor);
         for (String table : tables)
         {
             Set<String> dbTypes =null;

--- a/src/main/java/io/mycat/route/parser/druid/MycatSchemaStatVisitor.java
+++ b/src/main/java/io/mycat/route/parser/druid/MycatSchemaStatVisitor.java
@@ -1,14 +1,5 @@
 package io.mycat.route.parser.druid;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.alibaba.druid.sql.ast.SQLCommentHint;
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLExprImpl;
@@ -28,7 +19,6 @@ import com.alibaba.druid.sql.ast.expr.SQLInSubQueryExpr;
 import com.alibaba.druid.sql.ast.expr.SQLPropertyExpr;
 import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
 import com.alibaba.druid.sql.ast.expr.SQLSomeExpr;
-import com.alibaba.druid.sql.ast.expr.SQLValuableExpr;
 import com.alibaba.druid.sql.ast.statement.SQLAlterTableItem;
 import com.alibaba.druid.sql.ast.statement.SQLAlterTableStatement;
 import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
@@ -39,7 +29,6 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
 import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
-import com.alibaba.druid.sql.ast.statement.SQLUnionQuery;
 import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlCreateTableStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlDeleteStatement;
@@ -52,9 +41,16 @@ import com.alibaba.druid.stat.TableStat;
 import com.alibaba.druid.stat.TableStat.Column;
 import com.alibaba.druid.stat.TableStat.Condition;
 import com.alibaba.druid.stat.TableStat.Mode;
-import com.alibaba.druid.stat.TableStat.Relationship;
-
 import io.mycat.route.util.RouterUtil;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Druid解析器中用来从ast语法中提取表名、条件、字段等的vistor
@@ -62,27 +58,27 @@ import io.mycat.route.util.RouterUtil;
  *
  */
 public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
-	private boolean hasOrCondition = false;
-	private List<WhereUnit> whereUnits = new CopyOnWriteArrayList<WhereUnit>();
-	private List<WhereUnit> storedwhereUnits = new CopyOnWriteArrayList<WhereUnit>();
-	private List<SQLSelect> subQuerys = new CopyOnWriteArrayList<>();  //子查询集合
-	private boolean hasChange = false; // 是否有改写sql
-	private boolean subqueryRelationOr = false;   //子查询存在关联条件的情况下，是否有 or 条件
-	
-	private void reset() {
-		this.conditions.clear();
-		this.whereUnits.clear();
-		this.hasOrCondition = false;
-	}
-	
-	public List<WhereUnit> getWhereUnits() {
-		return whereUnits;
-	}
+    private boolean hasOrCondition = false;
+    private List<WhereUnit> whereUnits = new CopyOnWriteArrayList<WhereUnit>();
+    private List<WhereUnit> storedwhereUnits = new CopyOnWriteArrayList<WhereUnit>();
+    private Queue<SQLSelect> subQuerys = new LinkedBlockingQueue<>();  //子查询集合
+    private boolean hasChange = false; // 是否有改写sql
+    private boolean subqueryRelationOr = false;   //子查询存在关联条件的情况下，是否有 or 条件
 
-	public boolean hasOrCondition() {
-		return hasOrCondition;
-	}
-	
+    private void reset() {
+        this.conditions.clear();
+        this.whereUnits.clear();
+        this.hasOrCondition = false;
+    }
+
+    public List<WhereUnit> getWhereUnits() {
+        return whereUnits;
+    }
+
+    public boolean hasOrCondition() {
+        return hasOrCondition;
+    }
+
     @Override
     public boolean visit(SQLSelectStatement x) {
         setAliasMap();
@@ -202,13 +198,13 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
                 if(betweenExpr.getTestExpr() instanceof SQLPropertyExpr) {//字段带别名的
                     tableName = ((SQLIdentifierExpr)((SQLPropertyExpr) betweenExpr.getTestExpr()).getOwner()).getName();
                     column = ((SQLPropertyExpr) betweenExpr.getTestExpr()).getName();
-					SQLObject query = this.subQueryMap.get(tableName);
-					if(query == null) {
-						if (aliasMap.containsKey(tableName)) {
-							tableName = aliasMap.get(tableName);
-						}
-						return new Column(tableName, column);
-					}
+                    SQLObject query = this.subQueryMap.get(tableName);
+                    if(query == null) {
+                        if (aliasMap.containsKey(tableName)) {
+                            tableName = aliasMap.get(tableName);
+                        }
+                        return new Column(tableName, column);
+                    }
                     return handleSubQueryColumn(tableName, column);
                 } else if(betweenExpr.getTestExpr() instanceof SQLIdentifierExpr) {
                     column = ((SQLIdentifierExpr) betweenExpr.getTestExpr()).getName();
@@ -284,20 +280,20 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
                 SQLDeleteStatement delete = (SQLDeleteStatement) parent;
                 return delete.getTableName().getSimpleName();
             } else {
-                
+
             }
         }
         return "";
     }
-    
+
     private void setSubQueryRelationOrFlag(SQLExprImpl x){
-    	MycatSubQueryVisitor subQueryVisitor = new MycatSubQueryVisitor();
-    	x.accept(subQueryVisitor);
-    	if(subQueryVisitor.isRelationOr()){
-    		subqueryRelationOr = true;
-    	}
+        MycatSubQueryVisitor subQueryVisitor = new MycatSubQueryVisitor();
+        x.accept(subQueryVisitor);
+        if(subQueryVisitor.isRelationOr()){
+            subqueryRelationOr = true;
+        }
     }
-    
+
     /*
      * 子查询
      * (non-Javadoc)
@@ -305,9 +301,9 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLQueryExpr x) {
-    	setSubQueryRelationOrFlag(x);
-    	addSubQuerys(x.getSubQuery());
-    	return super.visit(x);
+        setSubQueryRelationOrFlag(x);
+        addSubQuerys(x.getSubQuery());
+        return super.visit(x);
     }
     /*
      * (non-Javadoc)
@@ -315,26 +311,26 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLSubqueryTableSource x){
-    	addSubQuerys(x.getSelect());
-    	return super.visit(x);
+        addSubQuerys(x.getSelect());
+        return super.visit(x);
     }
-    
+
     /*
      * (non-Javadoc)
      * @see com.alibaba.druid.sql.visitor.SQLASTVisitorAdapter#visit(com.alibaba.druid.sql.ast.expr.SQLExistsExpr)
      */
     @Override
     public boolean visit(SQLExistsExpr x) {
-    	setSubQueryRelationOrFlag(x);
-    	addSubQuerys(x.getSubQuery());
-    	return super.visit(x);
+        setSubQueryRelationOrFlag(x);
+        addSubQuerys(x.getSubQuery());
+        return super.visit(x);
     }
-    
+
     @Override
     public boolean visit(SQLInListExpr x) {
-    	return super.visit(x);
+        return super.visit(x);
     }
-    
+
     /*
      *  对 in 子查询的处理
      * (non-Javadoc)
@@ -342,117 +338,117 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLInSubQueryExpr x) {
-    	setSubQueryRelationOrFlag(x);
-    	addSubQuerys(x.getSubQuery());
-    	return super.visit(x);
+        setSubQueryRelationOrFlag(x);
+        addSubQuerys(x.getSubQuery());
+        return super.visit(x);
     }
-    
-    /* 
+
+    /*
      *  遇到 all 将子查询改写成  SELECT MAX(name) FROM subtest1
      *  例如:
      *        select * from subtest where id > all (select name from subtest1);
-     *    		>/>= all ----> >/>= max
-     *    		</<= all ----> </<= min
-     *    		<>   all ----> not in
+     *          >/>= all ----> >/>= max
+     *          </<= all ----> </<= min
+     *          <>   all ----> not in
      *          =    all ----> id = 1 and id = 2
      *          other  不改写
-     */    
+     */
     @Override
     public boolean visit(SQLAllExpr x) {
-    	setSubQueryRelationOrFlag(x);
-    	
-    	List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
-    	SQLExpr sexpr = itemlist.get(0).getExpr();
-    	
-		if(x.getParent() instanceof SQLBinaryOpExpr){
-			SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
-			SQLAggregateExpr saexpr = null;
-			switch (parentExpr.getOperator()) {
-			case GreaterThan:
-			case GreaterThanOrEqual:
-			case NotLessThan:
-				this.hasChange = true;
-				if(sexpr instanceof SQLIdentifierExpr 
-						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-					saexpr = new SQLAggregateExpr("MAX");
-					saexpr.getArguments().add(sexpr);
-	        		saexpr.setParent(itemlist.get(0));
-	        		itemlist.get(0).setExpr(saexpr);
-				}
-				SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
-        		x.getSubQuery().setParent(x.getParent());
-        		// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-            	if(x.getParent() instanceof SQLBinaryOpExpr){
-            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
-            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
-            		}
-            	}
-            	addSubQuerys(x.getSubQuery());
-            	return super.visit(x.getSubQuery());
-			case LessThan:
-			case LessThanOrEqual:
-			case NotGreaterThan:
-				this.hasChange = true;
-				if(sexpr instanceof SQLIdentifierExpr 
-						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-					saexpr = new SQLAggregateExpr("MIN");
-					saexpr.getArguments().add(sexpr);
-	        		saexpr.setParent(itemlist.get(0));
-	        		itemlist.get(0).setExpr(saexpr);
-	        		
-	            	x.subQuery.setParent(x.getParent());
-				}
-				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-            	SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
-            	if(x.getParent() instanceof SQLBinaryOpExpr){
-            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
-            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
-            		}
-            	}
-            	addSubQuerys(x.getSubQuery());
-            	return super.visit(x.getSubQuery());
-			 case LessThanOrGreater:
-			 case NotEqual:
-				this.hasChange = true;
-				SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
-				x.getSubQuery().setParent(notInSubQueryExpr);
-				notInSubQueryExpr.setNot(true);
-				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-				if(x.getParent() instanceof SQLBinaryOpExpr){
-					SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
-					
-					if(xp.getLeft().equals(x)){
-						notInSubQueryExpr.setExpr(xp.getRight());
-					}else if(xp.getRight().equals(x)){
-						notInSubQueryExpr.setExpr(xp.getLeft());
-					}
-					
-					if(xp.getParent() instanceof MySqlSelectQueryBlock){
-						((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
-					}else if(xp.getParent() instanceof SQLBinaryOpExpr){
-						SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
-						if(pp.getLeft().equals(xp)){
-							pp.setLeft(notInSubQueryExpr);
-						}else if(pp.getRight().equals(xp)){
-							pp.setRight(notInSubQueryExpr);
-						}
-					}
-	            }
-				addSubQuerys(x.getSubQuery());
-	            return super.visit(notInSubQueryExpr);
-			 default:
-				break;
-			}
-		}
-		addSubQuerys(x.getSubQuery());
-    	return super.visit(x);
+        setSubQueryRelationOrFlag(x);
+
+        List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
+        SQLExpr sexpr = itemlist.get(0).getExpr();
+
+        if(x.getParent() instanceof SQLBinaryOpExpr){
+            SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
+            SQLAggregateExpr saexpr = null;
+            switch (parentExpr.getOperator()) {
+            case GreaterThan:
+            case GreaterThanOrEqual:
+            case NotLessThan:
+                this.hasChange = true;
+                if(sexpr instanceof SQLIdentifierExpr
+                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+                    saexpr = new SQLAggregateExpr("MAX");
+                    saexpr.getArguments().add(sexpr);
+                    saexpr.setParent(itemlist.get(0));
+                    itemlist.get(0).setExpr(saexpr);
+                }
+                SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
+                x.getSubQuery().setParent(x.getParent());
+                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                if(x.getParent() instanceof SQLBinaryOpExpr){
+                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
+                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
+                    }
+                }
+                addSubQuerys(x.getSubQuery());
+                return super.visit(x.getSubQuery());
+            case LessThan:
+            case LessThanOrEqual:
+            case NotGreaterThan:
+                this.hasChange = true;
+                if(sexpr instanceof SQLIdentifierExpr
+                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+                    saexpr = new SQLAggregateExpr("MIN");
+                    saexpr.getArguments().add(sexpr);
+                    saexpr.setParent(itemlist.get(0));
+                    itemlist.get(0).setExpr(saexpr);
+
+                    x.subQuery.setParent(x.getParent());
+                }
+                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
+                if(x.getParent() instanceof SQLBinaryOpExpr){
+                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
+                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
+                    }
+                }
+                addSubQuerys(x.getSubQuery());
+                return super.visit(x.getSubQuery());
+             case LessThanOrGreater:
+             case NotEqual:
+                this.hasChange = true;
+                SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
+                x.getSubQuery().setParent(notInSubQueryExpr);
+                notInSubQueryExpr.setNot(true);
+                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                if(x.getParent() instanceof SQLBinaryOpExpr){
+                    SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
+
+                    if(xp.getLeft().equals(x)){
+                        notInSubQueryExpr.setExpr(xp.getRight());
+                    }else if(xp.getRight().equals(x)){
+                        notInSubQueryExpr.setExpr(xp.getLeft());
+                    }
+
+                    if(xp.getParent() instanceof MySqlSelectQueryBlock){
+                        ((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
+                    }else if(xp.getParent() instanceof SQLBinaryOpExpr){
+                        SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
+                        if(pp.getLeft().equals(xp)){
+                            pp.setLeft(notInSubQueryExpr);
+                        }else if(pp.getRight().equals(xp)){
+                            pp.setRight(notInSubQueryExpr);
+                        }
+                    }
+                }
+                addSubQuerys(x.getSubQuery());
+                return super.visit(notInSubQueryExpr);
+             default:
+                break;
+            }
+        }
+        addSubQuerys(x.getSubQuery());
+        return super.visit(x);
     }
-    
-    /* 
+
+    /*
      *  遇到 some 将子查询改写成  SELECT MIN(name) FROM subtest1
      *  例如:
      *        select * from subtest where id > some (select name from subtest1);
@@ -464,129 +460,129 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLSomeExpr x) {
-    	
-    	setSubQueryRelationOrFlag(x);
-    	
-    	List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
-    	SQLExpr sexpr = itemlist.get(0).getExpr();
-    	
-		if(x.getParent() instanceof SQLBinaryOpExpr){
-			SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
-			SQLAggregateExpr saexpr = null;
-			switch (parentExpr.getOperator()) {
-			case GreaterThan:
-			case GreaterThanOrEqual:
-			case NotLessThan:
-				this.hasChange = true;
-				if(sexpr instanceof SQLIdentifierExpr 
-						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-					saexpr = new SQLAggregateExpr("MIN");
-					saexpr.getArguments().add(sexpr);
-	        		saexpr.setParent(itemlist.get(0));
-	        		itemlist.get(0).setExpr(saexpr);
-				}
-				SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
-        		x.getSubQuery().setParent(maxSubQuery);
-        		// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-            	if(x.getParent() instanceof SQLBinaryOpExpr){
-            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
-            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
-            		}
-            	}
-            	addSubQuerys(x.getSubQuery());
-            	return super.visit(x.getSubQuery());
-			case LessThan:
-			case LessThanOrEqual:
-			case NotGreaterThan:
-				this.hasChange = true;
-				if(sexpr instanceof SQLIdentifierExpr 
-						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-					saexpr = new SQLAggregateExpr("MAX");
-					saexpr.getArguments().add(sexpr);
-	        		saexpr.setParent(itemlist.get(0));
-	        		itemlist.get(0).setExpr(saexpr);
-				}
-				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-            	SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
-        		x.getSubQuery().setParent(minSubQuery);
-            	
-            	if(x.getParent() instanceof SQLBinaryOpExpr){
-            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
-            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
-            		}
-            	}
-            	addSubQuerys(x.getSubQuery());
-            	return super.visit(x.getSubQuery());
-			 case LessThanOrGreater:
-			 case NotEqual:
-				 this.hasChange = true;
-					SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
-					x.getSubQuery().setParent(notInSubQueryExpr);
-					notInSubQueryExpr.setNot(true);
-					// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-					if(x.getParent() instanceof SQLBinaryOpExpr){
-						SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
-						
-						if(xp.getLeft().equals(x)){
-							notInSubQueryExpr.setExpr(xp.getRight());
-						}else if(xp.getRight().equals(x)){
-							notInSubQueryExpr.setExpr(xp.getLeft());
-						}
-						
-						if(xp.getParent() instanceof MySqlSelectQueryBlock){
-							((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
-						}else if(xp.getParent() instanceof SQLBinaryOpExpr){
-							SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
-							if(pp.getLeft().equals(xp)){
-								pp.setLeft(notInSubQueryExpr);
-							}else if(pp.getRight().equals(xp)){
-								pp.setRight(notInSubQueryExpr);
-							}
-						}
-		            }
-					addSubQuerys(x.getSubQuery());
-		            return super.visit(notInSubQueryExpr);
-			 case Equality:
-				 this.hasChange = true;
-				SQLInSubQueryExpr inSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
-				x.getSubQuery().setParent(inSubQueryExpr);
-				inSubQueryExpr.setNot(false);
-				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-				if(x.getParent() instanceof SQLBinaryOpExpr){
-					SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
-					
-					if(xp.getLeft().equals(x)){
-						inSubQueryExpr.setExpr(xp.getRight());
-					}else if(xp.getRight().equals(x)){
-						inSubQueryExpr.setExpr(xp.getLeft());
-					}
-					
-					if(xp.getParent() instanceof MySqlSelectQueryBlock){
-						((MySqlSelectQueryBlock)xp.getParent()).setWhere(inSubQueryExpr);
-					}else if(xp.getParent() instanceof SQLBinaryOpExpr){
-						SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
-						if(pp.getLeft().equals(xp)){
-							pp.setLeft(inSubQueryExpr);
-						}else if(pp.getRight().equals(xp)){
-							pp.setRight(inSubQueryExpr);
-						}
-					}
-	            }
-				addSubQuerys(x.getSubQuery());
-	            return super.visit(inSubQueryExpr);
-			 default:
-				break;
-			}
-		}
-		addSubQuerys(x.getSubQuery());
-    	return super.visit(x);
+
+        setSubQueryRelationOrFlag(x);
+
+        List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
+        SQLExpr sexpr = itemlist.get(0).getExpr();
+
+        if(x.getParent() instanceof SQLBinaryOpExpr){
+            SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
+            SQLAggregateExpr saexpr = null;
+            switch (parentExpr.getOperator()) {
+            case GreaterThan:
+            case GreaterThanOrEqual:
+            case NotLessThan:
+                this.hasChange = true;
+                if(sexpr instanceof SQLIdentifierExpr
+                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+                    saexpr = new SQLAggregateExpr("MIN");
+                    saexpr.getArguments().add(sexpr);
+                    saexpr.setParent(itemlist.get(0));
+                    itemlist.get(0).setExpr(saexpr);
+                }
+                SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
+                x.getSubQuery().setParent(maxSubQuery);
+                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                if(x.getParent() instanceof SQLBinaryOpExpr){
+                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
+                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
+                    }
+                }
+                addSubQuerys(x.getSubQuery());
+                return super.visit(x.getSubQuery());
+            case LessThan:
+            case LessThanOrEqual:
+            case NotGreaterThan:
+                this.hasChange = true;
+                if(sexpr instanceof SQLIdentifierExpr
+                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+                    saexpr = new SQLAggregateExpr("MAX");
+                    saexpr.getArguments().add(sexpr);
+                    saexpr.setParent(itemlist.get(0));
+                    itemlist.get(0).setExpr(saexpr);
+                }
+                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
+                x.getSubQuery().setParent(minSubQuery);
+
+                if(x.getParent() instanceof SQLBinaryOpExpr){
+                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
+                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
+                    }
+                }
+                addSubQuerys(x.getSubQuery());
+                return super.visit(x.getSubQuery());
+             case LessThanOrGreater:
+             case NotEqual:
+                 this.hasChange = true;
+                    SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
+                    x.getSubQuery().setParent(notInSubQueryExpr);
+                    notInSubQueryExpr.setNot(true);
+                    // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                    if(x.getParent() instanceof SQLBinaryOpExpr){
+                        SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
+
+                        if(xp.getLeft().equals(x)){
+                            notInSubQueryExpr.setExpr(xp.getRight());
+                        }else if(xp.getRight().equals(x)){
+                            notInSubQueryExpr.setExpr(xp.getLeft());
+                        }
+
+                        if(xp.getParent() instanceof MySqlSelectQueryBlock){
+                            ((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
+                        }else if(xp.getParent() instanceof SQLBinaryOpExpr){
+                            SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
+                            if(pp.getLeft().equals(xp)){
+                                pp.setLeft(notInSubQueryExpr);
+                            }else if(pp.getRight().equals(xp)){
+                                pp.setRight(notInSubQueryExpr);
+                            }
+                        }
+                    }
+                    addSubQuerys(x.getSubQuery());
+                    return super.visit(notInSubQueryExpr);
+             case Equality:
+                 this.hasChange = true;
+                SQLInSubQueryExpr inSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
+                x.getSubQuery().setParent(inSubQueryExpr);
+                inSubQueryExpr.setNot(false);
+                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                if(x.getParent() instanceof SQLBinaryOpExpr){
+                    SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
+
+                    if(xp.getLeft().equals(x)){
+                        inSubQueryExpr.setExpr(xp.getRight());
+                    }else if(xp.getRight().equals(x)){
+                        inSubQueryExpr.setExpr(xp.getLeft());
+                    }
+
+                    if(xp.getParent() instanceof MySqlSelectQueryBlock){
+                        ((MySqlSelectQueryBlock)xp.getParent()).setWhere(inSubQueryExpr);
+                    }else if(xp.getParent() instanceof SQLBinaryOpExpr){
+                        SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
+                        if(pp.getLeft().equals(xp)){
+                            pp.setLeft(inSubQueryExpr);
+                        }else if(pp.getRight().equals(xp)){
+                            pp.setRight(inSubQueryExpr);
+                        }
+                    }
+                }
+                addSubQuerys(x.getSubQuery());
+                return super.visit(inSubQueryExpr);
+             default:
+                break;
+            }
+        }
+        addSubQuerys(x.getSubQuery());
+        return super.visit(x);
     }
 
-    /* 
+    /*
      *  遇到 any 将子查询改写成  SELECT MIN(name) FROM subtest1
      *  例如:
      *    select * from subtest where id oper any (select name from subtest1);
@@ -598,132 +594,132 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLAnyExpr x) {
-    	
-    	setSubQueryRelationOrFlag(x);
-    	
-    	List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
-    	SQLExpr sexpr = itemlist.get(0).getExpr();
-    	
-		if(x.getParent() instanceof SQLBinaryOpExpr){
-			SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
-			SQLAggregateExpr saexpr = null;
-			switch (parentExpr.getOperator()) {
-			case GreaterThan:
-			case GreaterThanOrEqual:
-			case NotLessThan:
-				this.hasChange = true;
-				if(sexpr instanceof SQLIdentifierExpr 
-						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-					saexpr = new SQLAggregateExpr("MIN");
-					saexpr.getArguments().add(sexpr);
-	        		saexpr.setParent(itemlist.get(0));
-	        		itemlist.get(0).setExpr(saexpr);
-				}
-				SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
-        		x.getSubQuery().setParent(maxSubQuery);
-				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-            	if(x.getParent() instanceof SQLBinaryOpExpr){
-            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
-            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
-            		}
-            	}
-            	addSubQuerys(x.getSubQuery());
-            	return super.visit(x.getSubQuery());
-			case LessThan:
-			case LessThanOrEqual:
-			case NotGreaterThan:
-				this.hasChange = true;
-				if(sexpr instanceof SQLIdentifierExpr 
-						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-					saexpr = new SQLAggregateExpr("MAX");
-					saexpr.getArguments().add(sexpr);
-	        		saexpr.setParent(itemlist.get(0));
-	        		itemlist.get(0).setExpr(saexpr);
-				}
-				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-            	SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
-            	x.subQuery.setParent(minSubQuery);
-            	if(x.getParent() instanceof SQLBinaryOpExpr){
-            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
-            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-            			((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
-            		}
-            	}
-            	addSubQuerys(x.getSubQuery());
-            	return super.visit(x.getSubQuery());
-			 case LessThanOrGreater:
-			 case NotEqual:
-				 this.hasChange = true;
-					SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
-					x.getSubQuery().setParent(notInSubQueryExpr);
-					notInSubQueryExpr.setNot(true);
-					// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-					if(x.getParent() instanceof SQLBinaryOpExpr){
-						SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
-						
-						if(xp.getLeft().equals(x)){
-							notInSubQueryExpr.setExpr(xp.getRight());
-						}else if(xp.getRight().equals(x)){
-							notInSubQueryExpr.setExpr(xp.getLeft());
-						}
-						
-						if(xp.getParent() instanceof MySqlSelectQueryBlock){
-							((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
-						}else if(xp.getParent() instanceof SQLBinaryOpExpr){
-							SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
-							if(pp.getLeft().equals(xp)){
-								pp.setLeft(notInSubQueryExpr);
-							}else if(pp.getRight().equals(xp)){
-								pp.setRight(notInSubQueryExpr);
-							}
-						}
-		            }
-					addSubQuerys(x.getSubQuery());
-		            return super.visit(notInSubQueryExpr);
-			 case Equality:
-				 this.hasChange = true;
-				SQLInSubQueryExpr inSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
-				x.getSubQuery().setParent(inSubQueryExpr);
-				inSubQueryExpr.setNot(false);
-				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-				if(x.getParent() instanceof SQLBinaryOpExpr){
-					SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
-					
-					if(xp.getLeft().equals(x)){
-						inSubQueryExpr.setExpr(xp.getRight());
-					}else if(xp.getRight().equals(x)){
-						inSubQueryExpr.setExpr(xp.getLeft());
-					}
-					
-					if(xp.getParent() instanceof MySqlSelectQueryBlock){
-						((MySqlSelectQueryBlock)xp.getParent()).setWhere(inSubQueryExpr);
-					}else if(xp.getParent() instanceof SQLBinaryOpExpr){
-						SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
-						if(pp.getLeft().equals(xp)){
-							pp.setLeft(inSubQueryExpr);
-						}else if(pp.getRight().equals(xp)){
-							pp.setRight(inSubQueryExpr);
-						}
-					}
-	            }
-				addSubQuerys(x.getSubQuery());
-	            return super.visit(inSubQueryExpr);
-			 default:
-				break;
-			}
-		}
-		addSubQuerys(x.getSubQuery());
-    	return super.visit(x);
+
+        setSubQueryRelationOrFlag(x);
+
+        List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
+        SQLExpr sexpr = itemlist.get(0).getExpr();
+
+        if(x.getParent() instanceof SQLBinaryOpExpr){
+            SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
+            SQLAggregateExpr saexpr = null;
+            switch (parentExpr.getOperator()) {
+            case GreaterThan:
+            case GreaterThanOrEqual:
+            case NotLessThan:
+                this.hasChange = true;
+                if(sexpr instanceof SQLIdentifierExpr
+                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+                    saexpr = new SQLAggregateExpr("MIN");
+                    saexpr.getArguments().add(sexpr);
+                    saexpr.setParent(itemlist.get(0));
+                    itemlist.get(0).setExpr(saexpr);
+                }
+                SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
+                x.getSubQuery().setParent(maxSubQuery);
+                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                if(x.getParent() instanceof SQLBinaryOpExpr){
+                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
+                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
+                    }
+                }
+                addSubQuerys(x.getSubQuery());
+                return super.visit(x.getSubQuery());
+            case LessThan:
+            case LessThanOrEqual:
+            case NotGreaterThan:
+                this.hasChange = true;
+                if(sexpr instanceof SQLIdentifierExpr
+                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+                    saexpr = new SQLAggregateExpr("MAX");
+                    saexpr.getArguments().add(sexpr);
+                    saexpr.setParent(itemlist.get(0));
+                    itemlist.get(0).setExpr(saexpr);
+                }
+                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
+                x.subQuery.setParent(minSubQuery);
+                if(x.getParent() instanceof SQLBinaryOpExpr){
+                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
+                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+                        ((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
+                    }
+                }
+                addSubQuerys(x.getSubQuery());
+                return super.visit(x.getSubQuery());
+             case LessThanOrGreater:
+             case NotEqual:
+                 this.hasChange = true;
+                    SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
+                    x.getSubQuery().setParent(notInSubQueryExpr);
+                    notInSubQueryExpr.setNot(true);
+                    // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                    if(x.getParent() instanceof SQLBinaryOpExpr){
+                        SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
+
+                        if(xp.getLeft().equals(x)){
+                            notInSubQueryExpr.setExpr(xp.getRight());
+                        }else if(xp.getRight().equals(x)){
+                            notInSubQueryExpr.setExpr(xp.getLeft());
+                        }
+
+                        if(xp.getParent() instanceof MySqlSelectQueryBlock){
+                            ((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
+                        }else if(xp.getParent() instanceof SQLBinaryOpExpr){
+                            SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
+                            if(pp.getLeft().equals(xp)){
+                                pp.setLeft(notInSubQueryExpr);
+                            }else if(pp.getRight().equals(xp)){
+                                pp.setRight(notInSubQueryExpr);
+                            }
+                        }
+                    }
+                    addSubQuerys(x.getSubQuery());
+                    return super.visit(notInSubQueryExpr);
+             case Equality:
+                 this.hasChange = true;
+                SQLInSubQueryExpr inSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
+                x.getSubQuery().setParent(inSubQueryExpr);
+                inSubQueryExpr.setNot(false);
+                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+                if(x.getParent() instanceof SQLBinaryOpExpr){
+                    SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
+
+                    if(xp.getLeft().equals(x)){
+                        inSubQueryExpr.setExpr(xp.getRight());
+                    }else if(xp.getRight().equals(x)){
+                        inSubQueryExpr.setExpr(xp.getLeft());
+                    }
+
+                    if(xp.getParent() instanceof MySqlSelectQueryBlock){
+                        ((MySqlSelectQueryBlock)xp.getParent()).setWhere(inSubQueryExpr);
+                    }else if(xp.getParent() instanceof SQLBinaryOpExpr){
+                        SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
+                        if(pp.getLeft().equals(xp)){
+                            pp.setLeft(inSubQueryExpr);
+                        }else if(pp.getRight().equals(xp)){
+                            pp.setRight(inSubQueryExpr);
+                        }
+                    }
+                }
+                addSubQuerys(x.getSubQuery());
+                return super.visit(inSubQueryExpr);
+             default:
+                break;
+            }
+        }
+        addSubQuerys(x.getSubQuery());
+        return super.visit(x);
     }
-    
+
     @Override
-	public boolean visit(SQLBinaryOpExpr x) {
+    public boolean visit(SQLBinaryOpExpr x) {
         x.getLeft().setParent(x);
         x.getRight().setParent(x);
-        
+
         /*
          * fix bug 当 selectlist 存在多个子查询时, 主表没有别名的情况下.主表的查询条件 被错误的附加到子查询上.
          *  eg. select (select id from subtest2 where id = 1), (select id from subtest3 where id = 2) from subtest1 where id =4;
@@ -732,9 +728,9 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
          */
         String currenttable = x.getParent()==null?null: (String) x.getParent().getAttribute(SchemaStatVisitor.ATTR_TABLE);
         if(currenttable!=null){
-        	this.setCurrentTable(currenttable);
+            this.setCurrentTable(currenttable);
         }
-        
+
         switch (x.getOperator()) {
             case Equality:
             case LessThanOrEqualOrGreaterThan:
@@ -746,31 +742,31 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
             case LessThanOrEqual:
             case NotLessThan:
             case LessThanOrGreater:
-			case NotEqual:
-			case NotGreaterThan:
+            case NotEqual:
+            case NotGreaterThan:
                 handleCondition(x.getLeft(), x.getOperator().name, x.getRight());
                 handleCondition(x.getRight(), x.getOperator().name, x.getLeft());
                 handleRelationship(x.getLeft(), x.getOperator().name, x.getRight());
                 break;
             case BooleanOr:
-            	//永真条件，where条件抛弃
-            	if(!RouterUtil.isConditionAlwaysTrue(x)) {
-            		hasOrCondition = true;
-            		
-            		WhereUnit whereUnit = null;
-            		if(conditions.size() > 0) {
-            			whereUnit = new WhereUnit();
-            			whereUnit.setFinishedParse(true);
-            			whereUnit.addOutConditions(getConditions());
-            			WhereUnit innerWhereUnit = new WhereUnit(x);
-            			whereUnit.addSubWhereUnit(innerWhereUnit);
-            		} else {
-            			whereUnit = new WhereUnit(x);
-            			whereUnit.addOutConditions(getConditions());
-            		}
-            		whereUnits.add(whereUnit);
-            	}
-            	return false;
+                //永真条件，where条件抛弃
+                if(!RouterUtil.isConditionAlwaysTrue(x)) {
+                    hasOrCondition = true;
+
+                    WhereUnit whereUnit = null;
+                    if(conditions.size() > 0) {
+                        whereUnit = new WhereUnit();
+                        whereUnit.setFinishedParse(true);
+                        whereUnit.addOutConditions(getConditions());
+                        WhereUnit innerWhereUnit = new WhereUnit(x);
+                        whereUnit.addSubWhereUnit(innerWhereUnit);
+                    } else {
+                        whereUnit = new WhereUnit(x);
+                        whereUnit.addOutConditions(getConditions());
+                    }
+                    whereUnits.add(whereUnit);
+                }
+                return false;
             case Like:
             case NotLike:
             default:
@@ -778,211 +774,255 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
         }
         return true;
     }
-	
-	/**
-	 * 分解条件
-	 */
-	public List<List<Condition>> splitConditions() {
-		//按照or拆分
-		for(WhereUnit whereUnit : whereUnits) {
-			splitUntilNoOr(whereUnit);
-		}
-		
-		this.storedwhereUnits.addAll(whereUnits);
-		
-		loopFindSubWhereUnit(whereUnits);
-		
-		//拆分后的条件块解析成Condition列表
-		for(WhereUnit whereUnit : storedwhereUnits) {
-			this.getConditionsFromWhereUnit(whereUnit);
-		}
-		
-		//多个WhereUnit组合:多层集合的组合
-		return mergedConditions();
-	}
-	
-	/**
-	 * 循环寻找子WhereUnit（实际是嵌套的or）
-	 * @param whereUnitList
-	 */
-	private void loopFindSubWhereUnit(List<WhereUnit> whereUnitList) {
-		List<WhereUnit> subWhereUnits = new ArrayList<WhereUnit>();
-		for(WhereUnit whereUnit : whereUnitList) {
-			if(whereUnit.getSplitedExprList().size() > 0) {
-				List<SQLExpr> removeSplitedList = new ArrayList<SQLExpr>();
-				for(SQLExpr sqlExpr : whereUnit.getSplitedExprList()) {
-					reset();
-					if(isExprHasOr(sqlExpr)) {
-						removeSplitedList.add(sqlExpr);
-						WhereUnit subWhereUnit = this.whereUnits.get(0);
-						splitUntilNoOr(subWhereUnit);
-						whereUnit.addSubWhereUnit(subWhereUnit);
-						subWhereUnits.add(subWhereUnit);
-					} else {
-						this.conditions.clear();
-					}
-				}
-				if(removeSplitedList.size() > 0) {
-					whereUnit.getSplitedExprList().removeAll(removeSplitedList);
-				}
-			}
-			subWhereUnits.addAll(whereUnit.getSubWhereUnit());
-		}
-		if(subWhereUnits.size() > 0) {
-			loopFindSubWhereUnit(subWhereUnits);
-		}
-	}
-	
-	private boolean isExprHasOr(SQLExpr expr) {
-		expr.accept(this);
-		return hasOrCondition;
-	}
-	
-	private List<List<Condition>> mergedConditions() {
-		if(storedwhereUnits.size() == 0) {
-			return new ArrayList<List<Condition>>();
-		}
-		for(WhereUnit whereUnit : storedwhereUnits) {
-			mergeOneWhereUnit(whereUnit);
-		}
-		return getMergedConditionList(storedwhereUnits);
-		
-	}
-	
-	/**
-	 * 一个WhereUnit内递归
-	 * @param whereUnit
-	 */
-	private void mergeOneWhereUnit(WhereUnit whereUnit) {
-		if(whereUnit.getSubWhereUnit().size() > 0) {
-			for(WhereUnit sub : whereUnit.getSubWhereUnit()) {
-				mergeOneWhereUnit(sub);
-			}
-			
-			if(whereUnit.getSubWhereUnit().size() > 1) {
-				List<List<Condition>> mergedConditionList = getMergedConditionList(whereUnit.getSubWhereUnit());
-				if(whereUnit.getOutConditions().size() > 0) {
-					for(int i = 0; i < mergedConditionList.size() ; i++) {
-						mergedConditionList.get(i).addAll(whereUnit.getOutConditions());
-					}
-				}
-				whereUnit.setConditionList(mergedConditionList);
-			} else if(whereUnit.getSubWhereUnit().size() == 1) {
-				if(whereUnit.getOutConditions().size() > 0 && whereUnit.getSubWhereUnit().get(0).getConditionList().size() > 0) {
-					for(int i = 0; i < whereUnit.getSubWhereUnit().get(0).getConditionList().size() ; i++) {
-						whereUnit.getSubWhereUnit().get(0).getConditionList().get(i).addAll(whereUnit.getOutConditions());
-					}
-				}
-				whereUnit.getConditionList().addAll(whereUnit.getSubWhereUnit().get(0).getConditionList());
-			}
-		} else {
-			//do nothing
-		}
-	}
-	
-	/**
-	 * 条件合并：多个WhereUnit中的条件组合
-	 * @return
-	 */
-	private List<List<Condition>> getMergedConditionList(List<WhereUnit> whereUnitList) {
-		List<List<Condition>> mergedConditionList = new ArrayList<List<Condition>>();
-		if(whereUnitList.size() == 0) {
-			return mergedConditionList; 
-		}
-		mergedConditionList.addAll(whereUnitList.get(0).getConditionList());
-		
-		for(int i = 1; i < whereUnitList.size(); i++) {
-			mergedConditionList = merge(mergedConditionList, whereUnitList.get(i).getConditionList());
-		}
-		return mergedConditionList;
-	}
-	
-	/**
-	 * 两个list中的条件组合
-	 * @param list1
-	 * @param list2
-	 * @return
-	 */
-	private List<List<Condition>> merge(List<List<Condition>> list1, List<List<Condition>> list2) {
-		if(list1.size() == 0) {
-			return list2;
-		} else if (list2.size() == 0) {
-			return list1;
-		}
-		
+
+    /**
+     * 分解条件
+     */
+    public List<List<Condition>> splitConditions() {
+        //按照or拆分
+        for(WhereUnit whereUnit : whereUnits) {
+            splitUntilNoOr(whereUnit);
+        }
+
+        this.storedwhereUnits.addAll(whereUnits);
+
+        loopFindSubWhereUnit(whereUnits);
+
+        //拆分后的条件块解析成Condition列表
+        for(WhereUnit whereUnit : storedwhereUnits) {
+            this.getConditionsFromWhereUnit(whereUnit);
+        }
+
+        //多个WhereUnit组合:多层集合的组合
+        return mergedConditions();
+    }
+
+    /**
+     * 循环寻找子WhereUnit（实际是嵌套的or）
+     * @param whereUnitList
+     */
+    private void loopFindSubWhereUnit(List<WhereUnit> whereUnitList) {
+        List<WhereUnit> subWhereUnits = new ArrayList<WhereUnit>();
+        for(WhereUnit whereUnit : whereUnitList) {
+            if(whereUnit.getSplitedExprList().size() > 0) {
+                List<SQLExpr> removeSplitedList = new ArrayList<SQLExpr>();
+                for(SQLExpr sqlExpr : whereUnit.getSplitedExprList()) {
+                    reset();
+                    if(isExprHasOr(sqlExpr)) {
+                        removeSplitedList.add(sqlExpr);
+                        WhereUnit subWhereUnit = this.whereUnits.get(0);
+                        splitUntilNoOr(subWhereUnit);
+                        whereUnit.addSubWhereUnit(subWhereUnit);
+                        subWhereUnits.add(subWhereUnit);
+                    } else {
+                        this.conditions.clear();
+                    }
+                }
+                if(removeSplitedList.size() > 0) {
+                    whereUnit.getSplitedExprList().removeAll(removeSplitedList);
+                }
+            }
+            subWhereUnits.addAll(whereUnit.getSubWhereUnit());
+        }
+        if(subWhereUnits.size() > 0) {
+            loopFindSubWhereUnit(subWhereUnits);
+        }
+    }
+
+    private boolean isExprHasOr(SQLExpr expr) {
+        expr.accept(this);
+        return hasOrCondition;
+    }
+
+    private List<List<Condition>> mergedConditions() {
+        if(storedwhereUnits.size() == 0) {
+            return new ArrayList<List<Condition>>();
+        }
+        for(WhereUnit whereUnit : storedwhereUnits) {
+            mergeOneWhereUnit(whereUnit);
+        }
+        return getMergedConditionList(storedwhereUnits);
+    }
+
+    /**
+     * 一个WhereUnit内递归
+     * @param whereUnit
+     */
+    private void mergeOneWhereUnit(WhereUnit whereUnit) {
+        if(whereUnit.getSubWhereUnit().size() > 0) {
+            for(WhereUnit sub : whereUnit.getSubWhereUnit()) {
+                mergeOneWhereUnit(sub);
+            }
+
+            if(whereUnit.getSubWhereUnit().size() > 1) {
+                List<List<Condition>> mergedConditionList = getMergedConditionList(whereUnit.getSubWhereUnit());
+                if(whereUnit.getOutConditions().size() > 0) {
+                    for(int i = 0; i < mergedConditionList.size() ; i++) {
+                        mergedConditionList.get(i).addAll(whereUnit.getOutConditions());
+                    }
+                }
+                whereUnit.setConditionList(mergedConditionList);
+            } else if(whereUnit.getSubWhereUnit().size() == 1) {
+                if(whereUnit.getOutConditions().size() > 0 && whereUnit.getSubWhereUnit().get(0).getConditionList().size() > 0) {
+                    for(int i = 0; i < whereUnit.getSubWhereUnit().get(0).getConditionList().size() ; i++) {
+                        whereUnit.getSubWhereUnit().get(0).getConditionList().get(i).addAll(whereUnit.getOutConditions());
+                    }
+                }
+                whereUnit.getConditionList().addAll(whereUnit.getSubWhereUnit().get(0).getConditionList());
+            }
+        } else {
+            //do nothing
+        }
+    }
+
+    /**
+     * 条件合并：多个WhereUnit中的条件组合
+     * @return
+     */
+    private List<List<Condition>> getMergedConditionList(List<WhereUnit> whereUnitList) {
+        List<List<Condition>> mergedConditionList = new ArrayList<List<Condition>>();
+        if(whereUnitList.size() == 0) {
+            return mergedConditionList;
+        }
+        mergedConditionList.addAll(whereUnitList.get(0).getConditionList());
+
+        for(int i = 1; i < whereUnitList.size(); i++) {
+            mergedConditionList = merge(mergedConditionList, whereUnitList.get(i).getConditionList());
+        }
+        return mergedConditionList;
+    }
+
+    /**
+     * 两个list中的条件组合
+     * @param list1
+     * @param list2
+     * @return
+     */
+    private List<List<Condition>> merge(List<List<Condition>> list1, List<List<Condition>> list2) {
+        if(list1.size() == 0) {
+            return list2;
+        } else if (list2.size() == 0) {
+            return list1;
+        }
+
 		List<List<Condition>> retList = new ArrayList<List<Condition>>();
 		for(int i = 0; i < list1.size(); i++) {
 			for(int j = 0; j < list2.size(); j++) {
-				List<Condition> listTmp = new ArrayList<Condition>();
-				listTmp.addAll(list1.get(i));
-				listTmp.addAll(list2.get(j));
-				retList.add(listTmp);
+//				List<Condition> listTmp = new ArrayList<Condition>();
+//				listTmp.addAll(list1.get(i));
+//				listTmp.addAll(list2.get(j));
+//				retList.add(listTmp);
+			    /**
+		         * 单纯做笛卡尔积运算，会导致非常多不必要的条件列表，</br>
+		         * 当whereUnit和条件相对多时，会急剧增长条件列表项，内存直线上升，导致假死状态</br>
+		         * 因此，修改算法为 </br>
+		         * 1、先合并两个条件列表的元素为一个条件列表</br>
+		         * 2、计算合并后的条件列表，在结果retList中：</br>
+		         * &nbsp;2-1、如果当前的条件列表 是 另外一个条件列表的 超集，更新，并标识已存在</br>
+		         * &nbsp;2-2、如果当前的条件列表 是 另外一个条件列表的 子集，标识已存在</br>
+		         * 3、最后，如果被标识不存在，加入结果retList，否则丢弃。</br>
+		         *
+		         * @author SvenAugustus
+		         */
+  			    // 合并两个条件列表的元素为一个条件列表
+                List<Condition> listTmp = mergeSqlConditionList(list1.get(i), list2.get(j));
+
+                // 判定当前的条件列表 是否 另外一个条件列表的 子集
+                boolean exists = false;
+                Iterator<List<Condition>> it = retList.iterator();
+                while (it.hasNext()) {
+                  List<Condition> result = (List<Condition>) it.next();
+                  if (result != null && listTmp != null && listTmp.size() > result.size()) {
+                    // 如果当前的条件列表 是 另外一个条件列表的 超集，更新，并标识已存在
+                    if (sqlConditionListInOther(result, listTmp)) {
+                      result.clear();
+                      result.addAll(listTmp);
+                      exists = true;
+                      break;
+                    }
+                  } else {
+                    // 如果当前的条件列表 是 另外一个条件列表的 子集，标识已存在
+                    if (sqlConditionListInOther(listTmp, result)) {
+                      exists = true;
+                      break;
+                    }
+                  }
+                }
+                if (!exists) {// 被标识不存在，加入
+                  retList.add(listTmp);
+                } // 否则丢弃
 			}
 		}
-		return retList;
-	}
-	
-	private void getConditionsFromWhereUnit(WhereUnit whereUnit) {
-		List<List<Condition>> retList = new ArrayList<List<Condition>>();
-		//or语句外层的条件:如where condition1 and (condition2 or condition3),condition1就会在外层条件中,因为之前提取
-		List<Condition> outSideCondition = new ArrayList<Condition>();
-//		stashOutSideConditions();
-		outSideCondition.addAll(conditions);
-		this.conditions.clear();
-		for(SQLExpr sqlExpr : whereUnit.getSplitedExprList()) {
-			sqlExpr.accept(this);
-			List<Condition> conditions = new ArrayList<Condition>();
-			conditions.addAll(getConditions());
-			conditions.addAll(outSideCondition);
-			retList.add(conditions);
-			this.conditions.clear();
-		}
-		whereUnit.setConditionList(retList);
-		
-		for(WhereUnit subWhere : whereUnit.getSubWhereUnit()) {
-			getConditionsFromWhereUnit(subWhere);
-		}
-	}
-	
-	/**
-	 * 递归拆分OR
-	 * 
-	 * @param whereUnit
-	 * TODO:考虑嵌套or语句，条件中有子查询、 exists等很多种复杂情况是否能兼容
-	 */
-	private void splitUntilNoOr(WhereUnit whereUnit) {
-		if(whereUnit.isFinishedParse()) {
-			if(whereUnit.getSubWhereUnit().size() > 0) {
-				for(int i = 0; i < whereUnit.getSubWhereUnit().size(); i++) {
-					splitUntilNoOr(whereUnit.getSubWhereUnit().get(i));
-				}
-			} 
-		} else {
-			SQLBinaryOpExpr expr = whereUnit.getCanSplitExpr();
-			if(expr.getOperator() == SQLBinaryOperator.BooleanOr) {
-//				whereUnit.addSplitedExpr(expr.getRight());
-				addExprIfNotFalse(whereUnit, expr.getRight());
-				if(expr.getLeft() instanceof SQLBinaryOpExpr) {
-					whereUnit.setCanSplitExpr((SQLBinaryOpExpr)expr.getLeft());
-					splitUntilNoOr(whereUnit);
-				} else {
-					addExprIfNotFalse(whereUnit, expr.getLeft());
-				}
-			} else {
-				addExprIfNotFalse(whereUnit, expr);
-				whereUnit.setFinishedParse(true);
-			}
-		}
+        return retList;
     }
 
-	private void addExprIfNotFalse(WhereUnit whereUnit, SQLExpr expr) {
-		//非永假条件加入路由计算
-		if(!RouterUtil.isConditionAlwaysFalse(expr)) {
-			whereUnit.addSplitedExpr(expr);
-		}
-	}
-	
-	@Override
+    private void getConditionsFromWhereUnit(WhereUnit whereUnit) {
+        List<List<Condition>> retList = new ArrayList<List<Condition>>();
+        //or语句外层的条件:如where condition1 and (condition2 or condition3),condition1就会在外层条件中,因为之前提取
+        List<Condition> outSideCondition = new ArrayList<Condition>();
+//      stashOutSideConditions();
+        outSideCondition.addAll(conditions);
+        this.conditions.clear();
+
+        for (SQLExpr sqlExpr : whereUnit.getSplitedExprList()) {
+          sqlExpr.accept(this);
+//            List<Condition> conditions = new ArrayList<Condition>();
+//            conditions.addAll(getConditions()); conditions.addAll(outSideCondition);
+          /**
+           * 合并两个条件列表的元素为一个条件列表，减少不必要多的条件项</br>
+           *
+           * @author SvenAugustus
+           */
+          List<Condition> conditions = mergeSqlConditionList(getConditions(), outSideCondition);
+          retList.add(conditions);
+          this.conditions.clear();
+        }
+        whereUnit.setConditionList(retList);
+
+        for(WhereUnit subWhere : whereUnit.getSubWhereUnit()) {
+            getConditionsFromWhereUnit(subWhere);
+        }
+    }
+
+    /**
+     * 递归拆分OR
+     *
+     * @param whereUnit
+     * TODO:考虑嵌套or语句，条件中有子查询、 exists等很多种复杂情况是否能兼容
+     */
+    private void splitUntilNoOr(WhereUnit whereUnit) {
+        if(whereUnit.isFinishedParse()) {
+            if(whereUnit.getSubWhereUnit().size() > 0) {
+                for(int i = 0; i < whereUnit.getSubWhereUnit().size(); i++) {
+                    splitUntilNoOr(whereUnit.getSubWhereUnit().get(i));
+                }
+            }
+        } else {
+            SQLBinaryOpExpr expr = whereUnit.getCanSplitExpr();
+            if(expr.getOperator() == SQLBinaryOperator.BooleanOr) {
+//              whereUnit.addSplitedExpr(expr.getRight());
+                addExprIfNotFalse(whereUnit, expr.getRight());
+                if(expr.getLeft() instanceof SQLBinaryOpExpr) {
+                    whereUnit.setCanSplitExpr((SQLBinaryOpExpr)expr.getLeft());
+                    splitUntilNoOr(whereUnit);
+                } else {
+                    addExprIfNotFalse(whereUnit, expr.getLeft());
+                }
+            } else {
+                addExprIfNotFalse(whereUnit, expr);
+                whereUnit.setFinishedParse(true);
+            }
+        }
+    }
+
+    private void addExprIfNotFalse(WhereUnit whereUnit, SQLExpr expr) {
+        //非永假条件加入路由计算
+        if(!RouterUtil.isConditionAlwaysFalse(expr)) {
+            whereUnit.addSplitedExpr(expr);
+        }
+    }
+
+    @Override
     public boolean visit(SQLAlterTableStatement x) {
         String tableName = x.getName().toString();
         TableStat stat = getTableStat(tableName,tableName);
@@ -1023,7 +1063,7 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
         }
         return false;
     }
-	// DUAL
+    // DUAL
     public boolean visit(MySqlDeleteStatement x) {
         setAliasMap();
 
@@ -1049,10 +1089,10 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
 
         return false;
     }
-    
+
     public void endVisit(MySqlDeleteStatement x) {
     }
-    
+
     public boolean visit(SQLUpdateStatement x) {
         setAliasMap();
 
@@ -1068,10 +1108,10 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
             stat.incrementUpdateCount();
 
             Map<String, String> aliasMap = getAliasMap();
-            
+
             aliasMap.put(ident, ident);
             if(alias != null) {
-            	aliasMap.put(alias, ident);
+                aliasMap.put(alias, ident);
             }
         } else {
             x.getTableSource().accept(this);
@@ -1082,63 +1122,75 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
 
         return false;
     }
-    
+
     @Override
     public void endVisit(MySqlHintStatement x) {
-    	super.endVisit(x);
+        super.endVisit(x);
     }
-    
+
     @Override
     public boolean visit(MySqlHintStatement x) {
-    	List<SQLCommentHint> hits = x.getHints();
-    	if(hits != null && !hits.isEmpty()) {
-    		String schema = parseSchema(hits);
-    		if(schema != null ) {
-    			setCurrentTable(x, schema + ".");
-    			return true;
-    		}
-    	}
-    	return true;
+        List<SQLCommentHint> hits = x.getHints();
+        if(hits != null && !hits.isEmpty()) {
+            String schema = parseSchema(hits);
+            if(schema != null ) {
+                setCurrentTable(x, schema + ".");
+                return true;
+            }
+        }
+        return true;
     }
-    
+
     private String parseSchema(List<SQLCommentHint> hits) {
-    	String regx = "\\!mycat:schema\\s*=([\\s\\w]*)$";
-    	for(SQLCommentHint hit : hits ) {
-    		Pattern pattern = Pattern.compile(regx);
-    		Matcher m = pattern.matcher(hit.getText());
-    		if(m.matches()) {
-    			return m.group(1).trim();
-    		}
-    	}
-		return null;
+        String regx = "\\!mycat:schema\\s*=([\\s\\w]*)$";
+        for(SQLCommentHint hit : hits ) {
+            Pattern pattern = Pattern.compile(regx);
+            Matcher m = pattern.matcher(hit.getText());
+            if(m.matches()) {
+                return m.group(1).trim();
+            }
+        }
+        return null;
     }
 
-	public List<SQLSelect> getSubQuerys() {
-		return subQuerys;
-	}
-	
-	private void addSubQuerys(SQLSelect sqlselect){
-		/* 多个 sqlselect 之间  , equals 和 hashcode 是相同的.去重时 都被过滤掉了. */
-		if(subQuerys.isEmpty()){
-			subQuerys.add(sqlselect);
-			return;
-		}
-		Iterator<SQLSelect> iter = subQuerys.iterator();
-		while(iter.hasNext()){
-			SQLSelect ss = iter.next();
-			if(ss.getQuery() instanceof SQLSelectQueryBlock
-					&&sqlselect.getQuery() instanceof SQLSelectQueryBlock){
-				SQLSelectQueryBlock current = (SQLSelectQueryBlock)sqlselect.getQuery();
-				SQLSelectQueryBlock ssqb = (SQLSelectQueryBlock)ss.getQuery();
+    public Queue<SQLSelect> getSubQuerys() {
+        return subQuerys;
+    }
 
-				if(!sqlSelectQueryBlockEquals(ssqb,current)){
-					subQuerys.add(sqlselect);
-				}
-			}
-		}
-	}
-	
-	/* 多个 sqlselect 之间  , equals 和 hashcode 是相同的.去重时 使用 SQLSelectQueryBlock equals 方法 */
+    private void addSubQuerys(SQLSelect sqlselect){
+        /* 多个 sqlselect 之间  , equals 和 hashcode 是相同的.去重时 都被过滤掉了. */
+        if(subQuerys.isEmpty()){
+            subQuerys.add(sqlselect);
+            return;
+        }
+        boolean exists = false;
+        Iterator<SQLSelect> iter = subQuerys.iterator();
+        while(iter.hasNext()){
+            SQLSelect ss = iter.next();
+            if(ss.getQuery() instanceof SQLSelectQueryBlock
+                    &&sqlselect.getQuery() instanceof SQLSelectQueryBlock){
+                SQLSelectQueryBlock current = (SQLSelectQueryBlock)sqlselect.getQuery();
+                SQLSelectQueryBlock ssqb = (SQLSelectQueryBlock)ss.getQuery();
+//                  if(!sqlSelectQueryBlockEquals(ssqb,current)){
+//                    subQuerys.add(sqlselect);
+//                  }
+                /**
+                 * 修正判定逻辑，应改为全不在subQuerys中才加入<br/>
+                 *
+                 * @author SvenAugustus
+                 */
+                if(sqlSelectQueryBlockEquals(current,ssqb)){
+                   exists = true;
+                   break;
+                }
+            }
+        }
+        if(!exists) {
+          subQuerys.add(sqlselect);
+        }
+    }
+
+    /* 多个 sqlselect 之间  , equals 和 hashcode 是相同的.去重时 使用 SQLSelectQueryBlock equals 方法 */
     private boolean sqlSelectQueryBlockEquals(SQLSelectQueryBlock obj1,SQLSelectQueryBlock obj2) {
         if (obj1 == obj2) return true;
         if (obj2 == null) return false;
@@ -1163,11 +1215,181 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
         return true;
     }
 
-	public boolean isHasChange() {
-		return hasChange;
-	}
+    public boolean isHasChange() {
+        return hasChange;
+    }
 
-	public boolean isSubqueryRelationOr() {
-		return subqueryRelationOr;
-	}
+    public boolean isSubqueryRelationOr() {
+        return subqueryRelationOr;
+    }
+
+    /**
+     * 判定当前的条件列表 是否 另外一个条件列表的 子集
+     *
+     * @author SvenAugustus
+     * @param current 当前的条件列表
+     * @param other 另外一个条件列表
+     * @return
+     */
+    private boolean sqlConditionListInOther(List<Condition> current, List<Condition> other) {
+      if (current == null) {
+        if (other != null) {
+          return false;
+        }
+        return true;
+      }
+      if (current.size() > other.size()) {
+        return false;
+      }
+      if (other.size() == current.size()) {
+        // 判定两个条件列表的元素是否内容相等
+        return sqlConditionListEquals(current, other);
+      }
+      for (int j = 0; j < current.size(); j++) {
+        boolean exists = false;
+        for (int i = 0; i < other.size(); i++) {
+          // 判定两个条件是否相等
+          if (sqlConditionEquals(current.get(j), other.get(i))) {
+            exists = true;
+            break;
+          }
+        }
+        if (!exists) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /**
+     * 判定两个条件列表的元素是否内容相等
+     *
+     * @author SvenAugustus
+     * @param list1
+     * @param list2
+     * @return
+     */
+    private boolean sqlConditionListEquals(List<Condition> list1, List<Condition> list2) {
+      if (list1 == null) {
+        if (list2 != null) {
+          return false;
+        }
+        return true;
+      }
+      if (list2.size() != list1.size()) {
+        return false;
+      }
+      int len = list1.size();
+      for (int j = 0; j < len; j++) {
+        boolean exists = false;
+        for (int i = 0; i < len; i++) {
+          // 判定两个条件是否相等
+          if (sqlConditionEquals(list2.get(j), list1.get(i))) {
+            exists = true;
+            break;
+          }
+        }
+        if (!exists) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /**
+     * 合并两个条件列表的元素为一个条件列表
+     *
+     * @author SvenAugustus
+     * @param list1 条件列表1
+     * @param list2 条件列表2
+     * @return
+     */
+    private List<Condition> mergeSqlConditionList(List<Condition> list1, List<Condition> list2) {
+      if (list1 == null) {
+        list1 = new ArrayList();
+      }
+      if (list2 == null) {
+        list2 = new ArrayList();
+      }
+      List<Condition> retList = new ArrayList<Condition>();
+      if (!list1.isEmpty() && !(list1.get(0) instanceof Condition)) {
+        return retList;
+      }
+      if (!list2.isEmpty() && !(list2.get(0) instanceof Condition)) {
+        return retList;
+      }
+      retList.addAll(list1);
+      for (int j = 0; j < list2.size(); j++) {
+        boolean exists = false;
+        for (int i = 0; i < list1.size(); i++) {
+          if (sqlConditionEquals(list2.get(j), list1.get(i))) {
+            exists = true;
+            break;
+          }
+        }
+        if (!exists) {
+          retList.add(list2.get(j));
+        }
+      }
+      return retList;
+    }
+
+    /**
+     * 判定两个条件是否相等
+     *
+     * @author SvenAugustus
+     * @param obj1
+     * @param obj2
+     * @return
+     */
+    private boolean sqlConditionEquals(Condition obj1, Condition obj2) {
+      if (obj1 == obj2) {
+        return true;
+      }
+      if (obj2 == null) {
+        return false;
+      }
+      if (obj1.getClass() != obj2.getClass()) {
+        return false;
+      }
+      Condition other = (Condition) obj2;
+      if (obj1.getColumn() == null) {
+        if (other.getColumn() != null) {
+          return false;
+        }
+      } else if (!obj1.getColumn().equals(other.getColumn())) {
+        return false;
+      }
+      if (obj1.getOperator() == null) {
+        if (other.getOperator() != null) {
+          return false;
+        }
+      } else if (!obj1.getOperator().equals(other.getOperator())) {
+        return false;
+      }
+      if (obj1.getValues() == null) {
+        if (other.getValues() != null) {
+          return false;
+        }
+      } else {
+        boolean notEquals=false;
+        for (Object val1: obj1.getValues()) {
+          for (Object val2: obj2.getValues()) {
+            if(val1==null) {
+              if(val2!=null) {
+                notEquals=true;
+                break;
+              }
+            }else if(!val1.equals(val2)) {
+              notEquals=true;
+              break;
+            }
+          }
+          if(notEquals)break;
+        }
+        if(notEquals)
+        return false;
+      }
+      return true;
+    }
 }

--- a/src/main/java/io/mycat/route/parser/druid/MycatSchemaStatVisitor.java
+++ b/src/main/java/io/mycat/route/parser/druid/MycatSchemaStatVisitor.java
@@ -58,26 +58,26 @@ import java.util.regex.Pattern;
  *
  */
 public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
-    private boolean hasOrCondition = false;
-    private List<WhereUnit> whereUnits = new CopyOnWriteArrayList<WhereUnit>();
-    private List<WhereUnit> storedwhereUnits = new CopyOnWriteArrayList<WhereUnit>();
-    private Queue<SQLSelect> subQuerys = new LinkedBlockingQueue<>();  //子查询集合
-    private boolean hasChange = false; // 是否有改写sql
-    private boolean subqueryRelationOr = false;   //子查询存在关联条件的情况下，是否有 or 条件
+	private boolean hasOrCondition = false;
+	private List<WhereUnit> whereUnits = new CopyOnWriteArrayList<WhereUnit>();
+	private List<WhereUnit> storedwhereUnits = new CopyOnWriteArrayList<WhereUnit>();
+	private Queue<SQLSelect> subQuerys = new LinkedBlockingQueue<>();  //子查询集合
+	private boolean hasChange = false; // 是否有改写sql
+	private boolean subqueryRelationOr = false;   //子查询存在关联条件的情况下，是否有 or 条件
 
-    private void reset() {
-        this.conditions.clear();
-        this.whereUnits.clear();
-        this.hasOrCondition = false;
-    }
+	private void reset() {
+		this.conditions.clear();
+		this.whereUnits.clear();
+		this.hasOrCondition = false;
+	}
 
-    public List<WhereUnit> getWhereUnits() {
-        return whereUnits;
-    }
+	public List<WhereUnit> getWhereUnits() {
+		return whereUnits;
+	}
 
-    public boolean hasOrCondition() {
-        return hasOrCondition;
-    }
+	public boolean hasOrCondition() {
+		return hasOrCondition;
+	}
 
     @Override
     public boolean visit(SQLSelectStatement x) {
@@ -198,13 +198,13 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
                 if(betweenExpr.getTestExpr() instanceof SQLPropertyExpr) {//字段带别名的
                     tableName = ((SQLIdentifierExpr)((SQLPropertyExpr) betweenExpr.getTestExpr()).getOwner()).getName();
                     column = ((SQLPropertyExpr) betweenExpr.getTestExpr()).getName();
-                    SQLObject query = this.subQueryMap.get(tableName);
-                    if(query == null) {
-                        if (aliasMap.containsKey(tableName)) {
-                            tableName = aliasMap.get(tableName);
-                        }
-                        return new Column(tableName, column);
-                    }
+					SQLObject query = this.subQueryMap.get(tableName);
+					if(query == null) {
+						if (aliasMap.containsKey(tableName)) {
+							tableName = aliasMap.get(tableName);
+						}
+						return new Column(tableName, column);
+					}
                     return handleSubQueryColumn(tableName, column);
                 } else if(betweenExpr.getTestExpr() instanceof SQLIdentifierExpr) {
                     column = ((SQLIdentifierExpr) betweenExpr.getTestExpr()).getName();
@@ -287,11 +287,11 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
     }
 
     private void setSubQueryRelationOrFlag(SQLExprImpl x){
-        MycatSubQueryVisitor subQueryVisitor = new MycatSubQueryVisitor();
-        x.accept(subQueryVisitor);
-        if(subQueryVisitor.isRelationOr()){
-            subqueryRelationOr = true;
-        }
+    	MycatSubQueryVisitor subQueryVisitor = new MycatSubQueryVisitor();
+    	x.accept(subQueryVisitor);
+    	if(subQueryVisitor.isRelationOr()){
+    		subqueryRelationOr = true;
+    	}
     }
 
     /*
@@ -301,9 +301,9 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLQueryExpr x) {
-        setSubQueryRelationOrFlag(x);
-        addSubQuerys(x.getSubQuery());
-        return super.visit(x);
+    	setSubQueryRelationOrFlag(x);
+    	addSubQuerys(x.getSubQuery());
+    	return super.visit(x);
     }
     /*
      * (non-Javadoc)
@@ -311,8 +311,8 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLSubqueryTableSource x){
-        addSubQuerys(x.getSelect());
-        return super.visit(x);
+    	addSubQuerys(x.getSelect());
+    	return super.visit(x);
     }
 
     /*
@@ -321,14 +321,14 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLExistsExpr x) {
-        setSubQueryRelationOrFlag(x);
-        addSubQuerys(x.getSubQuery());
-        return super.visit(x);
+    	setSubQueryRelationOrFlag(x);
+    	addSubQuerys(x.getSubQuery());
+    	return super.visit(x);
     }
 
     @Override
     public boolean visit(SQLInListExpr x) {
-        return super.visit(x);
+    	return super.visit(x);
     }
 
     /*
@@ -338,114 +338,114 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
      */
     @Override
     public boolean visit(SQLInSubQueryExpr x) {
-        setSubQueryRelationOrFlag(x);
-        addSubQuerys(x.getSubQuery());
-        return super.visit(x);
+    	setSubQueryRelationOrFlag(x);
+    	addSubQuerys(x.getSubQuery());
+    	return super.visit(x);
     }
 
     /*
      *  遇到 all 将子查询改写成  SELECT MAX(name) FROM subtest1
      *  例如:
      *        select * from subtest where id > all (select name from subtest1);
-     *          >/>= all ----> >/>= max
-     *          </<= all ----> </<= min
-     *          <>   all ----> not in
+     *    		>/>= all ----> >/>= max
+     *    		</<= all ----> </<= min
+     *    		<>   all ----> not in
      *          =    all ----> id = 1 and id = 2
      *          other  不改写
      */
     @Override
     public boolean visit(SQLAllExpr x) {
-        setSubQueryRelationOrFlag(x);
+    	setSubQueryRelationOrFlag(x);
 
-        List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
-        SQLExpr sexpr = itemlist.get(0).getExpr();
+    	List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
+    	SQLExpr sexpr = itemlist.get(0).getExpr();
 
-        if(x.getParent() instanceof SQLBinaryOpExpr){
-            SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
-            SQLAggregateExpr saexpr = null;
-            switch (parentExpr.getOperator()) {
-            case GreaterThan:
-            case GreaterThanOrEqual:
-            case NotLessThan:
-                this.hasChange = true;
-                if(sexpr instanceof SQLIdentifierExpr
-                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-                    saexpr = new SQLAggregateExpr("MAX");
-                    saexpr.getArguments().add(sexpr);
-                    saexpr.setParent(itemlist.get(0));
-                    itemlist.get(0).setExpr(saexpr);
-                }
-                SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
-                x.getSubQuery().setParent(x.getParent());
-                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                if(x.getParent() instanceof SQLBinaryOpExpr){
-                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
-                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
-                    }
-                }
-                addSubQuerys(x.getSubQuery());
-                return super.visit(x.getSubQuery());
-            case LessThan:
-            case LessThanOrEqual:
-            case NotGreaterThan:
-                this.hasChange = true;
-                if(sexpr instanceof SQLIdentifierExpr
-                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-                    saexpr = new SQLAggregateExpr("MIN");
-                    saexpr.getArguments().add(sexpr);
-                    saexpr.setParent(itemlist.get(0));
-                    itemlist.get(0).setExpr(saexpr);
+		if(x.getParent() instanceof SQLBinaryOpExpr){
+			SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
+			SQLAggregateExpr saexpr = null;
+			switch (parentExpr.getOperator()) {
+			case GreaterThan:
+			case GreaterThanOrEqual:
+			case NotLessThan:
+				this.hasChange = true;
+				if(sexpr instanceof SQLIdentifierExpr
+						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+					saexpr = new SQLAggregateExpr("MAX");
+					saexpr.getArguments().add(sexpr);
+	        		saexpr.setParent(itemlist.get(0));
+	        		itemlist.get(0).setExpr(saexpr);
+				}
+				SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
+        		x.getSubQuery().setParent(x.getParent());
+        		// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+            	if(x.getParent() instanceof SQLBinaryOpExpr){
+            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
+            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
+            		}
+            	}
+            	addSubQuerys(x.getSubQuery());
+            	return super.visit(x.getSubQuery());
+			case LessThan:
+			case LessThanOrEqual:
+			case NotGreaterThan:
+				this.hasChange = true;
+				if(sexpr instanceof SQLIdentifierExpr
+						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+					saexpr = new SQLAggregateExpr("MIN");
+					saexpr.getArguments().add(sexpr);
+	        		saexpr.setParent(itemlist.get(0));
+	        		itemlist.get(0).setExpr(saexpr);
 
-                    x.subQuery.setParent(x.getParent());
-                }
-                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
-                if(x.getParent() instanceof SQLBinaryOpExpr){
-                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
-                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
-                    }
-                }
-                addSubQuerys(x.getSubQuery());
-                return super.visit(x.getSubQuery());
-             case LessThanOrGreater:
-             case NotEqual:
-                this.hasChange = true;
-                SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
-                x.getSubQuery().setParent(notInSubQueryExpr);
-                notInSubQueryExpr.setNot(true);
-                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                if(x.getParent() instanceof SQLBinaryOpExpr){
-                    SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
+	            	x.subQuery.setParent(x.getParent());
+				}
+				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+            	SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
+            	if(x.getParent() instanceof SQLBinaryOpExpr){
+            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
+            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
+            		}
+            	}
+            	addSubQuerys(x.getSubQuery());
+            	return super.visit(x.getSubQuery());
+			 case LessThanOrGreater:
+			 case NotEqual:
+				this.hasChange = true;
+				SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
+				x.getSubQuery().setParent(notInSubQueryExpr);
+				notInSubQueryExpr.setNot(true);
+				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+				if(x.getParent() instanceof SQLBinaryOpExpr){
+					SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
 
-                    if(xp.getLeft().equals(x)){
-                        notInSubQueryExpr.setExpr(xp.getRight());
-                    }else if(xp.getRight().equals(x)){
-                        notInSubQueryExpr.setExpr(xp.getLeft());
-                    }
+					if(xp.getLeft().equals(x)){
+						notInSubQueryExpr.setExpr(xp.getRight());
+					}else if(xp.getRight().equals(x)){
+						notInSubQueryExpr.setExpr(xp.getLeft());
+					}
 
-                    if(xp.getParent() instanceof MySqlSelectQueryBlock){
-                        ((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
-                    }else if(xp.getParent() instanceof SQLBinaryOpExpr){
-                        SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
-                        if(pp.getLeft().equals(xp)){
-                            pp.setLeft(notInSubQueryExpr);
-                        }else if(pp.getRight().equals(xp)){
-                            pp.setRight(notInSubQueryExpr);
-                        }
-                    }
-                }
-                addSubQuerys(x.getSubQuery());
-                return super.visit(notInSubQueryExpr);
-             default:
-                break;
-            }
-        }
-        addSubQuerys(x.getSubQuery());
-        return super.visit(x);
+					if(xp.getParent() instanceof MySqlSelectQueryBlock){
+						((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
+					}else if(xp.getParent() instanceof SQLBinaryOpExpr){
+						SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
+						if(pp.getLeft().equals(xp)){
+							pp.setLeft(notInSubQueryExpr);
+						}else if(pp.getRight().equals(xp)){
+							pp.setRight(notInSubQueryExpr);
+						}
+					}
+	            }
+				addSubQuerys(x.getSubQuery());
+	            return super.visit(notInSubQueryExpr);
+			 default:
+				break;
+			}
+		}
+		addSubQuerys(x.getSubQuery());
+    	return super.visit(x);
     }
 
     /*
@@ -461,125 +461,125 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
     @Override
     public boolean visit(SQLSomeExpr x) {
 
-        setSubQueryRelationOrFlag(x);
+    	setSubQueryRelationOrFlag(x);
 
-        List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
-        SQLExpr sexpr = itemlist.get(0).getExpr();
+    	List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
+    	SQLExpr sexpr = itemlist.get(0).getExpr();
 
-        if(x.getParent() instanceof SQLBinaryOpExpr){
-            SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
-            SQLAggregateExpr saexpr = null;
-            switch (parentExpr.getOperator()) {
-            case GreaterThan:
-            case GreaterThanOrEqual:
-            case NotLessThan:
-                this.hasChange = true;
-                if(sexpr instanceof SQLIdentifierExpr
-                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-                    saexpr = new SQLAggregateExpr("MIN");
-                    saexpr.getArguments().add(sexpr);
-                    saexpr.setParent(itemlist.get(0));
-                    itemlist.get(0).setExpr(saexpr);
-                }
-                SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
-                x.getSubQuery().setParent(maxSubQuery);
-                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                if(x.getParent() instanceof SQLBinaryOpExpr){
-                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
-                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
-                    }
-                }
-                addSubQuerys(x.getSubQuery());
-                return super.visit(x.getSubQuery());
-            case LessThan:
-            case LessThanOrEqual:
-            case NotGreaterThan:
-                this.hasChange = true;
-                if(sexpr instanceof SQLIdentifierExpr
-                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-                    saexpr = new SQLAggregateExpr("MAX");
-                    saexpr.getArguments().add(sexpr);
-                    saexpr.setParent(itemlist.get(0));
-                    itemlist.get(0).setExpr(saexpr);
-                }
-                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
-                x.getSubQuery().setParent(minSubQuery);
+		if(x.getParent() instanceof SQLBinaryOpExpr){
+			SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
+			SQLAggregateExpr saexpr = null;
+			switch (parentExpr.getOperator()) {
+			case GreaterThan:
+			case GreaterThanOrEqual:
+			case NotLessThan:
+				this.hasChange = true;
+				if(sexpr instanceof SQLIdentifierExpr
+						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+					saexpr = new SQLAggregateExpr("MIN");
+					saexpr.getArguments().add(sexpr);
+	        		saexpr.setParent(itemlist.get(0));
+	        		itemlist.get(0).setExpr(saexpr);
+				}
+				SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
+        		x.getSubQuery().setParent(maxSubQuery);
+        		// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+            	if(x.getParent() instanceof SQLBinaryOpExpr){
+            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
+            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
+            		}
+            	}
+            	addSubQuerys(x.getSubQuery());
+            	return super.visit(x.getSubQuery());
+			case LessThan:
+			case LessThanOrEqual:
+			case NotGreaterThan:
+				this.hasChange = true;
+				if(sexpr instanceof SQLIdentifierExpr
+						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+					saexpr = new SQLAggregateExpr("MAX");
+					saexpr.getArguments().add(sexpr);
+	        		saexpr.setParent(itemlist.get(0));
+	        		itemlist.get(0).setExpr(saexpr);
+				}
+				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+            	SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
+        		x.getSubQuery().setParent(minSubQuery);
 
-                if(x.getParent() instanceof SQLBinaryOpExpr){
-                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
-                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
-                    }
-                }
-                addSubQuerys(x.getSubQuery());
-                return super.visit(x.getSubQuery());
-             case LessThanOrGreater:
-             case NotEqual:
-                 this.hasChange = true;
-                    SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
-                    x.getSubQuery().setParent(notInSubQueryExpr);
-                    notInSubQueryExpr.setNot(true);
-                    // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                    if(x.getParent() instanceof SQLBinaryOpExpr){
-                        SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
+            	if(x.getParent() instanceof SQLBinaryOpExpr){
+            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
+            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
+            		}
+            	}
+            	addSubQuerys(x.getSubQuery());
+            	return super.visit(x.getSubQuery());
+			 case LessThanOrGreater:
+			 case NotEqual:
+				 this.hasChange = true;
+					SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
+					x.getSubQuery().setParent(notInSubQueryExpr);
+					notInSubQueryExpr.setNot(true);
+					// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+					if(x.getParent() instanceof SQLBinaryOpExpr){
+						SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
 
-                        if(xp.getLeft().equals(x)){
-                            notInSubQueryExpr.setExpr(xp.getRight());
-                        }else if(xp.getRight().equals(x)){
-                            notInSubQueryExpr.setExpr(xp.getLeft());
-                        }
+						if(xp.getLeft().equals(x)){
+							notInSubQueryExpr.setExpr(xp.getRight());
+						}else if(xp.getRight().equals(x)){
+							notInSubQueryExpr.setExpr(xp.getLeft());
+						}
 
-                        if(xp.getParent() instanceof MySqlSelectQueryBlock){
-                            ((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
-                        }else if(xp.getParent() instanceof SQLBinaryOpExpr){
-                            SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
-                            if(pp.getLeft().equals(xp)){
-                                pp.setLeft(notInSubQueryExpr);
-                            }else if(pp.getRight().equals(xp)){
-                                pp.setRight(notInSubQueryExpr);
-                            }
-                        }
-                    }
-                    addSubQuerys(x.getSubQuery());
-                    return super.visit(notInSubQueryExpr);
-             case Equality:
-                 this.hasChange = true;
-                SQLInSubQueryExpr inSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
-                x.getSubQuery().setParent(inSubQueryExpr);
-                inSubQueryExpr.setNot(false);
-                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                if(x.getParent() instanceof SQLBinaryOpExpr){
-                    SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
+						if(xp.getParent() instanceof MySqlSelectQueryBlock){
+							((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
+						}else if(xp.getParent() instanceof SQLBinaryOpExpr){
+							SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
+							if(pp.getLeft().equals(xp)){
+								pp.setLeft(notInSubQueryExpr);
+							}else if(pp.getRight().equals(xp)){
+								pp.setRight(notInSubQueryExpr);
+							}
+						}
+		            }
+					addSubQuerys(x.getSubQuery());
+		            return super.visit(notInSubQueryExpr);
+			 case Equality:
+				 this.hasChange = true;
+				SQLInSubQueryExpr inSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
+				x.getSubQuery().setParent(inSubQueryExpr);
+				inSubQueryExpr.setNot(false);
+				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+				if(x.getParent() instanceof SQLBinaryOpExpr){
+					SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
 
-                    if(xp.getLeft().equals(x)){
-                        inSubQueryExpr.setExpr(xp.getRight());
-                    }else if(xp.getRight().equals(x)){
-                        inSubQueryExpr.setExpr(xp.getLeft());
-                    }
+					if(xp.getLeft().equals(x)){
+						inSubQueryExpr.setExpr(xp.getRight());
+					}else if(xp.getRight().equals(x)){
+						inSubQueryExpr.setExpr(xp.getLeft());
+					}
 
-                    if(xp.getParent() instanceof MySqlSelectQueryBlock){
-                        ((MySqlSelectQueryBlock)xp.getParent()).setWhere(inSubQueryExpr);
-                    }else if(xp.getParent() instanceof SQLBinaryOpExpr){
-                        SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
-                        if(pp.getLeft().equals(xp)){
-                            pp.setLeft(inSubQueryExpr);
-                        }else if(pp.getRight().equals(xp)){
-                            pp.setRight(inSubQueryExpr);
-                        }
-                    }
-                }
-                addSubQuerys(x.getSubQuery());
-                return super.visit(inSubQueryExpr);
-             default:
-                break;
-            }
-        }
-        addSubQuerys(x.getSubQuery());
-        return super.visit(x);
+					if(xp.getParent() instanceof MySqlSelectQueryBlock){
+						((MySqlSelectQueryBlock)xp.getParent()).setWhere(inSubQueryExpr);
+					}else if(xp.getParent() instanceof SQLBinaryOpExpr){
+						SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
+						if(pp.getLeft().equals(xp)){
+							pp.setLeft(inSubQueryExpr);
+						}else if(pp.getRight().equals(xp)){
+							pp.setRight(inSubQueryExpr);
+						}
+					}
+	            }
+				addSubQuerys(x.getSubQuery());
+	            return super.visit(inSubQueryExpr);
+			 default:
+				break;
+			}
+		}
+		addSubQuerys(x.getSubQuery());
+    	return super.visit(x);
     }
 
     /*
@@ -595,128 +595,128 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
     @Override
     public boolean visit(SQLAnyExpr x) {
 
-        setSubQueryRelationOrFlag(x);
+    	setSubQueryRelationOrFlag(x);
 
-        List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
-        SQLExpr sexpr = itemlist.get(0).getExpr();
+    	List<SQLSelectItem> itemlist = ((SQLSelectQueryBlock)(x.getSubQuery().getQuery())).getSelectList();
+    	SQLExpr sexpr = itemlist.get(0).getExpr();
 
-        if(x.getParent() instanceof SQLBinaryOpExpr){
-            SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
-            SQLAggregateExpr saexpr = null;
-            switch (parentExpr.getOperator()) {
-            case GreaterThan:
-            case GreaterThanOrEqual:
-            case NotLessThan:
-                this.hasChange = true;
-                if(sexpr instanceof SQLIdentifierExpr
-                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-                    saexpr = new SQLAggregateExpr("MIN");
-                    saexpr.getArguments().add(sexpr);
-                    saexpr.setParent(itemlist.get(0));
-                    itemlist.get(0).setExpr(saexpr);
-                }
-                SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
-                x.getSubQuery().setParent(maxSubQuery);
-                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                if(x.getParent() instanceof SQLBinaryOpExpr){
-                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
-                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
-                    }
-                }
-                addSubQuerys(x.getSubQuery());
-                return super.visit(x.getSubQuery());
-            case LessThan:
-            case LessThanOrEqual:
-            case NotGreaterThan:
-                this.hasChange = true;
-                if(sexpr instanceof SQLIdentifierExpr
-                        || (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
-                    saexpr = new SQLAggregateExpr("MAX");
-                    saexpr.getArguments().add(sexpr);
-                    saexpr.setParent(itemlist.get(0));
-                    itemlist.get(0).setExpr(saexpr);
-                }
-                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
-                x.subQuery.setParent(minSubQuery);
-                if(x.getParent() instanceof SQLBinaryOpExpr){
-                    if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
-                    }else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
-                        ((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
-                    }
-                }
-                addSubQuerys(x.getSubQuery());
-                return super.visit(x.getSubQuery());
-             case LessThanOrGreater:
-             case NotEqual:
-                 this.hasChange = true;
-                    SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
-                    x.getSubQuery().setParent(notInSubQueryExpr);
-                    notInSubQueryExpr.setNot(true);
-                    // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                    if(x.getParent() instanceof SQLBinaryOpExpr){
-                        SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
+		if(x.getParent() instanceof SQLBinaryOpExpr){
+			SQLBinaryOpExpr parentExpr = (SQLBinaryOpExpr)x.getParent();
+			SQLAggregateExpr saexpr = null;
+			switch (parentExpr.getOperator()) {
+			case GreaterThan:
+			case GreaterThanOrEqual:
+			case NotLessThan:
+				this.hasChange = true;
+				if(sexpr instanceof SQLIdentifierExpr
+						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+					saexpr = new SQLAggregateExpr("MIN");
+					saexpr.getArguments().add(sexpr);
+	        		saexpr.setParent(itemlist.get(0));
+	        		itemlist.get(0).setExpr(saexpr);
+				}
+				SQLQueryExpr maxSubQuery = new SQLQueryExpr(x.getSubQuery());
+        		x.getSubQuery().setParent(maxSubQuery);
+				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+            	if(x.getParent() instanceof SQLBinaryOpExpr){
+            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setLeft(maxSubQuery);
+            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setRight(maxSubQuery);
+            		}
+            	}
+            	addSubQuerys(x.getSubQuery());
+            	return super.visit(x.getSubQuery());
+			case LessThan:
+			case LessThanOrEqual:
+			case NotGreaterThan:
+				this.hasChange = true;
+				if(sexpr instanceof SQLIdentifierExpr
+						|| (sexpr instanceof SQLPropertyExpr&&((SQLPropertyExpr)sexpr).getOwner() instanceof SQLIdentifierExpr)){
+					saexpr = new SQLAggregateExpr("MAX");
+					saexpr.getArguments().add(sexpr);
+	        		saexpr.setParent(itemlist.get(0));
+	        		itemlist.get(0).setExpr(saexpr);
+				}
+				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+            	SQLQueryExpr minSubQuery = new SQLQueryExpr(x.getSubQuery());
+            	x.subQuery.setParent(minSubQuery);
+            	if(x.getParent() instanceof SQLBinaryOpExpr){
+            		if(((SQLBinaryOpExpr)x.getParent()).getLeft().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setLeft(minSubQuery);
+            		}else if(((SQLBinaryOpExpr)x.getParent()).getRight().equals(x)){
+            			((SQLBinaryOpExpr)x.getParent()).setRight(minSubQuery);
+            		}
+            	}
+            	addSubQuerys(x.getSubQuery());
+            	return super.visit(x.getSubQuery());
+			 case LessThanOrGreater:
+			 case NotEqual:
+				 this.hasChange = true;
+					SQLInSubQueryExpr notInSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
+					x.getSubQuery().setParent(notInSubQueryExpr);
+					notInSubQueryExpr.setNot(true);
+					// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+					if(x.getParent() instanceof SQLBinaryOpExpr){
+						SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
 
-                        if(xp.getLeft().equals(x)){
-                            notInSubQueryExpr.setExpr(xp.getRight());
-                        }else if(xp.getRight().equals(x)){
-                            notInSubQueryExpr.setExpr(xp.getLeft());
-                        }
+						if(xp.getLeft().equals(x)){
+							notInSubQueryExpr.setExpr(xp.getRight());
+						}else if(xp.getRight().equals(x)){
+							notInSubQueryExpr.setExpr(xp.getLeft());
+						}
 
-                        if(xp.getParent() instanceof MySqlSelectQueryBlock){
-                            ((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
-                        }else if(xp.getParent() instanceof SQLBinaryOpExpr){
-                            SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
-                            if(pp.getLeft().equals(xp)){
-                                pp.setLeft(notInSubQueryExpr);
-                            }else if(pp.getRight().equals(xp)){
-                                pp.setRight(notInSubQueryExpr);
-                            }
-                        }
-                    }
-                    addSubQuerys(x.getSubQuery());
-                    return super.visit(notInSubQueryExpr);
-             case Equality:
-                 this.hasChange = true;
-                SQLInSubQueryExpr inSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
-                x.getSubQuery().setParent(inSubQueryExpr);
-                inSubQueryExpr.setNot(false);
-                // 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
-                if(x.getParent() instanceof SQLBinaryOpExpr){
-                    SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
+						if(xp.getParent() instanceof MySqlSelectQueryBlock){
+							((MySqlSelectQueryBlock)xp.getParent()).setWhere(notInSubQueryExpr);
+						}else if(xp.getParent() instanceof SQLBinaryOpExpr){
+							SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
+							if(pp.getLeft().equals(xp)){
+								pp.setLeft(notInSubQueryExpr);
+							}else if(pp.getRight().equals(xp)){
+								pp.setRight(notInSubQueryExpr);
+							}
+						}
+		            }
+					addSubQuerys(x.getSubQuery());
+		            return super.visit(notInSubQueryExpr);
+			 case Equality:
+				 this.hasChange = true;
+				SQLInSubQueryExpr inSubQueryExpr = new SQLInSubQueryExpr(x.getSubQuery());
+				x.getSubQuery().setParent(inSubQueryExpr);
+				inSubQueryExpr.setNot(false);
+				// 生成新的SQLQueryExpr 替换当前 SQLAllExpr 节点
+				if(x.getParent() instanceof SQLBinaryOpExpr){
+					SQLBinaryOpExpr xp = (SQLBinaryOpExpr)x.getParent();
 
-                    if(xp.getLeft().equals(x)){
-                        inSubQueryExpr.setExpr(xp.getRight());
-                    }else if(xp.getRight().equals(x)){
-                        inSubQueryExpr.setExpr(xp.getLeft());
-                    }
+					if(xp.getLeft().equals(x)){
+						inSubQueryExpr.setExpr(xp.getRight());
+					}else if(xp.getRight().equals(x)){
+						inSubQueryExpr.setExpr(xp.getLeft());
+					}
 
-                    if(xp.getParent() instanceof MySqlSelectQueryBlock){
-                        ((MySqlSelectQueryBlock)xp.getParent()).setWhere(inSubQueryExpr);
-                    }else if(xp.getParent() instanceof SQLBinaryOpExpr){
-                        SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
-                        if(pp.getLeft().equals(xp)){
-                            pp.setLeft(inSubQueryExpr);
-                        }else if(pp.getRight().equals(xp)){
-                            pp.setRight(inSubQueryExpr);
-                        }
-                    }
-                }
-                addSubQuerys(x.getSubQuery());
-                return super.visit(inSubQueryExpr);
-             default:
-                break;
-            }
-        }
-        addSubQuerys(x.getSubQuery());
-        return super.visit(x);
+					if(xp.getParent() instanceof MySqlSelectQueryBlock){
+						((MySqlSelectQueryBlock)xp.getParent()).setWhere(inSubQueryExpr);
+					}else if(xp.getParent() instanceof SQLBinaryOpExpr){
+						SQLBinaryOpExpr pp = ((SQLBinaryOpExpr)xp.getParent());
+						if(pp.getLeft().equals(xp)){
+							pp.setLeft(inSubQueryExpr);
+						}else if(pp.getRight().equals(xp)){
+							pp.setRight(inSubQueryExpr);
+						}
+					}
+	            }
+				addSubQuerys(x.getSubQuery());
+	            return super.visit(inSubQueryExpr);
+			 default:
+				break;
+			}
+		}
+		addSubQuerys(x.getSubQuery());
+    	return super.visit(x);
     }
 
     @Override
-    public boolean visit(SQLBinaryOpExpr x) {
+	public boolean visit(SQLBinaryOpExpr x) {
         x.getLeft().setParent(x);
         x.getRight().setParent(x);
 
@@ -728,7 +728,7 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
          */
         String currenttable = x.getParent()==null?null: (String) x.getParent().getAttribute(SchemaStatVisitor.ATTR_TABLE);
         if(currenttable!=null){
-            this.setCurrentTable(currenttable);
+        	this.setCurrentTable(currenttable);
         }
 
         switch (x.getOperator()) {
@@ -742,31 +742,31 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
             case LessThanOrEqual:
             case NotLessThan:
             case LessThanOrGreater:
-            case NotEqual:
-            case NotGreaterThan:
+			case NotEqual:
+			case NotGreaterThan:
                 handleCondition(x.getLeft(), x.getOperator().name, x.getRight());
                 handleCondition(x.getRight(), x.getOperator().name, x.getLeft());
                 handleRelationship(x.getLeft(), x.getOperator().name, x.getRight());
                 break;
             case BooleanOr:
-                //永真条件，where条件抛弃
-                if(!RouterUtil.isConditionAlwaysTrue(x)) {
-                    hasOrCondition = true;
+            	//永真条件，where条件抛弃
+            	if(!RouterUtil.isConditionAlwaysTrue(x)) {
+            		hasOrCondition = true;
 
-                    WhereUnit whereUnit = null;
-                    if(conditions.size() > 0) {
-                        whereUnit = new WhereUnit();
-                        whereUnit.setFinishedParse(true);
-                        whereUnit.addOutConditions(getConditions());
-                        WhereUnit innerWhereUnit = new WhereUnit(x);
-                        whereUnit.addSubWhereUnit(innerWhereUnit);
-                    } else {
-                        whereUnit = new WhereUnit(x);
-                        whereUnit.addOutConditions(getConditions());
-                    }
-                    whereUnits.add(whereUnit);
-                }
-                return false;
+            		WhereUnit whereUnit = null;
+            		if(conditions.size() > 0) {
+            			whereUnit = new WhereUnit();
+            			whereUnit.setFinishedParse(true);
+            			whereUnit.addOutConditions(getConditions());
+            			WhereUnit innerWhereUnit = new WhereUnit(x);
+            			whereUnit.addSubWhereUnit(innerWhereUnit);
+            		} else {
+            			whereUnit = new WhereUnit(x);
+            			whereUnit.addOutConditions(getConditions());
+            		}
+            		whereUnits.add(whereUnit);
+            	}
+            	return false;
             case Like:
             case NotLike:
             default:
@@ -775,130 +775,131 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
         return true;
     }
 
-    /**
-     * 分解条件
-     */
-    public List<List<Condition>> splitConditions() {
-        //按照or拆分
-        for(WhereUnit whereUnit : whereUnits) {
-            splitUntilNoOr(whereUnit);
-        }
+	/**
+	 * 分解条件
+	 */
+	public List<List<Condition>> splitConditions() {
+		//按照or拆分
+		for(WhereUnit whereUnit : whereUnits) {
+			splitUntilNoOr(whereUnit);
+		}
 
-        this.storedwhereUnits.addAll(whereUnits);
+		this.storedwhereUnits.addAll(whereUnits);
 
-        loopFindSubWhereUnit(whereUnits);
+		loopFindSubWhereUnit(whereUnits);
 
-        //拆分后的条件块解析成Condition列表
-        for(WhereUnit whereUnit : storedwhereUnits) {
-            this.getConditionsFromWhereUnit(whereUnit);
-        }
+		//拆分后的条件块解析成Condition列表
+		for(WhereUnit whereUnit : storedwhereUnits) {
+			this.getConditionsFromWhereUnit(whereUnit);
+		}
 
-        //多个WhereUnit组合:多层集合的组合
-        return mergedConditions();
-    }
+		//多个WhereUnit组合:多层集合的组合
+		return mergedConditions();
+	}
 
-    /**
-     * 循环寻找子WhereUnit（实际是嵌套的or）
-     * @param whereUnitList
-     */
-    private void loopFindSubWhereUnit(List<WhereUnit> whereUnitList) {
-        List<WhereUnit> subWhereUnits = new ArrayList<WhereUnit>();
-        for(WhereUnit whereUnit : whereUnitList) {
-            if(whereUnit.getSplitedExprList().size() > 0) {
-                List<SQLExpr> removeSplitedList = new ArrayList<SQLExpr>();
-                for(SQLExpr sqlExpr : whereUnit.getSplitedExprList()) {
-                    reset();
-                    if(isExprHasOr(sqlExpr)) {
-                        removeSplitedList.add(sqlExpr);
-                        WhereUnit subWhereUnit = this.whereUnits.get(0);
-                        splitUntilNoOr(subWhereUnit);
-                        whereUnit.addSubWhereUnit(subWhereUnit);
-                        subWhereUnits.add(subWhereUnit);
-                    } else {
-                        this.conditions.clear();
-                    }
-                }
-                if(removeSplitedList.size() > 0) {
-                    whereUnit.getSplitedExprList().removeAll(removeSplitedList);
-                }
-            }
-            subWhereUnits.addAll(whereUnit.getSubWhereUnit());
-        }
-        if(subWhereUnits.size() > 0) {
-            loopFindSubWhereUnit(subWhereUnits);
-        }
-    }
+	/**
+	 * 循环寻找子WhereUnit（实际是嵌套的or）
+	 * @param whereUnitList
+	 */
+	private void loopFindSubWhereUnit(List<WhereUnit> whereUnitList) {
+		List<WhereUnit> subWhereUnits = new ArrayList<WhereUnit>();
+		for(WhereUnit whereUnit : whereUnitList) {
+			if(whereUnit.getSplitedExprList().size() > 0) {
+				List<SQLExpr> removeSplitedList = new ArrayList<SQLExpr>();
+				for(SQLExpr sqlExpr : whereUnit.getSplitedExprList()) {
+					reset();
+					if(isExprHasOr(sqlExpr)) {
+						removeSplitedList.add(sqlExpr);
+						WhereUnit subWhereUnit = this.whereUnits.get(0);
+						splitUntilNoOr(subWhereUnit);
+						whereUnit.addSubWhereUnit(subWhereUnit);
+						subWhereUnits.add(subWhereUnit);
+					} else {
+						this.conditions.clear();
+					}
+				}
+				if(removeSplitedList.size() > 0) {
+					whereUnit.getSplitedExprList().removeAll(removeSplitedList);
+				}
+			}
+			subWhereUnits.addAll(whereUnit.getSubWhereUnit());
+		}
+		if(subWhereUnits.size() > 0) {
+			loopFindSubWhereUnit(subWhereUnits);
+		}
+	}
 
-    private boolean isExprHasOr(SQLExpr expr) {
-        expr.accept(this);
-        return hasOrCondition;
-    }
+	private boolean isExprHasOr(SQLExpr expr) {
+		expr.accept(this);
+		return hasOrCondition;
+	}
 
-    private List<List<Condition>> mergedConditions() {
-        if(storedwhereUnits.size() == 0) {
-            return new ArrayList<List<Condition>>();
-        }
-        for(WhereUnit whereUnit : storedwhereUnits) {
-            mergeOneWhereUnit(whereUnit);
-        }
-        return getMergedConditionList(storedwhereUnits);
-    }
+	private List<List<Condition>> mergedConditions() {
+		if(storedwhereUnits.size() == 0) {
+			return new ArrayList<List<Condition>>();
+		}
+		for(WhereUnit whereUnit : storedwhereUnits) {
+			mergeOneWhereUnit(whereUnit);
+		}
+		return getMergedConditionList(storedwhereUnits);
 
-    /**
-     * 一个WhereUnit内递归
-     * @param whereUnit
-     */
-    private void mergeOneWhereUnit(WhereUnit whereUnit) {
-        if(whereUnit.getSubWhereUnit().size() > 0) {
-            for(WhereUnit sub : whereUnit.getSubWhereUnit()) {
-                mergeOneWhereUnit(sub);
-            }
+	}
 
-            if(whereUnit.getSubWhereUnit().size() > 1) {
-                List<List<Condition>> mergedConditionList = getMergedConditionList(whereUnit.getSubWhereUnit());
-                if(whereUnit.getOutConditions().size() > 0) {
-                    for(int i = 0; i < mergedConditionList.size() ; i++) {
-                        mergedConditionList.get(i).addAll(whereUnit.getOutConditions());
-                    }
-                }
-                whereUnit.setConditionList(mergedConditionList);
-            } else if(whereUnit.getSubWhereUnit().size() == 1) {
-                if(whereUnit.getOutConditions().size() > 0 && whereUnit.getSubWhereUnit().get(0).getConditionList().size() > 0) {
-                    for(int i = 0; i < whereUnit.getSubWhereUnit().get(0).getConditionList().size() ; i++) {
-                        whereUnit.getSubWhereUnit().get(0).getConditionList().get(i).addAll(whereUnit.getOutConditions());
-                    }
-                }
-                whereUnit.getConditionList().addAll(whereUnit.getSubWhereUnit().get(0).getConditionList());
-            }
-        } else {
-            //do nothing
-        }
-    }
+	/**
+	 * 一个WhereUnit内递归
+	 * @param whereUnit
+	 */
+	private void mergeOneWhereUnit(WhereUnit whereUnit) {
+		if(whereUnit.getSubWhereUnit().size() > 0) {
+			for(WhereUnit sub : whereUnit.getSubWhereUnit()) {
+				mergeOneWhereUnit(sub);
+			}
 
-    /**
-     * 条件合并：多个WhereUnit中的条件组合
-     * @return
-     */
-    private List<List<Condition>> getMergedConditionList(List<WhereUnit> whereUnitList) {
-        List<List<Condition>> mergedConditionList = new ArrayList<List<Condition>>();
-        if(whereUnitList.size() == 0) {
-            return mergedConditionList;
-        }
-        mergedConditionList.addAll(whereUnitList.get(0).getConditionList());
+			if(whereUnit.getSubWhereUnit().size() > 1) {
+				List<List<Condition>> mergedConditionList = getMergedConditionList(whereUnit.getSubWhereUnit());
+				if(whereUnit.getOutConditions().size() > 0) {
+					for(int i = 0; i < mergedConditionList.size() ; i++) {
+						mergedConditionList.get(i).addAll(whereUnit.getOutConditions());
+					}
+				}
+				whereUnit.setConditionList(mergedConditionList);
+			} else if(whereUnit.getSubWhereUnit().size() == 1) {
+				if(whereUnit.getOutConditions().size() > 0 && whereUnit.getSubWhereUnit().get(0).getConditionList().size() > 0) {
+					for(int i = 0; i < whereUnit.getSubWhereUnit().get(0).getConditionList().size() ; i++) {
+						whereUnit.getSubWhereUnit().get(0).getConditionList().get(i).addAll(whereUnit.getOutConditions());
+					}
+				}
+				whereUnit.getConditionList().addAll(whereUnit.getSubWhereUnit().get(0).getConditionList());
+			}
+		} else {
+			//do nothing
+		}
+	}
 
-        for(int i = 1; i < whereUnitList.size(); i++) {
-            mergedConditionList = merge(mergedConditionList, whereUnitList.get(i).getConditionList());
-        }
-        return mergedConditionList;
-    }
+	/**
+	 * 条件合并：多个WhereUnit中的条件组合
+	 * @return
+	 */
+	private List<List<Condition>> getMergedConditionList(List<WhereUnit> whereUnitList) {
+		List<List<Condition>> mergedConditionList = new ArrayList<List<Condition>>();
+		if(whereUnitList.size() == 0) {
+			return mergedConditionList;
+		}
+		mergedConditionList.addAll(whereUnitList.get(0).getConditionList());
 
-    /**
-     * 两个list中的条件组合
-     * @param list1
-     * @param list2
-     * @return
-     */
-    private List<List<Condition>> merge(List<List<Condition>> list1, List<List<Condition>> list2) {
+		for(int i = 1; i < whereUnitList.size(); i++) {
+			mergedConditionList = merge(mergedConditionList, whereUnitList.get(i).getConditionList());
+		}
+		return mergedConditionList;
+	}
+
+	/**
+	 * 两个list中的条件组合
+	 * @param list1
+	 * @param list2
+	 * @return
+	 */
+	    private List<List<Condition>> merge(List<List<Condition>> list1, List<List<Condition>> list2) {
         if(list1.size() == 0) {
             return list2;
         } else if (list2.size() == 0) {
@@ -956,17 +957,16 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
         return retList;
     }
 
-    private void getConditionsFromWhereUnit(WhereUnit whereUnit) {
-        List<List<Condition>> retList = new ArrayList<List<Condition>>();
-        //or语句外层的条件:如where condition1 and (condition2 or condition3),condition1就会在外层条件中,因为之前提取
-        List<Condition> outSideCondition = new ArrayList<Condition>();
-//      stashOutSideConditions();
-        outSideCondition.addAll(conditions);
-        this.conditions.clear();
-
-        for (SQLExpr sqlExpr : whereUnit.getSplitedExprList()) {
-          sqlExpr.accept(this);
-//            List<Condition> conditions = new ArrayList<Condition>();
+	private void getConditionsFromWhereUnit(WhereUnit whereUnit) {
+		List<List<Condition>> retList = new ArrayList<List<Condition>>();
+		//or语句外层的条件:如where condition1 and (condition2 or condition3),condition1就会在外层条件中,因为之前提取
+		List<Condition> outSideCondition = new ArrayList<Condition>();
+//		stashOutSideConditions();
+		outSideCondition.addAll(conditions);
+		this.conditions.clear();
+		for(SQLExpr sqlExpr : whereUnit.getSplitedExprList()) {
+			sqlExpr.accept(this);
+			//            List<Condition> conditions = new ArrayList<Condition>();
 //            conditions.addAll(getConditions()); conditions.addAll(outSideCondition);
           /**
            * 合并两个条件列表的元素为一个条件列表，减少不必要多的条件项</br>
@@ -974,55 +974,55 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
            * @author SvenAugustus
            */
           List<Condition> conditions = mergeSqlConditionList(getConditions(), outSideCondition);
-          retList.add(conditions);
-          this.conditions.clear();
-        }
-        whereUnit.setConditionList(retList);
+			retList.add(conditions);
+			this.conditions.clear();
+		}
+		whereUnit.setConditionList(retList);
 
-        for(WhereUnit subWhere : whereUnit.getSubWhereUnit()) {
-            getConditionsFromWhereUnit(subWhere);
-        }
+		for(WhereUnit subWhere : whereUnit.getSubWhereUnit()) {
+			getConditionsFromWhereUnit(subWhere);
+		}
+	}
+
+	/**
+	 * 递归拆分OR
+	 *
+	 * @param whereUnit
+	 * TODO:考虑嵌套or语句，条件中有子查询、 exists等很多种复杂情况是否能兼容
+	 */
+	private void splitUntilNoOr(WhereUnit whereUnit) {
+		if(whereUnit.isFinishedParse()) {
+			if(whereUnit.getSubWhereUnit().size() > 0) {
+				for(int i = 0; i < whereUnit.getSubWhereUnit().size(); i++) {
+					splitUntilNoOr(whereUnit.getSubWhereUnit().get(i));
+				}
+			}
+		} else {
+			SQLBinaryOpExpr expr = whereUnit.getCanSplitExpr();
+			if(expr.getOperator() == SQLBinaryOperator.BooleanOr) {
+//				whereUnit.addSplitedExpr(expr.getRight());
+				addExprIfNotFalse(whereUnit, expr.getRight());
+				if(expr.getLeft() instanceof SQLBinaryOpExpr) {
+					whereUnit.setCanSplitExpr((SQLBinaryOpExpr)expr.getLeft());
+					splitUntilNoOr(whereUnit);
+				} else {
+					addExprIfNotFalse(whereUnit, expr.getLeft());
+				}
+			} else {
+				addExprIfNotFalse(whereUnit, expr);
+				whereUnit.setFinishedParse(true);
+			}
+		}
     }
 
-    /**
-     * 递归拆分OR
-     *
-     * @param whereUnit
-     * TODO:考虑嵌套or语句，条件中有子查询、 exists等很多种复杂情况是否能兼容
-     */
-    private void splitUntilNoOr(WhereUnit whereUnit) {
-        if(whereUnit.isFinishedParse()) {
-            if(whereUnit.getSubWhereUnit().size() > 0) {
-                for(int i = 0; i < whereUnit.getSubWhereUnit().size(); i++) {
-                    splitUntilNoOr(whereUnit.getSubWhereUnit().get(i));
-                }
-            }
-        } else {
-            SQLBinaryOpExpr expr = whereUnit.getCanSplitExpr();
-            if(expr.getOperator() == SQLBinaryOperator.BooleanOr) {
-//              whereUnit.addSplitedExpr(expr.getRight());
-                addExprIfNotFalse(whereUnit, expr.getRight());
-                if(expr.getLeft() instanceof SQLBinaryOpExpr) {
-                    whereUnit.setCanSplitExpr((SQLBinaryOpExpr)expr.getLeft());
-                    splitUntilNoOr(whereUnit);
-                } else {
-                    addExprIfNotFalse(whereUnit, expr.getLeft());
-                }
-            } else {
-                addExprIfNotFalse(whereUnit, expr);
-                whereUnit.setFinishedParse(true);
-            }
-        }
-    }
+	private void addExprIfNotFalse(WhereUnit whereUnit, SQLExpr expr) {
+		//非永假条件加入路由计算
+		if(!RouterUtil.isConditionAlwaysFalse(expr)) {
+			whereUnit.addSplitedExpr(expr);
+		}
+	}
 
-    private void addExprIfNotFalse(WhereUnit whereUnit, SQLExpr expr) {
-        //非永假条件加入路由计算
-        if(!RouterUtil.isConditionAlwaysFalse(expr)) {
-            whereUnit.addSplitedExpr(expr);
-        }
-    }
-
-    @Override
+	@Override
     public boolean visit(SQLAlterTableStatement x) {
         String tableName = x.getName().toString();
         TableStat stat = getTableStat(tableName,tableName);
@@ -1063,7 +1063,7 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
         }
         return false;
     }
-    // DUAL
+	// DUAL
     public boolean visit(MySqlDeleteStatement x) {
         setAliasMap();
 
@@ -1111,7 +1111,7 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
 
             aliasMap.put(ident, ident);
             if(alias != null) {
-                aliasMap.put(alias, ident);
+            	aliasMap.put(alias, ident);
             }
         } else {
             x.getTableSource().accept(this);
@@ -1125,52 +1125,52 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
 
     @Override
     public void endVisit(MySqlHintStatement x) {
-        super.endVisit(x);
+    	super.endVisit(x);
     }
 
     @Override
     public boolean visit(MySqlHintStatement x) {
-        List<SQLCommentHint> hits = x.getHints();
-        if(hits != null && !hits.isEmpty()) {
-            String schema = parseSchema(hits);
-            if(schema != null ) {
-                setCurrentTable(x, schema + ".");
-                return true;
-            }
-        }
-        return true;
+    	List<SQLCommentHint> hits = x.getHints();
+    	if(hits != null && !hits.isEmpty()) {
+    		String schema = parseSchema(hits);
+    		if(schema != null ) {
+    			setCurrentTable(x, schema + ".");
+    			return true;
+    		}
+    	}
+    	return true;
     }
 
     private String parseSchema(List<SQLCommentHint> hits) {
-        String regx = "\\!mycat:schema\\s*=([\\s\\w]*)$";
-        for(SQLCommentHint hit : hits ) {
-            Pattern pattern = Pattern.compile(regx);
-            Matcher m = pattern.matcher(hit.getText());
-            if(m.matches()) {
-                return m.group(1).trim();
-            }
-        }
-        return null;
+    	String regx = "\\!mycat:schema\\s*=([\\s\\w]*)$";
+    	for(SQLCommentHint hit : hits ) {
+    		Pattern pattern = Pattern.compile(regx);
+    		Matcher m = pattern.matcher(hit.getText());
+    		if(m.matches()) {
+    			return m.group(1).trim();
+    		}
+    	}
+		return null;
     }
 
-    public Queue<SQLSelect> getSubQuerys() {
-        return subQuerys;
-    }
+	public Queue<SQLSelect> getSubQuerys() {
+		return subQuerys;
+	}
 
-    private void addSubQuerys(SQLSelect sqlselect){
-        /* 多个 sqlselect 之间  , equals 和 hashcode 是相同的.去重时 都被过滤掉了. */
-        if(subQuerys.isEmpty()){
-            subQuerys.add(sqlselect);
-            return;
-        }
+	private void addSubQuerys(SQLSelect sqlselect){
+		/* 多个 sqlselect 之间  , equals 和 hashcode 是相同的.去重时 都被过滤掉了. */
+		if(subQuerys.isEmpty()){
+			subQuerys.add(sqlselect);
+			return;
+		}
         boolean exists = false;
-        Iterator<SQLSelect> iter = subQuerys.iterator();
-        while(iter.hasNext()){
-            SQLSelect ss = iter.next();
-            if(ss.getQuery() instanceof SQLSelectQueryBlock
-                    &&sqlselect.getQuery() instanceof SQLSelectQueryBlock){
-                SQLSelectQueryBlock current = (SQLSelectQueryBlock)sqlselect.getQuery();
-                SQLSelectQueryBlock ssqb = (SQLSelectQueryBlock)ss.getQuery();
+		Iterator<SQLSelect> iter = subQuerys.iterator();
+		while(iter.hasNext()){
+			SQLSelect ss = iter.next();
+			if(ss.getQuery() instanceof SQLSelectQueryBlock
+					&&sqlselect.getQuery() instanceof SQLSelectQueryBlock){
+				SQLSelectQueryBlock current = (SQLSelectQueryBlock)sqlselect.getQuery();
+				SQLSelectQueryBlock ssqb = (SQLSelectQueryBlock)ss.getQuery();
 //                  if(!sqlSelectQueryBlockEquals(ssqb,current)){
 //                    subQuerys.add(sqlselect);
 //                  }
@@ -1186,11 +1186,11 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
             }
         }
         if(!exists) {
-          subQuerys.add(sqlselect);
-        }
-    }
+					subQuerys.add(sqlselect);
+				}
+			}
 
-    /* 多个 sqlselect 之间  , equals 和 hashcode 是相同的.去重时 使用 SQLSelectQueryBlock equals 方法 */
+	/* 多个 sqlselect 之间  , equals 和 hashcode 是相同的.去重时 使用 SQLSelectQueryBlock equals 方法 */
     private boolean sqlSelectQueryBlockEquals(SQLSelectQueryBlock obj1,SQLSelectQueryBlock obj2) {
         if (obj1 == obj2) return true;
         if (obj2 == null) return false;
@@ -1215,13 +1215,13 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
         return true;
     }
 
-    public boolean isHasChange() {
-        return hasChange;
-    }
+	public boolean isHasChange() {
+		return hasChange;
+	}
 
-    public boolean isSubqueryRelationOr() {
-        return subqueryRelationOr;
-    }
+	public boolean isSubqueryRelationOr() {
+		return subqueryRelationOr;
+	}
 
     /**
      * 判定当前的条件列表 是否 另外一个条件列表的 子集
@@ -1235,7 +1235,7 @@ public class MycatSchemaStatVisitor extends MySqlSchemaStatVisitor {
       if (current == null) {
         if (other != null) {
           return false;
-        }
+}
         return true;
       }
       if (current.size() > other.size()) {

--- a/src/main/java/io/mycat/route/parser/druid/SchemaStatVisitorFactory.java
+++ b/src/main/java/io/mycat/route/parser/druid/SchemaStatVisitorFactory.java
@@ -1,0 +1,26 @@
+package io.mycat.route.parser.druid;
+
+import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
+import io.mycat.config.model.SchemaConfig;
+
+/**
+ * 为防止SchemaStatVisitor被污染，采用factory创建
+ *
+ * Date：2017年12月1日
+ * 
+ * @author SvenAugustus
+ * @version 1.0
+ * @since JDK 1.7
+ */
+public class SchemaStatVisitorFactory {
+
+  /**
+   * 创建
+   * 
+   * @return
+   */
+  public static SchemaStatVisitor create(SchemaConfig schema) {
+    SchemaStatVisitor visitor = new MycatSchemaStatVisitor();
+    return visitor;
+  }
+}

--- a/src/test/java/io/mycat/parser/druid/MycatSchemaStatVisitorTest.java
+++ b/src/test/java/io/mycat/parser/druid/MycatSchemaStatVisitorTest.java
@@ -16,15 +16,14 @@ import io.mycat.route.parser.druid.MycatSchemaStatVisitor;
 
 /**
  * TODO: 增加描述
- * 
+ *
  * @author user
  * @date 2015-6-2 下午5:50:25
- * @version 0.1.0 
+ * @version 0.1.0
  * @copyright wonhigh.cn
  */
 public class MycatSchemaStatVisitorTest {
-	
-	
+
 	/**
 	 * 从注解中解析 mycat schema
 	 */
@@ -38,8 +37,8 @@ public class MycatSchemaStatVisitorTest {
 		Assert.assertEquals(getSchema(sql), "helper1.");
 		System.out.println(getSchema(sql));
 	}
-	
-	
+
+
 	/**
 	 * 3层嵌套or语句
 	 */
@@ -55,29 +54,29 @@ public class MycatSchemaStatVisitorTest {
 		Assert.assertEquals(list.get(2).size(), 3);
 		Assert.assertEquals(list.get(3).size(), 4);
 		Assert.assertEquals(list.get(4).size(), 3);
-		
+
 		Assert.assertEquals(list.get(0).get(0).toString(), "travelrecord.days = 5");
 		Assert.assertEquals(list.get(0).get(1).toString(), "travelrecord.id = (1, 2)");
-		
+
 		Assert.assertEquals(list.get(1).get(0).toString(), "travelrecord.fee = 3");
 		Assert.assertEquals(list.get(1).get(1).toString(), "travelrecord.id = (1, 2)");
-		
+
 		Assert.assertEquals(list.get(2).get(0).toString(), "travelrecord.fee = 0");
 		Assert.assertEquals(list.get(2).get(1).toString(), "travelrecord.traveldate = 2015-05-04 00:00:07.375");
 		Assert.assertEquals(list.get(2).get(2).toString(), "travelrecord.id = (1, 2)");
-		
+
 		Assert.assertEquals(list.get(3).get(0).toString(), "travelrecord.fee = null");
 		Assert.assertEquals(list.get(3).get(1).toString(), "travelrecord.days = null");
 		Assert.assertEquals(list.get(3).get(2).toString(), "travelrecord.traveldate = 2015-05-04 00:00:07.375");
 		Assert.assertEquals(list.get(3).get(3).toString(), "travelrecord.id = (1, 2)");
-		
+
 		Assert.assertEquals(list.get(4).get(0).toString(), "travelrecord.user_id = 2");
 		Assert.assertEquals(list.get(4).get(1).toString(), "travelrecord.traveldate = 2015-05-04 00:00:07.375");
 		Assert.assertEquals(list.get(4).get(2).toString(), "travelrecord.id = (1, 2)");
 
 		System.out.println(list.size());
 	}
-	
+
 	/**
 	 * 1层嵌套or语句
 	 */
@@ -86,23 +85,23 @@ public class MycatSchemaStatVisitorTest {
 		String sql = "select id from travelrecord "
     			+ " where id = 1 and ( fee=3 or days=5 or name = 'zhangsan')" ;
 		List<List<Condition>> list = getConditionList(sql);
-		
+
 		Assert.assertEquals(list.size(), 3);
 		Assert.assertEquals(list.get(0).size(), 2);
 		Assert.assertEquals(list.get(1).size(), 2);
 		Assert.assertEquals(list.get(2).size(), 2);
 
-		
+
 		Assert.assertEquals(list.get(0).get(0).toString(), "travelrecord.name = zhangsan");
 		Assert.assertEquals(list.get(0).get(1).toString(), "travelrecord.id = 1");
-		
+
 		Assert.assertEquals(list.get(1).get(0).toString(), "travelrecord.days = 5");
 		Assert.assertEquals(list.get(1).get(1).toString(), "travelrecord.id = 1");
-		
+
 		Assert.assertEquals(list.get(2).get(0).toString(), "travelrecord.fee = 3");
 		Assert.assertEquals(list.get(2).get(1).toString(), "travelrecord.id = 1");
 	}
-	
+
 	/**
 	 * 1层嵌套or语句
 	 */
@@ -111,21 +110,146 @@ public class MycatSchemaStatVisitorTest {
 		String sql = "select id from travelrecord "
     			+ " where id = 1 and fee=3 or days=5 or name = 'zhangsan'" ;
 		List<List<Condition>> list = getConditionList(sql);
-		
+
 		Assert.assertEquals(list.size(), 3);
-		
+
 		Assert.assertEquals(list.get(0).size(), 1);
 		Assert.assertEquals(list.get(1).size(), 1);
 		Assert.assertEquals(list.get(2).size(), 2);
 
 		Assert.assertEquals(list.get(0).get(0).toString(), "travelrecord.name = zhangsan");
-		
+
 		Assert.assertEquals(list.get(1).get(0).toString(), "travelrecord.days = 5");
-		
+
 		Assert.assertEquals(list.get(2).get(0).toString(), "travelrecord.id = 1");
 		Assert.assertEquals(list.get(2).get(1).toString(), "travelrecord.fee = 3");
 	}
-	
+
+	String sql = "select count(*) count from (select *\r\n"
+      + "          from (select b.sales_count,\r\n" + "                       b.special_type,\r\n"
+      + "                       a.prod_offer_id offer_id,\r\n"
+      + "                       a.alias_name as offer_name,\r\n"
+      + "                       (select c.attr_value_name\r\n"
+      + "                          from attr_value c\r\n"
+      + "                         where c.attr_id = '994001448'\r\n"
+      + "                           and c.attr_value = b.special_type) as attr_value_name,\r\n"
+      + "                       a.offer_type offer_kind,\r\n"
+      + "                       a.offer_comments,\r\n" + "                       a.is_ge\r\n"
+      + "                  from prod_offer a, special_offer b\r\n"
+      + "                 where a.prod_offer_id = b.prod_offer_id\r\n"
+      + "                   and (a.offer_type = '11' or a.offer_type = '10')\r\n"
+      + "                   and (b.region_id = '731' or b.region_id = '10000000')\r\n"
+      + "                   and a.status_cd = '10'\r\n"
+      + "                   and b.special_type = '0'\r\n" + "                union all\r\n"
+      + "                select b.sales_count,\r\n" + "                       b.special_type,\r\n"
+      + "                       a.prod_offer_id offer_id,\r\n"
+      + "                       a.alias_name as offer_name,\r\n"
+      + "                       (select c.attr_value_name\r\n"
+      + "                          from attr_value c\r\n"
+      + "                         where c.attr_id = '994001448'\r\n"
+      + "                           and c.attr_value = b.special_type) as attr_value_name,\r\n"
+      + "                       a.offer_type offer_kind,\r\n"
+      + "                       a.offer_comments,\r\n" + "                       a.is_ge\r\n"
+      + "                  from prod_offer a, special_offer b\r\n"
+      + "                 where a.prod_offer_id = b.prod_offer_id\r\n"
+      + "                   and (a.offer_type = '11' or a.offer_type = '10')\r\n"
+      + "                   and (b.region_id = '731' or b.region_id = '10000000')\r\n"
+      + "                   and a.status_cd = '10'\r\n"
+      + "                   and b.special_type = '1'\r\n"
+      + "                   and exists (select 1\r\n"
+      + "                          from prod_offer_channel l\r\n"
+      + "                         where a.prod_offer_id = l.prod_offer_id\r\n"
+      + "                           and l.channel_id = '11')\r\n"
+      + "                   and not exists\r\n" + "                 (select 1\r\n"
+      + "                          from product_offer_cat ml\r\n"
+      + "                         where ml.prod_offer_id = a.prod_offer_id\r\n"
+      + "                           and ml.offer_cat_type = '89')\r\n"
+      + "                   and (exists (select 1\r\n"
+      + "                                  from sales_restrication\r\n"
+      + "                                 where object_id = a.prod_offer_id\r\n"
+      + "                                   and domain_id = '1965868'\r\n"
+      + "                                   and restrication_flag = '0'\r\n"
+      + "                                   and domain_type = '19F'\r\n"
+      + "                                   and state = '00A') or exists\r\n"
+      + "                        (select 1\r\n"
+      + "                           from sales_restrication\r\n"
+      + "                          where object_id = a.prod_offer_id\r\n"
+      + "                            and domain_id = '843073100000000'\r\n"
+      + "                            and restrication_flag = '0'\r\n"
+      + "                            and domain_type = '19E'\r\n"
+      + "                            and state = '00A') or exists\r\n"
+      + "                        (select 1\r\n"
+      + "                           from sales_restrication\r\n"
+      + "                          where object_id = a.prod_offer_id\r\n"
+      + "                            and domain_id = '1965868'\r\n"
+      + "                            and restrication_flag = '0'\r\n"
+      + "                            and domain_type = '19X'\r\n"
+      + "                            and state = '00A'\r\n"
+      + "                            and (max_value = 1 or min_value = 1)\r\n"
+      + "                            and extended_field = '731') or exists\r\n"
+      + "                        (select 1\r\n"
+      + "                           from sales_restrication\r\n"
+      + "                          where object_id = a.prod_offer_id\r\n"
+      + "                            and domain_id = concat('-', '11')\r\n"
+      + "                            and restrication_flag = '0'\r\n"
+      + "                            and domain_type = '19F'\r\n"
+      + "                            and state = '00A') or not exists\r\n"
+      + "                        (select 1\r\n"
+      + "                           from sales_restrication\r\n"
+      + "                          where object_id = a.prod_offer_id\r\n"
+      + "                            and restrication_flag = '0'\r\n"
+      + "                            and (domain_type in ('19F', '19E') or\r\n"
+      + "                                (domain_type = '19X' and\r\n"
+      + "                                extended_field = '731' and\r\n"
+      + "                                (max_value = 1 or min_value = 1)))\r\n"
+      + "                            and state = '00A'))\r\n"
+      + "                   and not exists (select 1\r\n"
+      + "                          from sales_restrication\r\n"
+      + "                         where object_id = a.prod_offer_id\r\n"
+      + "                           and domain_id = '1965868'\r\n"
+      + "                           and restrication_flag = '1'\r\n"
+      + "                           and domain_type = '19F'\r\n"
+      + "                           and state = '00A')\r\n"
+      + "                   and not exists (select 1\r\n"
+      + "                          from sales_restrication\r\n"
+      + "                         where object_id = a.prod_offer_id\r\n"
+      + "                           and domain_id = '843073100000000'\r\n"
+      + "                           and restrication_flag = '1'\r\n"
+      + "                           and domain_type = '19E'\r\n"
+      + "                           and state = '00A')\r\n"
+      + "                   and not exists\r\n" + "                 (select 1\r\n"
+      + "                          from sales_restrication\r\n"
+      + "                         where object_id = a.prod_offer_id\r\n"
+      + "                           and domain_id = '1965868'\r\n"
+      + "                           and restrication_flag = '1'\r\n"
+      + "                           and domain_type = '19X'\r\n"
+      + "                           and state = '00A'\r\n"
+      + "                           and (min_value = 1 or max_value = 1)\r\n"
+      + "                           and extended_field = '731')\r\n"
+      + "                   and not exists (select 1\r\n"
+      + "                          from sales_restrication\r\n"
+      + "                         where object_id = a.prod_offer_id\r\n"
+      + "                           and domain_id = concat('-', '11')\r\n"
+      + "                           and restrication_flag = '1'\r\n"
+      + "                           and domain_type = '19F'\r\n"
+      + "                           and state = '00A')\r\n" + "                   and exists\r\n"
+      + "                 (select 1\r\n" + "                          from prod_offer_region v1\r\n"
+      + "                         where v1.prod_offer_id = a.prod_offer_id\r\n"
+      + "                           and (v1.common_region_id = '731' or\r\n"
+      + "                               v1.common_region_id = '10000000' or\r\n"
+      + "                               v1.common_region_id = '73101'))) t\r\n"
+      + "         order by t.sales_count desc)";
+
+	/**
+   * 8层以上 嵌套or语句
+   */
+  @Test
+  public void test5() {
+    List<List<Condition>> list = getConditionList(sql);
+
+    Assert.assertTrue(list.size() < 100);
+  }
+
 	private String getSchema(String sql) {
 		SQLStatementParser parser =null;
 		parser = new MySqlStatementParser(sql);
@@ -140,8 +264,8 @@ public class MycatSchemaStatVisitorTest {
 			e.printStackTrace();
 		}
 		statement.accept(visitor);
-		
-		
+
+
 		return visitor.getCurrentTable();
 	}
 
@@ -159,7 +283,7 @@ public class MycatSchemaStatVisitorTest {
 			e.printStackTrace();
 		}
 		statement.accept(visitor);
-		
+
 		List<List<Condition>> mergedConditionList = new ArrayList<List<Condition>>();
 		if(visitor.hasOrCondition()) {//包含or语句
 			//TODO
@@ -168,7 +292,7 @@ public class MycatSchemaStatVisitorTest {
 		} else {//不包含OR语句
 			mergedConditionList.add(visitor.getConditions());
 		}
-		
+
 		return mergedConditionList;
 	}
 }


### PR DESCRIPTION
已修正子查询加入逻辑 和 条件组合运算算法为 合并重复组合，不保留子集，只保留超集. by SvenAugustus

问题描述：
采用单元测试 MycatSchemaStatVisitorTest.test5() 
测试8层以上嵌套的sql，在本案例没提交前，发现mycat单机内存急剧飙升到700MB。
子查询达到14万之多。修正子查询逻辑后，条件组合仍达到33万之多。太恐怖了。

经分析子查询加入逻辑，以及条件组合算法有问题。
其中条件组合采用的是笛卡尔积，而条件组合目前只用于路由计算。
根据路由计算逻辑，如果 一个条件列表 是 另一个条件列表的 超集。其实计算 超集的 路由，再计算 子集的 路由就不需要。
因此，条件组合算法修正为：<合并重复组合，不保留子集，只保留超集>

单元测试MycatSchemaStatVisitorTest 通过。
