### PR TITLE
修复控制台显示拼写错误

### DIFF
--- a/src/main/java/io/mycat/server/response/SelectVersionComment.java
+++ b/src/main/java/io/mycat/server/response/SelectVersionComment.java
@@ -38,7 +38,7 @@ import io.mycat.server.ServerConnection;
  */
 public class SelectVersionComment {
 
-    private static final byte[] VERSION_COMMENT = "MyCat Server (OpenCloundDB)".getBytes();
+    private static final byte[] VERSION_COMMENT = "MyCat Server (OpenCloudDB)".getBytes();
     private static final int FIELD_COUNT = 1;
     private static final ResultSetHeaderPacket header = PacketUtil.getHeader(FIELD_COUNT);
     private static final FieldPacket[] fields = new FieldPacket[FIELD_COUNT];


### PR DESCRIPTION
通过命令行连接mycat都会显示该拼写错误信息。