### PR TITLE
 增加开关以用来禁止MyCat中开事务后出现不能repeatable read的现象

### DIFF
--- a/src/main/java/io/mycat/config/model/SystemConfig.java
+++ b/src/main/java/io/mycat/config/model/SystemConfig.java
@@ -962,8 +962,7 @@ public final class SystemConfig {
 		return strictTxIsolation;
 	}
 
-	public SystemConfig setStrictTxIsolation(boolean strictTxIsolation) {
+	public void setStrictTxIsolation(boolean strictTxIsolation) {
 		this.strictTxIsolation = strictTxIsolation;
-		return this;
 	}
 }

--- a/src/main/java/io/mycat/config/model/SystemConfig.java
+++ b/src/main/java/io/mycat/config/model/SystemConfig.java
@@ -174,6 +174,8 @@ public final class SystemConfig {
 	
 	private long glableTableCheckPeriod;
 
+	// 如果为true的话 严格遵守隔离级别,不会在仅仅只有select语句的时候在事务中切换连接
+	private boolean strictTxIsolation = false;
 	/**
 	 * Mycat 使用 Off Heap For Merge/Order/Group/Limit计算相关参数
 	 */
@@ -955,6 +957,13 @@ public final class SystemConfig {
 	public void setSubqueryRelationshipCheck(boolean subqueryRelationshipCheck) {
 		this.subqueryRelationshipCheck = subqueryRelationshipCheck;
 	}
-	
-	
+
+	public boolean isStrictTxIsolation() {
+		return strictTxIsolation;
+	}
+
+	public SystemConfig setStrictTxIsolation(boolean strictTxIsolation) {
+		this.strictTxIsolation = strictTxIsolation;
+		return this;
+	}
 }

--- a/src/main/resources/server.xml
+++ b/src/main/resources/server.xml
@@ -70,7 +70,8 @@
 
 		<!-- XA Recovery Log日志名称 -->
 		<!--<property name="XARecoveryLogBaseName">tmlog</property>-->
-
+		<!--如果为 true的话 严格遵守隔离级别,不会在仅仅只有select语句的时候在事务中切换连接-->
+		<property name="strictTxIsolation">false</property>
 	</system>
 	
 	<!-- 全局SQL防火墙设置 -->


### PR DESCRIPTION
MyCat有一个特性，就是开事务之后，如果不运行update/delete/select for update等语句的话，不会将当前连接与当前session绑定。这就会导致两次select中如果有其它的在提交的话，会出现两次同样的select不一致的现象,即不能repeatable read。当然这个特性也是有用的，可以提高性能。但是会让人很困惑，因为和直连mysql有些不同,可能会在依赖repeatable read的场景出现问题。所以做了一个开关,当server.xml的system配置了strictTxIsolation=true的时候(<property name="strictTxIsolation">true</property>)，会关掉这个特性，以保证repeatable read