### PR TITLE
fix the null message for backend connection

### DIFF
--- a/src/main/java/io/mycat/net/ConnectionException.java
+++ b/src/main/java/io/mycat/net/ConnectionException.java
@@ -32,7 +32,7 @@ public class ConnectionException extends RuntimeException {
 	private final String msg;
 
 	public ConnectionException(int code, String msg) {
-		super();
+		super(msg);
 		this.code = code;
 		this.msg = msg;
 	}


### PR DESCRIPTION
### 问题
后端连接有时候获取的异常信息没法很好传递到前端连接，导致实际的SQL异常，客户端无法获知。

### 分析
举个例子，配置单数据单分片，其中数据库的最大连接数改为 3：   
如 Linux 修改 /etc/mysql/my.conf 以下配置
```
max_connections=3
```
重启物理数据库

模拟超过3个连接mycat,进行简单测试。

实际后端异常是 `Too many connections`，但客户端无法获知。

因此，需要改动。


