### PR TITLE
update about clear tableID2DataNodeCache when parse delete or update SQL

### DIFF
--- a/src/main/java/io/mycat/cache/DefaultLayedCachePool.java
+++ b/src/main/java/io/mycat/cache/DefaultLayedCachePool.java
@@ -162,4 +162,10 @@ public class DefaultLayedCachePool implements LayerCachePool {
 		return maxSize;
 	}
 
+	//clear cache by cacheName
+	public void clearCache(String cacheName) {
+		LOGGER.info("clear cache :"+cacheName);
+		CachePool pool = getCache(cacheName);
+		pool.clearCache();
+	}
 }

--- a/src/main/java/io/mycat/config/Versions.java
+++ b/src/main/java/io/mycat/config/Versions.java
@@ -32,7 +32,7 @@ public abstract class Versions {
     public static final byte PROTOCOL_VERSION = 10;
 
     /**服务器版本**/
-    public static byte[] SERVER_VERSION = "5.6.29-mycat-1.6.7.3-release-20190809210613".getBytes();
+    public static byte[] SERVER_VERSION = "5.6.29-mycat-1.6.7.3-release-20190814194820".getBytes();
 
     public static void setServerVersion(String version) {
         byte[] mysqlVersionPart = version.getBytes();

--- a/src/main/java/io/mycat/route/parser/druid/impl/DruidDeleteParser.java
+++ b/src/main/java/io/mycat/route/parser/druid/impl/DruidDeleteParser.java
@@ -5,6 +5,8 @@ import java.sql.SQLNonTransientException;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlDeleteStatement;
 
+import io.mycat.MycatServer;
+import io.mycat.cache.DefaultLayedCachePool;
 import io.mycat.config.model.SchemaConfig;
 import io.mycat.route.RouteResultset;
 import io.mycat.util.StringUtil;
@@ -15,6 +17,13 @@ public class DruidDeleteParser extends DefaultDruidParser {
 		MySqlDeleteStatement delete = (MySqlDeleteStatement)stmt;
 		String tableName = StringUtil.removeBackquote(delete.getTableName().getSimpleName().toUpperCase());
 		ctx.addTable(tableName);
+
+		//在解析SQL时清空该表的主键缓存
+		DefaultLayedCachePool tableID2DataNodeCache=(DefaultLayedCachePool) MycatServer.getInstance().getCacheService()
+				.getCachePool("TableID2DataNodeCache");
+		tableID2DataNodeCache.clearCache(schema.getName().toLowerCase()+"_"+tableName.toUpperCase());
+		tableID2DataNodeCache.getCacheStatic().reset();
+
 	}
 }
 


### PR DESCRIPTION
问题描述：
    TableId2DataNodeCache缓存表主键到datanode的关系，当分片键不在主键上，mycat使用主键缓存，通过主键去delete一条记录（假设主键缓存命中这条记录），那么这条数据被删除后，主键缓存中该条记录的主键缓存不会及时被删除，倘若在删除了之后又插入了一条主键与该主键相同的数据，且分片键的数据改变的话，那我下次查询（假设hint主键缓存），那么mycat会按缓存中的datanode去路由你的SQL，若你新的分片键不在该datanode的话，查询结果会为空！update操作同理，若update主键后，再insert新数据时，使用的是update前的主键，也可能出现查询结果为空！
解决方法：
    TableId2DataNodeCache是LayerCachePool类型，为双层CachePool，
第一层：schema_tableName，value为CachePool；第二层：key为主键值，value为datanode；
在delete/update的SQL解析时清空对应表的主键缓存；源码中没有提供通过CacheName来clearCache的方法，所以在DefaultLayerCachePool中重载了clearCache(String cacheName)的方法。