### PR TITLE
fix mergAvg for on heap merge

### DIFF
--- a/src/main/java/io/mycat/sqlengine/mpp/RowDataPacketGrouper.java
+++ b/src/main/java/io/mycat/sqlengine/mpp/RowDataPacketGrouper.java
@@ -33,7 +33,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-
+import java.util.TreeSet;
 
 import io.mycat.net.mysql.RowDataPacket;
 import io.mycat.util.ByteUtil;
@@ -257,7 +257,7 @@ public class RowDataPacketGrouper {
 		
 		
 
-		Set<Integer> rmIndexSet = new HashSet<Integer>();
+		TreeSet<Integer> rmIndexSet = new TreeSet<Integer>();
 		for (MergeCol merg : mergCols) {
 			if(merg.mergeType==MergeCol.MERGE_AVG)
 			{
@@ -274,7 +274,8 @@ public class RowDataPacketGrouper {
 				}
 			}
 		}
-		for(Integer index : rmIndexSet) {
+		// remove by index from large to small, to make sure each element deleted correctly
+		for(int index : rmIndexSet.descendingSet()) {
 			toRow.fieldValues.remove(index);
 			toRow.fieldCount = toRow.fieldCount - 1;
 		}


### PR DESCRIPTION
```java
for(Integer index : rmIndexSet) {
	toRow.fieldValues.remove(index);
	toRow.fieldCount = toRow.fieldCount - 1;
}
```
以上的remove方法调用的是List.remove(Object o)，而非List.remove(int index)；所以无法达到删除的目的。
新实现的代码中，根据index从大到小删除，避免了元素移动使index变化导致的错误删除。