### PR TITLE
修改mysql压力大,心跳一直无法恢复正常

### DIFF
--- a/src/main/java/io/mycat/backend/heartbeat/MySQLHeartbeat.java
+++ b/src/main/java/io/mycat/backend/heartbeat/MySQLHeartbeat.java
@@ -27,15 +27,13 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
-
-import com.alibaba.fastjson.JSON;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.mycat.backend.datasource.PhysicalDBPool;
 import io.mycat.backend.datasource.PhysicalDatasource;
 import io.mycat.backend.mysql.nio.MySQLDataSource;
 import io.mycat.config.model.DataHostConfig;
-import io.mycat.util.TimeUtil;
 
 /**
  * @author mycat
@@ -122,13 +120,17 @@ public class MySQLHeartbeat extends DBHeartbeat {
 	 */
 	public void heartbeat() {
 		final ReentrantLock lock = this.lock;
-		lock.lock();
+		if(!lock.tryLock()){
+			return;
+		}
 		try {
 			if (isChecking.compareAndSet(false, true)) {
 				MySQLDetector detector = this.detector;
 				if (detector == null || detector.isQuit()) {
 					try {
 						detector = new MySQLDetector(this);
+						//由于没有设置导致无限循环. modifyBy zwy  todo 对应修改其他的心跳机制.
+						detector.setHeartbeatTimeout(this.getHeartbeatTimeout());
 						detector.heartbeat();
 					} catch (Exception e) {
 						LOGGER.warn(source.getConfig().toString(), e);
@@ -137,7 +139,7 @@ public class MySQLHeartbeat extends DBHeartbeat {
 					}
 					this.detector = detector;
 				} else {
-					detector.heartbeat();
+						detector.heartbeat();
 				}
 			} else {
 				MySQLDetector detector = this.detector;
@@ -170,9 +172,7 @@ public class MySQLHeartbeat extends DBHeartbeat {
 		if (this.status != OK_STATUS) {
 			switchSourceIfNeed("heartbeat error");
 		}
-//		String str = JSON.toJSONString(this);
 
-//		System.out.println(str);
 	}
 
 	private void setOk(MySQLDetector detector) {
@@ -210,7 +210,7 @@ public class MySQLHeartbeat extends DBHeartbeat {
 				//设置3秒钟之后重试.
 				if (detector != null && !detector.isQuit()) {
 	            	LOGGER.error("set Error " + errorCount + "  " +  this.source.getConfig() );
-					source.setHeartbeatRecoveryTime( TimeUtil.currentTimeMillis() + 3000);
+				//	source.setHeartbeatRecoveryTime( TimeUtil.currentTimeMillis() + 3000);
 	               // heartbeat(); // error count not enough, heart beat again
 	            }
 			} else {

--- a/src/main/java/io/mycat/manager/response/ShowHelp.java
+++ b/src/main/java/io/mycat/manager/response/ShowHelp.java
@@ -149,7 +149,8 @@ public final class ShowHelp {
         helps.put("show @@white", "show mycat white host ");
         helps.put("show @@white.set=?,?", "set mycat white host,[ip,user]");
 		helps.put("show @@directmemory=1 or 2", "show mycat direct memory usage");
-        
+		helps.put("show @@check_global -SCHEMA= ? -TABLE=? -retry=? -interval=?", "check mycat global table consistency ");
+
         // switch
         helps.put("switch @@datasource name:index", "Switch dataSource");
 


### PR DESCRIPTION
目前版本发现当mysql压力大的时候,mycat对于mysql的心跳检测会一直存在异常,原因是因为						detector.setHeartbeatTimeout(this.getHeartbeatTimeout());
 这个超时连接没有设置,导致所有的心跳检测一直都是超时的,导致心跳无法恢复正常.