### PR TITLE
当后端连接不能在同个事务中被复用时，应该产生警告日志

### DIFF
--- a/src/main/java/io/mycat/server/NonBlockingSession.java
+++ b/src/main/java/io/mycat/server/NonBlockingSession.java
@@ -464,9 +464,9 @@ public class NonBlockingSession implements Session {
             conn.setAttachment(node);
             return true;
         } else {
-            // slavedb connection and can't use anymore ,release it
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("release slave connection,can't be used in trasaction  "
+            // Previous connection and can't use anymore ,release it
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Release previous connection,can't be used in trasaction  "
                         + conn + " for " + node);
             }
             releaseConnection(node, LOGGER.isDebugEnabled(), false);


### PR DESCRIPTION
在做读写分离时，我们采用了以下方案，在dataHost上配置了balance=0, 默认禁用读写分离，然后只有带有/*#mycat:db_type=slave*/的语句才会被分发到readHost，希望这样逐步放开读流量可以避免全部迁移带来的影响。

     <dataHost name="masterFirst" maxCon="100" minCon="50" balance="0" tempReadHostAvailable="1"
                writeType="0" dbType="mysql" dbDriver="native" switchType="-1"  slaveThreshold="10">
          <writeHost host=mysqla>
                <readHost host=mysqlb/>
          </writeHost>
    ....

但是测试发现部分事务会丢失记录，通过分析发现部分经过MyCAT的事务会被一条rollback回滚。经过分析，是以下模式的事务会被回滚:
 
    1. set autocommit=0;
    2. INSERT INTO tablea ...
    3. /*#mycat:db_type=slave*/SELECT xx from tableb
    4. COMMIT

在MySQL端看到以上序列会变为以下模式，在writeHost上

    1. set autocommit=0;INSERT INTO tablea ...
    2. ROLLBACK

在readHost上

    1. SELECT xx from tableb

这样，插入到表tablea的数据就丢了。而此时，业务服务器，MyCAT服务器和MySQL端都无任何错误日志。
经过分析，发现是MyCAT对以上场景的处理逻辑如下
* MyCAT在一个连接到MySQL writeHost的连接内碰到一个到readHost的语句
* MyCAT释放writeHost连接回连接池，而释放连接会发起rollback（这是为什么会多一个rollback的原因）
* MyCAT新建到readHost的连接，并执行到readHost的语句

这个逻辑应该是没有问题的，因为MyCAT要保证在一个前端事务边界内(面向应用)任一时刻只能关联同一个后端连接(到MySQL)。而根源是应用程序做读写分离用法上的问题。但是[NonBlockingSession.java代码](https://github.com/MyCATApache/Mycat-Server/blob/fc63d9536cd171e399fa523da97aaba4d8bec81a/src/main/java/io/mycat/server/NonBlockingSession.java#L468)在释放并切换连接只产生了一行debug日志，导致我们在丢失数据的时候在所有地方都找不到错误日志。所以debug级别明显不利于排查。 

而在一个事务中在多个后端连接上进行切换，并在切换连接时会产生事务回滚，这完全是值得发起警告的行为！所以建议将此处的日志级别提升为警告级别，以便让使用者碰到类似行为时可以在MyCAT日志中发现问题来进行更快速的定位和处理。


