### PR TITLE
修改通过zk reload_from_zk命令加载配置文件时的bug

### DIFF
--- a/src/main/java/io/mycat/manager/handler/ZKHandler.java
+++ b/src/main/java/io/mycat/manager/handler/ZKHandler.java
@@ -51,7 +51,7 @@ public class ZKHandler {
                 ZktoXmlMain.ZKLISTENER.notifly(ZkNofiflyCfg.ZK_NOTIFLY_LOAD_ALL.getKey());
 
                 // 执行重新加载本地配制信息
-                ReloadHandler.handle("RELOAD @@config_all", c, 7 >>> 8);
+                ReloadHandler.handle("RELOAD @@config_all", c, 6);
 
                 offset += RELOAD_FROM_ZK.length();
 


### PR DESCRIPTION
通过zk reload_from_zk命令加载配置文件的时候无法正确执行，代码中对于命令的offset设置不正常。
7>>>8 后结果是0，offset为0的情况下ReloadHandler中无法正确识别命令。