### PR TITLE
1.6 now() function support

### DIFF
--- a/src/main/java/io/mycat/config/model/TableConfig.java
+++ b/src/main/java/io/mycat/config/model/TableConfig.java
@@ -153,17 +153,26 @@ public class TableConfig {
         StringBuilder tableSb = new StringBuilder();
         StringBuilder condition = new StringBuilder();
         TableConfig prevTC = null;
+        String ancestorTableName = null;
         int level = 0;
         String latestCond = null;
         while (tb.parentTC != null) {
-            tableSb.append(tb.parentTC.name).append(',');
+            ancestorTableName = tb.parentTC.name;
+            String currentTableName = tb.name;
+            if (!ancestorTableName.contains("`")){
+                ancestorTableName = "`"+ancestorTableName+"`";
+            }
+            if (!currentTableName.contains("`")){
+                currentTableName = "`"+currentTableName+"`";
+            }
+            tableSb.append(ancestorTableName).append(',');
             String relation = null;
             if (level == 0) {
-                latestCond = " " + tb.parentTC.getName() + '.' + tb.parentKey
+                latestCond = " " + ancestorTableName + '.' + tb.parentKey
                         + "=";
             } else {
-                relation = tb.parentTC.getName() + '.' + tb.parentKey + '='
-                        + tb.name + '.' + tb.joinKey;
+                relation = ancestorTableName + '.' + tb.parentKey + '='
+                        + currentTableName + '.' + tb.joinKey;
                 condition.append(relation).append(" AND ");
             }
             level++;
@@ -171,7 +180,7 @@ public class TableConfig {
             tb = tb.parentTC;
         }
         String sql = "SELECT "
-                + prevTC.parentTC.name
+                + ancestorTableName
                 + '.'
                 + prevTC.parentKey
                 + " FROM "

--- a/src/main/java/io/mycat/route/parser/druid/DruidParserFactory.java
+++ b/src/main/java/io/mycat/route/parser/druid/DruidParserFactory.java
@@ -1,11 +1,5 @@
 package io.mycat.route.parser.druid;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLAlterTableStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
@@ -15,21 +9,15 @@ import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlInsertStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlLockTableStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlUpdateStatement;
 import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
-
 import io.mycat.config.model.SchemaConfig;
 import io.mycat.config.model.TableConfig;
-import io.mycat.route.parser.druid.impl.DefaultDruidParser;
-import io.mycat.route.parser.druid.impl.DruidAlterTableParser;
-import io.mycat.route.parser.druid.impl.DruidCreateTableParser;
-import io.mycat.route.parser.druid.impl.DruidDeleteParser;
-import io.mycat.route.parser.druid.impl.DruidInsertParser;
-import io.mycat.route.parser.druid.impl.DruidLockTableParser;
-import io.mycat.route.parser.druid.impl.DruidSelectDb2Parser;
-import io.mycat.route.parser.druid.impl.DruidSelectOracleParser;
-import io.mycat.route.parser.druid.impl.DruidSelectParser;
-import io.mycat.route.parser.druid.impl.DruidSelectPostgresqlParser;
-import io.mycat.route.parser.druid.impl.DruidSelectSqlServerParser;
-import io.mycat.route.parser.druid.impl.DruidUpdateParser;
+import io.mycat.route.parser.druid.impl.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * DruidParser的工厂类
@@ -104,6 +92,7 @@ public class DruidParserFactory
             if (dbTypes.contains("oracle"))
             {
                 parser = new DruidSelectOracleParser();
+                ((DruidSelectOracleParser)parser).setInvocationHandler(SqlMethodInvocationHandlerFactory.getForOracle());
                 break;
             } else if (dbTypes.contains("db2"))
             {
@@ -116,6 +105,7 @@ public class DruidParserFactory
             } else if (dbTypes.contains("postgresql"))
             {
                 parser = new DruidSelectPostgresqlParser();
+                ((DruidSelectPostgresqlParser)parser).setInvocationHandler(SqlMethodInvocationHandlerFactory.getForPgsql());
                 break;
             }
         }

--- a/src/main/java/io/mycat/route/parser/druid/SqlMethodInvocationHandler.java
+++ b/src/main/java/io/mycat/route/parser/druid/SqlMethodInvocationHandler.java
@@ -1,0 +1,21 @@
+package io.mycat.route.parser.druid;
+
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+
+import java.sql.SQLNonTransientException;
+
+/**
+ * 调用sql函数如now()等
+ *
+ * @author zhuyiqiang
+ * @version 2018/9/3
+ */
+public interface SqlMethodInvocationHandler {
+    /**
+     * 调用sql函数，返回结果
+     * @param expr 函数表达式
+     * @return 执行结果
+     * @throws SQLNonTransientException
+     */
+    String invoke(SQLMethodInvokeExpr expr) throws SQLNonTransientException;
+}

--- a/src/main/java/io/mycat/route/parser/druid/SqlMethodInvocationHandlerFactory.java
+++ b/src/main/java/io/mycat/route/parser/druid/SqlMethodInvocationHandlerFactory.java
@@ -1,0 +1,29 @@
+package io.mycat.route.parser.druid;
+
+import io.mycat.route.parser.druid.impl.MysqlMethodInvocationHandler;
+import io.mycat.route.parser.druid.impl.OracleMethodInvocationHandler;
+import io.mycat.route.parser.druid.impl.PgsqlMethodInvocationHandler;
+
+/**
+ * 按不同的db生成对应的sql函数处理器
+ *
+ * @author zhuyiqiang
+ * @version 2018/9/5
+ */
+public class SqlMethodInvocationHandlerFactory {
+    private static MysqlMethodInvocationHandler mysql = new MysqlMethodInvocationHandler();
+    private static OracleMethodInvocationHandler oracle = new OracleMethodInvocationHandler();
+    private static PgsqlMethodInvocationHandler pgsql = new PgsqlMethodInvocationHandler();
+
+    public static MysqlMethodInvocationHandler getForMysql() {
+        return mysql;
+    }
+
+    public static OracleMethodInvocationHandler getForOracle() {
+        return oracle;
+    }
+
+    public static PgsqlMethodInvocationHandler getForPgsql() {
+        return pgsql;
+    }
+}

--- a/src/main/java/io/mycat/route/parser/druid/impl/DruidInsertParser.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/DruidInsertParser.java
@@ -321,8 +321,10 @@ public class DruidInsertParser extends DefaultDruidParser {
 			SQLCharExpr charExpr = (SQLCharExpr)expr;
 			shardingValue = charExpr.getText();
 		} else if (expr instanceof SQLMethodInvokeExpr) {
-			SQLMethodInvokeExpr charExpr = (SQLMethodInvokeExpr)expr;
-			shardingValue = tryInvokeSQLMethod(charExpr);
+			SQLMethodInvokeExpr methodInvokeExpr = (SQLMethodInvokeExpr)expr;
+			shardingValue = tryInvokeSQLMethod(methodInvokeExpr);
+		} else {
+			shardingValue = expr.toString();
 		}
 		return shardingValue;
 	}

--- a/src/main/java/io/mycat/route/parser/druid/impl/MysqlMethodInvocationHandler.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/MysqlMethodInvocationHandler.java
@@ -1,0 +1,115 @@
+package io.mycat.route.parser.druid.impl;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlIntervalExpr;
+import io.mycat.route.parser.druid.SqlMethodInvocationHandler;
+import org.apache.commons.lang.time.DateFormatUtils;
+import org.apache.commons.lang.time.DateUtils;
+
+import java.sql.SQLNonTransientException;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * mysql函数调用
+ *
+ * @author zhuyiqiang
+ * @version 2018/9/3
+ */
+public class MysqlMethodInvocationHandler implements SqlMethodInvocationHandler {
+    private final String[] SUPPORT_PATTERNS = {
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-dd",
+            "yyyy-MM-dd HH:mm"
+    };
+
+    @Override
+    public String invoke(SQLMethodInvokeExpr expr) throws SQLNonTransientException {
+        SQLExpr ret = doInvoke(expr);
+        if (ret != null) {
+            return ret.toString();
+        }
+        throw new SQLNonTransientException("unsupported mysql function expression: " + expr.toString());
+    }
+
+    private SQLExpr doInvoke(SQLMethodInvokeExpr expr) throws SQLNonTransientException {
+        String methodName = expr.getMethodName().toUpperCase();
+        switch (methodName) {
+            case "NOW":
+            case "SYSDATE":
+            case "CURRENT_TIMESTAMP":
+                return invokeNow();
+            case "ADDDATE":
+            case "DATE_ADD":
+                return invokeAddDate(expr, false);
+            case "SUBDATE":
+            case "DATE_SUB":
+                return invokeAddDate(expr, true);
+        }
+        return null;
+    }
+
+    private SQLExpr invokeNow() {
+        String time = DateFormatUtils.format(new Date(), "yyyy-MM-dd HH:mm:ss");
+        return new SQLCharExpr(time);
+    }
+
+    private SQLExpr invokeAddDate(SQLMethodInvokeExpr expr, boolean negative) throws SQLNonTransientException {
+        List<SQLExpr> parameters = expr.getParameters();
+        if (parameters.size() != 2) {
+            throwSyntaxError(expr);
+        }
+        SQLExpr p1 = parameters.get(0);
+        SQLExpr p2 = parameters.get(1);
+        if (p1 instanceof SQLMethodInvokeExpr) {
+            p1 = doInvoke((SQLMethodInvokeExpr) p1);
+        }
+        if (p1 instanceof SQLCharExpr) {
+            String time = ((SQLCharExpr) p1).getText();
+            Integer delta = null;
+            String unit = null;
+            if (p2 instanceof SQLIntegerExpr) {
+                delta = (Integer) ((SQLIntegerExpr) p2).getNumber();
+                unit = "DAY";
+            } else if (p2 instanceof MySqlIntervalExpr) {
+                SQLIntegerExpr value = (SQLIntegerExpr) ((MySqlIntervalExpr) p2).getValue();
+                delta = (Integer) value.getNumber();
+                unit = ((MySqlIntervalExpr) p2).getUnit().name();
+            } else {
+                throwSyntaxError(p2);
+            }
+            try {
+                Date date = DateUtils.parseDate(time, SUPPORT_PATTERNS);
+                Date result;
+                delta = negative ? -delta : delta;
+                if ("MONTH".equals(unit)) {
+                    result = DateUtils.addMonths(date, delta);
+                } else if ("DAY".equals(unit)) {
+                    result = DateUtils.addDays(date, delta);
+                } else if ("HOUR".equals(unit)) {
+                    result = DateUtils.addHours(date, delta);
+                } else if ("MINUTE".equals(unit)) {
+                    result = DateUtils.addMinutes(date, delta);
+                } else if ("SECOND".equals(unit)) {
+                    result = DateUtils.addSeconds(date, delta);
+                } else {
+                    return null;
+                }
+                String ret = DateFormatUtils.format(result, "yyyy-MM-dd HH:mm:ss");
+                return new SQLCharExpr(ret);
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
+    }
+
+    private void throwSyntaxError(SQLExpr expr) throws SQLNonTransientException {
+        String errMsg = "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '" + expr + "' at line 1";
+        throw new SQLNonTransientException(errMsg);
+    }
+}

--- a/src/main/java/io/mycat/route/parser/druid/impl/OracleMethodInvocationHandler.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/OracleMethodInvocationHandler.java
@@ -1,0 +1,19 @@
+package io.mycat.route.parser.druid.impl;
+
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import io.mycat.route.parser.druid.SqlMethodInvocationHandler;
+
+import java.sql.SQLNonTransientException;
+
+/**
+ * oracle函数调用
+ *
+ * @author zhuyiqiang
+ * @version 2018/9/3
+ */
+public class OracleMethodInvocationHandler implements SqlMethodInvocationHandler {
+    @Override
+    public String invoke(SQLMethodInvokeExpr expr) throws SQLNonTransientException {
+        return null;
+    }
+}

--- a/src/main/java/io/mycat/route/parser/druid/impl/PgsqlMethodInvocationHandler.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/PgsqlMethodInvocationHandler.java
@@ -1,0 +1,19 @@
+package io.mycat.route.parser.druid.impl;
+
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import io.mycat.route.parser.druid.SqlMethodInvocationHandler;
+
+import java.sql.SQLNonTransientException;
+
+/**
+ * PostgreSQL函数调用
+ *
+ * @author zhuyiqiang
+ * @version 2018/9/3
+ */
+public class PgsqlMethodInvocationHandler implements SqlMethodInvocationHandler {
+    @Override
+    public String invoke(SQLMethodInvokeExpr expr) throws SQLNonTransientException {
+        return null;
+    }
+}


### PR DESCRIPTION
1. 增加now(), sysdate(), current_timestamp(), adddate(), date_add(), subdate(), date_sub()函数的支持，包括insert语句和批量insert语句。由于目前mycat不支持update分片字段的值，故update语句未做处理。是否支持这些函数对select语句影响不大，故select语句也未做处理。
2. bug修复：表名包含关键字(如order)，子表插入数据时，会检测父表是否含有对应的记录，此时mycat发出的查询sql抛语法错误。已修正。