### PR TITLE
fix sequence duplication when clock backwards

### DIFF
--- a/src/main/java/io/mycat/route/sequence/handler/IncrSequenceTimeHandler.java
+++ b/src/main/java/io/mycat/route/sequence/handler/IncrSequenceTimeHandler.java
@@ -96,11 +96,9 @@ public class IncrSequenceTimeHandler implements SequenceHandler {
 		public synchronized long nextId() {
 			long timestamp = timeGen();
 			if (timestamp < lastTimestamp) {
-			try {
-				throw new Exception("Clock moved backwards.  Refusing to generate id for "+ (lastTimestamp - timestamp) + " milliseconds");
-			} catch (Exception e) {
-				LOGGER.error("error",e);
-			}
+				String errorMessage = "Clock moved backwards.  Refusing to generate id for "+ (lastTimestamp - timestamp) + " milliseconds";
+				LOGGER.error(errorMessage);
+				throw new RuntimeException(errorMessage);
 			}
 
 			if (lastTimestamp == timestamp) {


### PR DESCRIPTION
当使用服务器本地时间戳生成全局ID时，由于时间同步导致mycat服务器时间回退，mycat会使用回退后的时间生成全局ID，并进行数据插入等操作；该操作可能导致全局ID与之前生成的重复；而 客户端/业务服务器 对此一无所知。