### PR TITLE
修复聚合函数的问题

### DIFF
--- a/src/main/java/io/mycat/sqlengine/mpp/UnsafeRowGrouper.java
+++ b/src/main/java/io/mycat/sqlengine/mpp/UnsafeRowGrouper.java
@@ -768,16 +768,17 @@ public class UnsafeRowGrouper {
 							 bufferHolder.reset();
 							 for (int i = 0; i < toRow.numFields(); i++) {
 
-								 if (!toRow.isNullAt(i) && i != index) {
-									 unsafeRowWriter.write(i, toRow.getBinary(i));
-								 } else if (!toRow.isNullAt(i) && i == index) {
+								 if (i == index) {
 									 unsafeRowWriter.write(i,result);
+								 } else if (!toRow.isNullAt(i)) {
+									 unsafeRowWriter.write(i, toRow.getBinary(i));
 								 } else if (toRow.isNullAt(i)){
 									 unsafeRow.setNullAt(i);
 								 }
 							 }
 							 unsafeRow.setTotalSize(bufferHolder.totalSize());
 							 aggregationMap.put(key, unsafeRow);
+							 toRow = unsafeRow;
 							 break;
 						 default:
 							 break;

--- a/src/main/java/io/mycat/sqlengine/mpp/UnsafeRowGrouper.java
+++ b/src/main/java/io/mycat/sqlengine/mpp/UnsafeRowGrouper.java
@@ -655,8 +655,12 @@ public class UnsafeRowGrouper {
 					 case ColMeta.COL_TYPE_INT:
 					 case ColMeta.COL_TYPE_LONG:
 					 case ColMeta.COL_TYPE_INT24:
-						 left = BytesTools.int2Bytes(toRow.getInt(index));
-						 right = BytesTools.int2Bytes(newRow.getInt(index));
+						 if (!toRow.isNullAt(index)) {
+						 	left = BytesTools.int2Bytes(toRow.getInt(index));
+						 }
+						 if (!newRow.isNullAt(index)) {
+						 	right = BytesTools.int2Bytes(newRow.getInt(index));
+						 }
 						 break;
 					 case ColMeta.COL_TYPE_SHORT:
 						 left = BytesTools.short2Bytes(toRow.getShort(index));


### PR DESCRIPTION
当某些分片数据为空时，使用聚合函数结果异常。
1、数字类型
分片1：  select min(id) from user   mysql单独执行返回null
分片2：  select min(id) from user   mysql单独执行返回200
mycat： select min(id) from user    mycat执行返回0

1、非数字类型
分片1：  select min(id) from user   mysql单独执行返回null
分片2：  select min(id) from user   mysql单独执行返回‘200’
mycat： select min(id) from user    mycat执行返回null或‘200’
