### PR TITLE
修复按DateTime字段排序的问题

### DIFF
--- a/src/main/java/io/mycat/sqlengine/mpp/RowDataPacketSorter.java
+++ b/src/main/java/io/mycat/sqlengine/mpp/RowDataPacketSorter.java
@@ -174,21 +174,22 @@ public class RowDataPacketSorter {
         case ColMeta.COL_TYPE_LONGLONG:
         case ColMeta.COL_TYPE_INT24:
         case ColMeta.COL_TYPE_NEWDECIMAL:
-            // 因为mysql的日期也是数字字符串方式表达，因此可以跟整数等一起对待
+        // 因为mysql的日期也是数字字符串方式表达，因此可以跟整数等一起对待
         case ColMeta.COL_TYPE_DATE:
         case ColMeta.COL_TYPE_TIMSTAMP:
         case ColMeta.COL_TYPE_TIME:
         case ColMeta.COL_TYPE_YEAR:
-        case ColMeta.COL_TYPE_DATETIME:
         case ColMeta.COL_TYPE_NEWDATE:
         case ColMeta.COL_TYPE_BIT:
 //            return BytesTools.compareTo(left,right);
         	return ByteUtil.compareNumberByte(left, right);
         case ColMeta.COL_TYPE_VAR_STRING:
         case ColMeta.COL_TYPE_STRING:
-            // ENUM和SET类型都是字符串，按字符串处理
+        // ENUM和SET类型都是字符串，按字符串处理
         case ColMeta.COL_TYPE_ENUM:
         case ColMeta.COL_TYPE_SET:
+        //MySQL与SQL Server的DateTime格式不同 需按字符串处理
+        case ColMeta.COL_TYPE_DATETIME:
             return BytesTools.compareTo(left,right);
             // BLOB相关类型和GEOMETRY类型不支持排序，略掉
         }


### PR DESCRIPTION
MySQL的DateTime与SQL Server的DateTime不一致，SQL Server中多出3位毫秒，如果按照数字对待会导致排序错乱，需要按字符串来比较。