### PR TITLE
添加针对mysql协议中COM_FIELD_LIST相关指令的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ hs_err_pid*
 /RUNNING_PID
 .DS_Store
 /target/
+/conf/

--- a/src/main/java/io/mycat/backend/mysql/nio/handler/SimpleLogHandler.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/handler/SimpleLogHandler.java
@@ -25,7 +25,8 @@ package io.mycat.backend.mysql.nio.handler;
 
 import java.util.List;
 
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.mycat.backend.BackendConnection;
 
@@ -46,31 +47,37 @@ public class SimpleLogHandler implements ResponseHandler{
 
 	@Override
 	public void errorResponse(byte[] err, BackendConnection conn) {
-		LOGGER.warn("caught error resp: " + conn + " " + new String(err));
+		LOGGER.warn("caught error resp: " + conn + " " + bytesToHex(err));
 	}
 
 	@Override
 	public void okResponse(byte[] ok, BackendConnection conn) {
-		LOGGER.info("okResponse: " + conn );
+		LOGGER.info("okResponse: " + conn + "," + bytesToHex(ok) );
 		
 	}
 
 	@Override
 	public void fieldEofResponse(byte[] header, List<byte[]> fields,
 			byte[] eof, BackendConnection conn) {
-		LOGGER.info("fieldEofResponse: " + conn );
+		LOGGER.info("fieldEofResponse : " + conn );
+		System.out.println("SimpleLogHandler.fieldEofResponse header: " + bytesToHex(header) );
+		for(byte[] field : fields) {
+			System.out.println("SimpleLogHandler.fieldEofResponse fields: " + bytesToHex(field) );
+		}
+		System.out.println("SimpleLogHandler.fieldEofResponse eof: " + bytesToHex(eof) );
 		
 	}
 
 	@Override
 	public void rowResponse(byte[] row, BackendConnection conn) {
 		LOGGER.info("rowResponse: " + conn );
-		
+		System.out.println("SimpleLogHandler.rowResponse: " + bytesToHex(row) );
 	}
 
 	@Override
 	public void rowEofResponse(byte[] eof, BackendConnection conn) {
 		LOGGER.info("rowEofResponse: " + conn );
+		System.out.println("SimpleLogHandler.rowEofResponse: " + bytesToHex(eof) );
 		
 	}
 
@@ -86,4 +93,11 @@ public class SimpleLogHandler implements ResponseHandler{
 		
 	}
 
+	public static String bytesToHex(byte[] bytes) {
+		StringBuilder sb = new StringBuilder();
+		for (byte b : bytes) {
+			sb.append(String.format("%02x ", b));
+		}
+		return sb.toString();
+	}
 }

--- a/src/main/java/io/mycat/backend/mysql/nio/handler/SingleNodeHandler.java
+++ b/src/main/java/io/mycat/backend/mysql/nio/handler/SingleNodeHandler.java
@@ -71,19 +71,19 @@ public class SingleNodeHandler implements ResponseHandler, Terminatable, LoadDat
 	
 	// only one thread access at one time no need lock
 	private volatile byte packetId;
-	private volatile ByteBuffer buffer;
+	protected volatile ByteBuffer buffer;
 	private volatile boolean isRunning;
 	private Runnable terminateCallBack;
-	private long startTime;
-	private long netInBytes;
-	private long netOutBytes;
+	protected long startTime;
+	protected long netInBytes;
+	protected long netOutBytes;
 	private long selectRows;
-	private long affectedRows;
+	protected long affectedRows;
 	protected final AtomicBoolean errorRepsponsed = new AtomicBoolean(false);
 	
 	private boolean prepared;
-	private int fieldCount;
-	private List<FieldPacket> fieldPackets = new ArrayList<FieldPacket>();
+	protected int fieldCount;
+	protected List<FieldPacket> fieldPackets = new ArrayList<FieldPacket>();
 
     private volatile boolean isDefaultNodeShowTable;
     private volatile boolean isDefaultNodeShowFullTable;
@@ -123,7 +123,18 @@ public class SingleNodeHandler implements ResponseHandler, Terminatable, LoadDat
 		}
         
 	}
-
+	public NonBlockingSession getSession() {
+		return this.session;
+	}
+	public RouteResultsetNode getRouteResultsetNode() {
+		return this.node;
+	}
+	public RouteResultset getRouteResultset(){
+		return this.rrs;
+	}
+	public ByteBuffer getBuffer() {
+		return this.buffer;
+	}
 	@Override
 	public void terminate(Runnable callback) {
 		boolean zeroReached = false;
@@ -139,7 +150,7 @@ public class SingleNodeHandler implements ResponseHandler, Terminatable, LoadDat
 		}
 	}
 
-	private void endRunning() {
+	protected void endRunning() {
 		Runnable callback = null;
 		if (isRunning) {
 			isRunning = false;
@@ -398,7 +409,7 @@ public class SingleNodeHandler implements ResponseHandler, Terminatable, LoadDat
 	 * 
 	 * @return
 	 */
-	private ByteBuffer allocBuffer() {
+	protected ByteBuffer allocBuffer() {
 		if (buffer == null) {
 			buffer = session.getSource().allocate();
 		}

--- a/src/main/java/io/mycat/net/FrontendConnection.java
+++ b/src/main/java/io/mycat/net/FrontendConnection.java
@@ -52,6 +52,7 @@ import io.mycat.net.mysql.HandshakePacket;
 import io.mycat.net.mysql.HandshakeV10Packet;
 import io.mycat.net.mysql.MySQLPacket;
 import io.mycat.net.mysql.OkPacket;
+import io.mycat.server.parser.ServerParse;
 import io.mycat.util.CompressUtil;
 import io.mycat.util.RandomUtil;
 
@@ -457,6 +458,24 @@ public abstract class FrontendConnection extends AbstractConnection {
 		} else {
 			writeErrMessage(ErrorCode.ER_UNKNOWN_COM_ERROR, "Prepare unsupported!");
 		}
+	}
+	/** 
+	 * 用来模拟mysql协议命令中的com_field_list，方便通过发sql测试 
+	 * https://dev.mysql.com/doc/internals/en/com-field-list.html
+	 */
+	public void fieldList(byte[] data) {
+		// 取得语句
+		String sql = null;		
+		try {
+			MySQLMessage mm = new MySQLMessage(data);
+			mm.position(5);
+			sql = mm.readString(charset);
+			sql = ServerParse.COM_FIELD_LIST_FLAG + sql;
+		} catch (UnsupportedEncodingException e) {
+			writeErrMessage(ErrorCode.ER_UNKNOWN_CHARACTER_SET, "Unknown charset '" + charset + "'");
+			return;
+		}		
+		this.query( sql );
 	}
 
 	public void ping() {

--- a/src/main/java/io/mycat/net/NIOSocketWR.java
+++ b/src/main/java/io/mycat/net/NIOSocketWR.java
@@ -60,8 +60,8 @@ public class NIOSocketWR extends SocketWR {
 			}
 
 		} catch (IOException e) {
-			if (AbstractConnection.LOGGER.isDebugEnabled()) {
-				AbstractConnection.LOGGER.debug("caught err:", e);
+			if (AbstractConnection.LOGGER.isWarnEnabled()) {
+				AbstractConnection.LOGGER.warn("caught err:", e);
 			}
 			con.close("err:" + e);
 		} finally {

--- a/src/main/java/io/mycat/net/handler/FrontendCommandHandler.java
+++ b/src/main/java/io/mycat/net/handler/FrontendCommandHandler.java
@@ -106,6 +106,9 @@ public class FrontendCommandHandler implements NIOHandler
                 commands.doHeartbeat();
                 source.heartbeat(data);
                 break;
+            case MySQLPacket.COM_FIELD_LIST:
+                source.fieldList(data);
+                break;
             default:
                      commands.doOther();
                      source.writeErrMessage(ErrorCode.ER_UNKNOWN_COM_ERROR,

--- a/src/main/java/io/mycat/server/ServerQueryHandler.java
+++ b/src/main/java/io/mycat/server/ServerQueryHandler.java
@@ -23,12 +23,24 @@
  */
 package io.mycat.server;
 
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.mycat.config.ErrorCode;
 import io.mycat.net.handler.FrontendQueryHandler;
 import io.mycat.net.mysql.OkPacket;
-import io.mycat.server.handler.*;
+import io.mycat.server.handler.BeginHandler;
+import io.mycat.server.handler.CommandHandler;
+import io.mycat.server.handler.Explain2Handler;
+import io.mycat.server.handler.ExplainHandler;
+import io.mycat.server.handler.KillHandler;
+import io.mycat.server.handler.MigrateHandler;
+import io.mycat.server.handler.SavepointHandler;
+import io.mycat.server.handler.SelectHandler;
+import io.mycat.server.handler.SetHandler;
+import io.mycat.server.handler.ShowHandler;
+import io.mycat.server.handler.StartHandler;
+import io.mycat.server.handler.UseHandler;
 import io.mycat.server.parser.ServerParse;
 
 /**
@@ -68,6 +80,9 @@ public class ServerQueryHandler implements FrontendQueryHandler {
 		//explain2 datanode=? sql=?
 		case ServerParse.EXPLAIN2:
 			Explain2Handler.handle(sql, c, rs >>> 8);
+			break;
+		case ServerParse.COMMAND:
+			CommandHandler.handle(sql, c, 16);
 			break;
 		case ServerParse.SET:
 			SetHandler.handle(sql, c, rs >>> 8);

--- a/src/main/java/io/mycat/server/handler/CommandHandler.java
+++ b/src/main/java/io/mycat/server/handler/CommandHandler.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2013, OpenCloudDB/MyCAT and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software;Designed and Developed mainly by many Chinese 
+ * opensource volunteers. you can redistribute it and/or modify it under the 
+ * terms of the GNU General Public License version 2 only, as published by the
+ * Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * 
+ * Any questions about this component can be directed to it's project Web address 
+ * https://code.google.com/p/opencloudb/.
+ *
+ */
+package io.mycat.server.handler;
+import java.sql.SQLNonTransientException;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.mycat.MycatServer;
+import io.mycat.backend.BackendConnection;
+import io.mycat.backend.mysql.nio.handler.SimpleLogHandler;
+import io.mycat.backend.mysql.nio.handler.SingleNodeHandler;
+import io.mycat.config.ErrorCode;
+import io.mycat.config.model.SchemaConfig;
+import io.mycat.config.model.SystemConfig;
+import io.mycat.net.mysql.FieldPacket;
+import io.mycat.route.RouteResultset;
+import io.mycat.server.NonBlockingSession;
+import io.mycat.server.ServerConnection;
+import io.mycat.server.parser.ServerParse;
+import io.mycat.server.util.SchemaUtil;
+import io.mycat.statistic.stat.QueryResult;
+import io.mycat.statistic.stat.QueryResultDispatcher;
+/**
+ * <pre>
+ * 用于解决mysql 协议中com_field_list命令的支持
+ * https://dev.mysql.com/doc/internals/en/com-field-list.html
+ * </pre>
+ * @author stones_he@163.com
+ */
+public class CommandHandler {
+	private static final Logger logger = LoggerFactory.getLogger(CommandHandler.class);
+	//
+	public static void handle(String stmt, ServerConnection c, int offset) {
+		String table = stmt.substring(offset).trim();
+		//int sqlType = ServerParse.parse(stmt) & 0xff;
+		String db = c.getSchema();
+		if (db == null) {
+			db = SchemaUtil.detectDefaultDb(stmt, ServerParse.COMMAND);
+			if (db == null) {
+				c.writeErrMessage(ErrorCode.ER_NO_DB_ERROR, "No database selected");
+				return;
+			}
+		}
+		SchemaConfig schema = MycatServer.getInstance().getConfig().getSchemas().get(db);
+		if (schema == null) {
+			c.writeErrMessage(ErrorCode.ER_BAD_DB_ERROR, "Unknown database '" + db + "'");
+			return;
+		}
+		SystemConfig system = MycatServer.getInstance().getConfig().getSystem();
+		RouteResultset rrs = null;
+		try {
+			rrs = MycatServer	.getInstance()
+								.getRouterservice()
+								.route(system, schema, ServerParse.COMMAND, stmt, c.getCharset(), c);
+			if (rrs == null) {
+				return;
+			}
+		} catch (SQLNonTransientException e) {
+			logger.warn("", e);
+			c.writeErrMessage(ErrorCode.ERR_HANDLE_DATA, e.toString());
+		}
+		//
+		CommandExecResultHandler handler = new CommandExecResultHandler(rrs, c.getSession2(), table);
+		try {
+			handler.execute();
+		} catch (Exception e1) {
+			logger.warn("", e1);
+			c.writeErrMessage(ErrorCode.ERR_HANDLE_DATA, e1.toString());
+		}
+	}
+}
+class CommandExecResultHandler extends SingleNodeHandler {
+	private static final Logger logger = LoggerFactory.getLogger(CommandExecResultHandler.class);
+	private String table;
+	public CommandExecResultHandler(RouteResultset rrs, NonBlockingSession session, String table) {
+		super(rrs, session);
+		this.table = table;
+	}
+	private void rowEofResponse0(byte[] eof, BackendConnection conn) {
+		logger.debug("CommandExecResultHandler.rowEofResponse eof: {}", SimpleLogHandler.bytesToHex(eof));
+		// 
+		ServerConnection source = getSession().getSource();
+		conn.recordSql(source.getHost(), source.getSchema(), getRouteResultsetNode().getStatement());
+		// 判断是调用存储过程的话不能在这里释放链接
+		if (!getRouteResultset().isCallStatement() || (getRouteResultset().isCallStatement() && getRouteResultset()
+																													.getProcedure()
+																													.isResultSimpleValue())) {
+			getSession().releaseConnectionIfSafe(conn, logger.isDebugEnabled(), false);
+			endRunning();
+		}
+		//
+		int resultSize = source.getWriteQueue().size() * MycatServer.getInstance()
+																	.getConfig()
+																	.getSystem()
+																	.getBufferPoolPageSize();
+		resultSize = resultSize + getBuffer().position();
+		if (!errorRepsponsed.get() && !getSession().closed() && source.canResponse()) {
+			source.write(getBuffer());
+		}
+		source.setExecuteSql(null);
+		//查询结果派发
+		QueryResult queryResult = new QueryResult(	getSession().getSource().getUser(),
+													getRouteResultset().getSqlType(),
+													getRouteResultset().getStatement(),
+													affectedRows,
+													netInBytes,
+													netOutBytes,
+													startTime,
+													System.currentTimeMillis(),
+													resultSize,
+													source.getHost());
+		QueryResultDispatcher.dispatchQuery(queryResult);
+	}
+	@Override
+	public void fieldEofResponse(byte[] header, List<byte[]> fields, byte[] eof, BackendConnection conn) {
+		logger.debug("CommandExecResultHandler.fieldEofResponse header: {}", SimpleLogHandler.bytesToHex(header));
+		for (byte[] field : fields) {
+			logger.debug("CommandExecResultHandler.fieldEofResponse fields: {}", SimpleLogHandler.bytesToHex(field));
+		}
+		logger.debug("CommandExecResultHandler.fieldEofResponse eof: {}", SimpleLogHandler.bytesToHex(eof));
+		//
+		fieldEofResponse0(header, fields, eof, conn);
+		rowEofResponse0(eof, conn);
+	}
+	private void fieldEofResponse0(byte[] header, List<byte[]> fields, byte[] eof, BackendConnection conn) {
+		byte packetId = 0;
+		this.netOutBytes += header.length;
+		for (int i = 0, len = fields.size(); i < len; ++i) {
+			byte[] field = fields.get(i);
+			this.netOutBytes += field.length;
+		}
+		header[3] = ++packetId;
+		ServerConnection source = getSession().getSource();
+		buffer = source.writeToBuffer(header, allocBuffer());
+		for (int i = 0, len = fields.size(); i < len; ++i) {
+			byte[] field = fields.get(i);
+			field[3] = ++packetId;
+			// 保存field信息
+			FieldPacket fieldPk = new FieldPacket();
+			fieldPk.read(field);
+			fieldPackets.add(fieldPk);
+			buffer = source.writeToBuffer(field, buffer);
+		}
+		fieldCount = fieldPackets.size();
+		eof[3] = ++packetId;
+		this.netOutBytes += eof.length;
+		buffer = source.writeToBuffer(eof, buffer);
+	}
+	@Override
+	public String toString() {
+		return "CommandExecResultHandler [node=" + getRouteResultsetNode() + ", table=" + table + "]";
+	}
+}

--- a/src/main/java/io/mycat/server/parser/ServerParse.java
+++ b/src/main/java/io/mycat/server/parser/ServerParse.java
@@ -60,6 +60,8 @@ public final class ServerParse {
 	public static final int UNLOCK = 23;
     public static final int LOAD_DATA_INFILE_SQL = 99;
     public static final int DDL = 100;
+    public static final int COMMAND = 101;
+    public static final String COM_FIELD_LIST_FLAG="select @@command ";
 
 
 	public static final int MIGRATE  = 203;
@@ -720,6 +722,10 @@ public final class ServerParse {
 
 	// SELECT' '
 	static int selectCheck(String stmt, int offset) {
+		// SELECT @@command ,对应mysql协议是0x04
+		if(stmt.startsWith(COM_FIELD_LIST_FLAG)) {
+			return COMMAND;
+		}
 		if (stmt.length() > offset + 4) {
 			char c1 = stmt.charAt(++offset);
 			char c2 = stmt.charAt(++offset);

--- a/src/main/java/io/mycat/server/util/SchemaUtil.java
+++ b/src/main/java/io/mycat/server/util/SchemaUtil.java
@@ -1,6 +1,7 @@
 package io.mycat.server.util;
 
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlShowColumnsStatement;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
 import com.alibaba.druid.sql.parser.SQLStatementParser;
 import com.alibaba.druid.sql.visitor.SchemaStatVisitor;
@@ -49,16 +50,37 @@ public class SchemaUtil {
             if (schemaInfo != null && schemaInfo.schema != null && schemaConfigMap.containsKey(schemaInfo.schema)) {
                 db = schemaInfo.schema;
             }
+        } else if(ServerParse.COMMAND == type) {
+            int index = sql.indexOf(ServerParse.COM_FIELD_LIST_FLAG);
+            String table = sql.substring(index + 17);
+            db = getSchema(schemaConfigMap, table);
         } else if ((ServerParse.SHOW == type || ServerParse.USE == type || ServerParse.EXPLAIN == type || ServerParse.SET == type
                 || ServerParse.HELP == type || ServerParse.DESCRIBE == type)
                 && !schemaConfigMap.isEmpty()) {
-            //兼容mysql gui  不填默认database
-            db = schemaConfigMap.entrySet().iterator().next().getKey();
+            try {
+                //当前存在多个schema的时候使用原来的逻辑会出现bug，改为根据mycat schema配置中的对应关系获取
+                SQLStatementParser parser = new MySqlStatementParser(sql);
+                MySqlShowColumnsStatement stmt = (MySqlShowColumnsStatement)parser.parseStatement();
+                db = getSchema(schemaConfigMap, stmt.getTable().getSimpleName());
+            } catch (Exception e) {
+                //e.printStackTrace();
+                //兼容mysql gui  不填默认database
+                db = schemaConfigMap.entrySet().iterator().next().getKey();
+            }
         }
         return db;
     }
-
-
+    /** 根据mycat schema配置中的对应关系获取对应的db */
+    public static String getSchema(Map<String, SchemaConfig> schemaConfigMap, String table) {
+        String db = null;
+        for (Map.Entry<String,SchemaConfig> entry : schemaConfigMap.entrySet()) {
+            if(entry.getValue().getTables().containsKey(table.toUpperCase())) {
+                db = entry.getKey();
+                break;
+            }
+        }
+        return db;
+    }
     public static String parseShowTableSchema(String sql) {
         Matcher ma = pattern.matcher(sql);
         if (ma.matches() && ma.groupCount() >= 5) {
@@ -104,8 +126,9 @@ public class SchemaUtil {
             return sb.toString();
         }
     }
-
-    private static Pattern pattern = Pattern.compile("^\\s*(SHOW)\\s+(FULL)*\\s*(TABLES)\\s+(FROM)\\s+([a-zA-Z_0-9]+)\\s*([a-zA-Z_0-9\\s]*)", Pattern.CASE_INSENSITIVE);
+    //sample：SHOW FULL TABLES FROM information_schema WHERE Tables_in_information_schema LIKE 'KEY_COLUMN_USAGE'
+    //注意sql中like后面会有单引号
+    private static Pattern pattern = Pattern.compile("^\\s*(SHOW)\\s+(FULL)*\\s*(TABLES)\\s+(FROM)\\s+([a-zA-Z_0-9]+)\\s*(['a-zA-Z_0-9\\s]*)", Pattern.CASE_INSENSITIVE);
 
     public static void main(String[] args) {
         String sql = "SELECT name, type FROM `mysql`.`proc` as xxxx WHERE Db='base'";
@@ -120,7 +143,7 @@ public class SchemaUtil {
                 + "  `_slot` int(11) DEFAULT NULL COMMENT '自动迁移算法slot,禁止修改',\n" + "  PRIMARY KEY (`id`)\n"
                 + ") ENGINE=InnoDB AUTO_INCREMENT=805781256930734081 DEFAULT CHARSET=utf8";
         System.out.println(parseSchema(sql));
-        String pat3 = "show  full  tables from  base like ";
+        String pat3 = "SHOW FULL TABLES FROM information_schema WHERE Tables_in_information_schema LIKE 'KEY_COLUMN_USAGE'";
         Matcher ma = pattern.matcher(pat3);
         if (ma.matches()) {
             System.out.println(ma.groupCount());


### PR DESCRIPTION
在部分数据库工具中使用到了mysql协议中的COM_FIELD_LIST（https://dev.mysql.com/doc/internals/en/com-field-list.html）指令，本版本添加了相关指令的支持。
由于此指令不是一个查询指令，如果要测试需要通过支持mysql协议的客户端进行测试。
同时修改在多schema下部分show指令的bug。