### PR TITLE
功能增强，按自然月分。不用配置开始和结束时间

### DIFF
--- a/src/test/java/io/mycat/route/function/PartitionByMonthTest.java
+++ b/src/test/java/io/mycat/route/function/PartitionByMonthTest.java
@@ -26,6 +26,8 @@ package io.mycat.route.function;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 public class PartitionByMonthTest {
 
 	@Test
@@ -84,5 +86,52 @@ public class PartitionByMonthTest {
 		Assert.assertEquals(true, 11 == partition.calculate("2015-12-11"));
 		Assert.assertEquals(true, 11 == partition.calculate("2016-12-31"));
 
+	}
+
+	/**
+	 * 范围对比
+	 */
+	@Test
+	public void sence1CalculateRangeContrastTest(){
+		// 场景1：无开始/结束时间，节点数量必须是12个，从1月~12月
+		PartitionByMonth partition = new PartitionByMonth();
+		partition.setDateFormat("yyyy-MM-dd");
+        partition.setsBeginDate("2013-01-01");
+        partition.setsEndDate("2013-12-01");
+		partition.init();
+
+		PartitionByMonth scene = new PartitionByMonth();
+		scene.setDateFormat("yyyy-MM-dd");
+		scene.init();
+		Assert.assertEquals(
+				Arrays.toString(partition.calculateRange("2014-01-01", "2014-04-03")),
+				Arrays.toString(scene.calculateRange("2014-01-01", "2014-04-03"))
+		);
+		Assert.assertEquals(
+				Arrays.toString(partition.calculateRange("2013-01-01", "2014-04-03")),
+				Arrays.toString(scene.calculateRange("2013-01-01", "2014-04-03"))
+		);
+//		Assert.assertEquals(
+//				// []
+//				Arrays.toString(partition.calculateRange("2015-01-01", "2014-04-03")),
+//				// null
+//				Arrays.toString(scene.calculateRange("2015-01-01", "2014-04-03"))
+//		);
+	}
+	@Test
+	public void sence1(){
+		PartitionByMonth scene = new PartitionByMonth();
+		scene.setDateFormat("yyyy-MM-dd");
+		scene.init();
+
+		Assert.assertEquals(true, 0 == scene.calculate("2014-01-01"));
+		Assert.assertEquals(true, 0 == scene.calculate("2014-01-10"));
+		Assert.assertEquals(true, 0 == scene.calculate("2014-01-31"));
+		Assert.assertEquals(true, 1 == scene.calculate("2014-02-01"));
+		Assert.assertEquals(true, 1 == scene.calculate("2014-02-28"));
+		Assert.assertEquals(true, 2 == scene.calculate("2014-03-1"));
+		Assert.assertEquals(true, 11 == scene.calculate("2014-12-31"));
+		Assert.assertEquals(true, 0 == scene.calculate("2015-01-31"));
+		Assert.assertEquals(true, 11 == scene.calculate("2015-12-31"));
 	}
 }


### PR DESCRIPTION
本pr只是增加了功能：场景1；外加文档说明

# 自然月
可设置属性：
* dateFormat  ： 日期格式化，默认为 yyyy-MM-dd
* sBeginDate  ： 开始日期，无默认值
* sEndDate   ：结束日期，无默认值

> 节点从0开始

## 场景1
默认设置；节点数量必须是12个，从1月~12月
* "2014-01-01" = 节点0
* "2013-01-01" = 节点0
* "2018-05-01" = 节点4
* "2019-12-01" = 节点11

## 场景2
sBeginDate = "2017-01-01"

该配置表示"2017-01月"是第0个节点，从该时间按月递增，无最大节点

*  "2014-01-01" = 未找到节点
*  "2017-01-01" = 节点0
*  "2017-12-01" = 节点11
*  "2018-01-01" = 节点12
*  "2018-12-01" = 节点23

## 场景3
sBeginDate = "2015-01-01"
sEndDate = "2015-12-01"

该配置可看成与场景1一致；场景1的配置效率更高
*  "2014-01-01" = 节点0
*  "2014-02-01" = 节点1
*  "2015-02-01" = 节点1
*  "2017-01-01" = 节点0
*  "2017-12-01" = 节点11
*  "2018-12-01" = 节点11

该配置可看成是与场景1一致

## 场景4
sBeginDate = "2015-01-01"
sEndDate = "2015-03-01"

该配置标识只有3个节点；很难与月份对应上；平均分散到3个节点上