### PR TITLE
修改JDBC连接PostgreSQL时BLOB字段无法正常存取问题

### DIFF
--- a/src/main/java/io/mycat/backend/jdbc/AbstractSqlBinary4PgRewriter.java
+++ b/src/main/java/io/mycat/backend/jdbc/AbstractSqlBinary4PgRewriter.java
@@ -1,0 +1,73 @@
+package io.mycat.backend.jdbc;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
+import com.alibaba.druid.sql.ast.expr.SQLHexExpr;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlCharExpr;
+
+import java.sql.*;
+
+public abstract class AbstractSqlBinary4PgRewriter implements SqlRewriter {
+	public abstract String rewrite(Connection con, String origSQL, String charset) throws SQLException;
+
+	protected SQLMethodInvokeExpr genDecodeHex(SQLExpr sqlExpr) {
+		SQLMethodInvokeExpr newSqlExpr = new SQLMethodInvokeExpr();
+		newSqlExpr.setMethodName("decode");
+
+		SQLCharExpr para = new SQLCharExpr();
+		para.setText(((SQLHexExpr) sqlExpr).getHex());
+		newSqlExpr.addParameter(para);
+
+		para = new SQLCharExpr();
+		para.setText("hex");
+		newSqlExpr.addParameter(para);
+
+		return newSqlExpr;
+	}
+
+
+	protected SQLMethodInvokeExpr genConvertFrom(SQLExpr sqlExpr, String charSet) {
+		SQLMethodInvokeExpr newSqlExpr = new SQLMethodInvokeExpr();
+		newSqlExpr.setMethodName("convert_from");
+
+		newSqlExpr.addParameter(sqlExpr);
+
+		SQLCharExpr para = new SQLCharExpr();
+		para.setText(charSet);
+		newSqlExpr.addParameter(para);
+
+		return newSqlExpr;
+	}
+
+	protected void CleanBinaryCharset(MySqlCharExpr charExpr) {
+		if (charExpr.getCharset().compareToIgnoreCase("_binary") == 0 ) {
+			charExpr.setCharset(null);
+		}
+	}
+
+	protected SQLMethodInvokeExpr genMethodExpr4Hex(int colType, SQLExpr sqlExpr, String charset) {
+		switch (colType) {
+			case Types.ARRAY:
+			case Types.BIT:
+				return null;
+			case Types.BINARY:
+			case Types.VARBINARY:
+			case Types.LONGVARBINARY:
+			case Types.BLOB:
+				return genDecodeHex(sqlExpr);
+			default:
+				return genConvertFrom(genDecodeHex(sqlExpr), charset);
+		}
+	}
+	protected  int getColumnDataTye(Connection con, String tabName, String colName) throws SQLException {
+		int dataType = Types.BINARY;
+		DatabaseMetaData metaData = con.getMetaData();
+		ResultSet rs = metaData.getColumns(null, null, tabName.toLowerCase(), colName.toLowerCase());
+		while (rs.next()) {
+			dataType = rs.getInt("DATA_TYPE");
+		}
+		rs.close();
+		return dataType;
+	}
+}

--- a/src/main/java/io/mycat/backend/jdbc/InsertSqlBinary4PgRewriter.java
+++ b/src/main/java/io/mycat/backend/jdbc/InsertSqlBinary4PgRewriter.java
@@ -1,0 +1,64 @@
+package io.mycat.backend.jdbc;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLHexExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlCharExpr;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+public class InsertSqlBinary4PgRewriter extends AbstractSqlBinary4PgRewriter {
+	@Override
+	public String rewrite(Connection con, String origSQL, String charset) throws SQLException {
+		SQLStatement sqlStatement = null;
+
+		//尝试以MySQL讲法解析语句,如何解析通过,则进行有关"X'"与"_binary"的替换
+		try {
+			SQLStatementParser parser  = new MySqlStatementParser(origSQL);
+			sqlStatement = parser.parseStatement();
+		} catch (Throwable e) {
+			return origSQL;
+		}
+
+		if (!(sqlStatement instanceof SQLInsertStatement)) {
+			return origSQL;
+		}
+
+		SQLInsertStatement statement = (SQLInsertStatement) sqlStatement;
+		List<SQLInsertStatement.ValuesClause> valuesClauseList = statement.getValuesList();
+		String tabName = statement.getTableName().getSimpleName();
+		List<SQLExpr> colExprs = statement.getColumns();
+
+		boolean isRewrite = false;
+		for (int i = 0; i < valuesClauseList.size(); i++) {
+			SQLInsertStatement.ValuesClause valuesClause = valuesClauseList.get(i);
+			List<SQLExpr> values = valuesClause.getValues();
+			for (int j = 0; j < values.size(); j++) {
+				SQLExpr sqlExpr = values.get(j);
+				if (sqlExpr instanceof SQLHexExpr) {
+					String colName = ((SQLIdentifierExpr)colExprs.get(j)).getName();
+					int colType = getColumnDataTye(con, tabName, colName);
+					SQLExpr newSqlExpr =  super.genMethodExpr4Hex(colType, sqlExpr, charset);
+					if (newSqlExpr != null) {
+						values.set(j, newSqlExpr);
+						isRewrite = true;
+					}
+				} else if (sqlExpr instanceof MySqlCharExpr) {
+					super.CleanBinaryCharset( (MySqlCharExpr) sqlExpr);
+					isRewrite = true;
+				}
+			}
+		}
+
+		if (isRewrite) {
+			return sqlStatement.toString();
+		}
+		return origSQL;
+	}
+}

--- a/src/main/java/io/mycat/backend/jdbc/JDBCConnection.java
+++ b/src/main/java/io/mycat/backend/jdbc/JDBCConnection.java
@@ -69,6 +69,9 @@ public class JDBCConnection implements BackendConnection {
 
 	private NIOProcessor processor;
 
+	private InsertSqlBinary4PgRewriter insertSqlBinary4PgRewriter = new InsertSqlBinary4PgRewriter();
+	private UpdateSqlBinary4PgRewriter updateSqlBinary4PgRewriter = new UpdateSqlBinary4PgRewriter();
+
 	public NIOProcessor getProcessor() {
 		return processor;
 	}
@@ -322,6 +325,18 @@ public class JDBCConnection implements BackendConnection {
 					ouputResultSet(sc, orgin);
 				}
 			} else {
+				//如果Backend数据库类型是postgresql且SQL语句中存在"X'"或"_binary'", 则需要改写SQL
+				if ("postgresql".equalsIgnoreCase(dbType) &&
+						(orgin.indexOf("X'") >= 0 || orgin.indexOf("_binary'") >= 0)) {
+					switch (sqlType) {
+						case ServerParse.INSERT:
+							orgin = insertSqlBinary4PgRewriter.rewrite(con, orgin, sc.getCharset());
+							break;
+						case ServerParse.UPDATE:
+							orgin = updateSqlBinary4PgRewriter.rewrite(con, orgin, sc.getCharset());
+							break;
+					}
+				}
 				executeddl(sc, orgin);
 			}
 

--- a/src/main/java/io/mycat/backend/jdbc/SqlRewriter.java
+++ b/src/main/java/io/mycat/backend/jdbc/SqlRewriter.java
@@ -1,0 +1,8 @@
+package io.mycat.backend.jdbc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface SqlRewriter {
+	public String rewrite(Connection con, String origSQL, String charset) throws SQLException;
+}

--- a/src/main/java/io/mycat/backend/jdbc/UpdateSqlBinary4PgRewriter.java
+++ b/src/main/java/io/mycat/backend/jdbc/UpdateSqlBinary4PgRewriter.java
@@ -1,0 +1,81 @@
+package io.mycat.backend.jdbc;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLHexExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.expr.SQLListExpr;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateSetItem;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlCharExpr;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+public class UpdateSqlBinary4PgRewriter extends AbstractSqlBinary4PgRewriter {
+	@Override
+	public String rewrite(Connection con, String origSQL, String charset) throws SQLException {
+		SQLStatement sqlStatement = null;
+
+		//尝试以MySQL讲法解析语句,如何解析通过,则进行有关"X'"与"_binary"的替换
+		try {
+			SQLStatementParser parser  = new MySqlStatementParser(origSQL);
+			sqlStatement = parser.parseStatement();
+		} catch (Throwable e) {
+			return origSQL;
+		}
+
+		if (!(sqlStatement instanceof SQLUpdateStatement)) {
+			return origSQL;
+		}
+
+		SQLUpdateStatement statement = (SQLUpdateStatement) sqlStatement;
+		List<SQLUpdateSetItem> updateSetItems =  statement.getItems();
+		String tabName = statement.getTableName().getSimpleName();
+
+		boolean isRewrite = false;
+		for (int i = 0 ; i < updateSetItems.size(); i++) {
+			SQLUpdateSetItem updateSetItem = updateSetItems.get(i);
+			SQLExpr sqlExpr = updateSetItem.getValue();
+
+			if (sqlExpr instanceof SQLHexExpr) {
+				String colName = ((SQLIdentifierExpr)updateSetItem.getColumn()).getName();
+				int colType = getColumnDataTye(con, tabName, colName);
+				SQLExpr newSqlExpr =  super.genMethodExpr4Hex(colType, sqlExpr, charset);
+				if (newSqlExpr != null) {
+					updateSetItem.setValue(newSqlExpr);
+					isRewrite = true;
+				}
+			} else if (sqlExpr instanceof MySqlCharExpr) {
+				super.CleanBinaryCharset((MySqlCharExpr)sqlExpr);
+				isRewrite = true;
+			} else if (sqlExpr instanceof SQLListExpr) {
+				List<SQLExpr> colExprs = ((SQLListExpr)updateSetItem.getColumn()).getItems();
+				List<SQLExpr> valExprs = ((SQLListExpr) sqlExpr).getItems();
+				for (int j = 0; j < valExprs.size(); j++) {
+					SQLExpr sqlExpr2 = valExprs.get(j);
+					if (sqlExpr2 instanceof SQLHexExpr) {
+						String colName = ((SQLIdentifierExpr)colExprs.get(j)).getName();
+						int colType = getColumnDataTye(con, tabName, colName);
+						SQLExpr newSqlExpr =  super.genMethodExpr4Hex(colType, sqlExpr2, charset);
+						if (newSqlExpr != null) {
+							valExprs.set(j, newSqlExpr);
+							isRewrite = true;
+						}
+					} else if (sqlExpr2 instanceof MySqlCharExpr) {
+						super.CleanBinaryCharset((MySqlCharExpr)sqlExpr2);
+						isRewrite = true;
+					}
+				}
+			}
+		}
+
+		if (isRewrite) {
+			return sqlStatement.toString();
+		}
+		return origSQL;
+	}
+}

--- a/src/main/java/io/mycat/util/MysqlDefs.java
+++ b/src/main/java/io/mycat/util/MysqlDefs.java
@@ -342,6 +342,10 @@ public final class MysqlDefs {
 				return javaType;
 			}
 		}
+		case Types.BINARY:
+		case Types.VARBINARY: {  //Types.BINRARY makes the last mysql column type GEOMETRY, NOT BLOB or Binary
+			return Types.LONGVARBINARY;
+		}
 		default: {
 			return javaType;
 		}


### PR DESCRIPTION
又基于TAG 1.6.6-druid代码基础做了修改

在通过MyCAT保存BLOB(mysql类型)到PostgreSQL时会出现报错,是因为语句转到JDBC发往PostgreSQL时,BLOB字段数值会以:

十六进制串加上"X"前缀 (MyCat Server端prepare语句)
或字符串明文加上"_binary"前缀 (MySQL JDBC客户端prepare语句)
的方式出现在语句中, 而PostgreSQL不识别"_binary"前缀, 在字段类型为bytea时不支持"X"前缀,在字段类型为Char/Varchar/Text时将"X"前缀误解成bit类型前缀.

因些对此种情况做了代码修改. 在语句中发现这两个前缀时,对语句进行解析,并从Postgresq数据库中获取对应字段实际类型,做出相应语句重写.