### PR TITLE
修改解析sql时会产生死循环的bug

### DIFF
--- a/src/main/java/org/opencloudb/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/org/opencloudb/route/impl/DruidMycatRouteStrategy.java
@@ -334,6 +334,8 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 				} else {
 					pos++;
 				}
+			}else{
+				break;
 			}
 		}
 		


### PR DESCRIPTION
开发过程中如果sql语法不正确就有可能产生死循环，因为条件分支语句没有形成完整的闭环。
bug发现过程：
1.开发人员写了一条查询sql，执行没有响应；
2.运维人员查看mycat日志，并无发现异常；
3.运维尝试查看mycat的CPU使用率，结果100%一直持续；
4.找到占用cpu的线程号，使用jstack查看线程执行的堆栈情况，结果发现如下图：
![_20180801175106](https://user-images.githubusercontent.com/9315085/43514795-83a2192e-95b3-11e8-9be4-36326479ef03.png)
5.跟踪代码发现337行是while循环语句的结尾，得出结论：循环始终没有跳出；
6.再查看开发人员写的sql语句：and column = 1 desc limit 10,20（由于使用的DAO底层会自动补全select语句，所以开发人员忽略了，本身也是框架DAO层的bug），此sql语句没有被解析成正常的select语句，而是被解析成了describe语句，执行了 analyseDescrSQL方法，但由于条件分支没有一个满足，但代码又没给出默认的行为，所以循环一直没有跳出；
说明：这本身也不算做严格意义上的bug，因为是在开发期间发现的，按理说只要保证生产环境没有sql的语法错误就不会出现此类问题，但是站在以下两个层面，觉得有必要修复：
1：代码规范性，条件分支必须有完整的闭环，否则没有默认行为；
2：此类问题直接导致系统没有响应，没有语法错误提示，没有日志，排查困难，后续如果再有人遇到也是不必要的负担；
（1.5以后版本中DruidMycatRouteStrategy类中的analyseDescrSQL方法都存在此问题，希望考虑合并）