### PR TITLE
增加解析事务只读语句和设置SQL查询最大行语句支持

### DIFF
--- a/src/main/java/io/mycat/backend/BackendConnection.java
+++ b/src/main/java/io/mycat/backend/BackendConnection.java
@@ -58,6 +58,8 @@ public interface BackendConnection extends ClosableConnection {
 
 	public boolean isAutocommit();
 
+	public boolean isTxReadonly();
+
 	public long getId();
 
 	public void discardClose(String reason);

--- a/src/main/java/io/mycat/backend/BackendConnection.java
+++ b/src/main/java/io/mycat/backend/BackendConnection.java
@@ -59,6 +59,7 @@ public interface BackendConnection extends ClosableConnection {
 	public boolean isAutocommit();
 
 	public boolean isTxReadonly();
+	public int getSqlSelectLimit();
 
 	public long getId();
 

--- a/src/main/java/io/mycat/backend/jdbc/JDBCConnection.java
+++ b/src/main/java/io/mycat/backend/jdbc/JDBCConnection.java
@@ -931,7 +931,7 @@ public class JDBCConnection implements BackendConnection {
 			return true;
 		} else {
 			try {
-				return con.getAutoCommit();
+				return con.isReadOnly();
 			} catch (SQLException e) {
 
 			}

--- a/src/main/java/io/mycat/backend/postgresql/PostgreSQLBackendConnection.java
+++ b/src/main/java/io/mycat/backend/postgresql/PostgreSQLBackendConnection.java
@@ -43,9 +43,10 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 		private final AtomicInteger synCmdCount;
 		private final Integer txtIsolation;
 		private final boolean xaStarted;
+		private Boolean txReadonly;
 
 		public StatusSync(boolean xaStarted, String schema, Integer charsetIndex, Integer txtIsolation,
-				Boolean autocommit, int synCount) {
+				Boolean autocommit, int synCount, Boolean txReadonly) {
 			super();
 			this.xaStarted = xaStarted;
 			this.schema = schema;
@@ -53,6 +54,7 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 			this.txtIsolation = txtIsolation;
 			this.autocommit = autocommit;
 			this.synCmdCount = new AtomicInteger(synCount);
+			this.txReadonly = txReadonly;
 		}
 
 		public boolean synAndExecuted(PostgreSQLBackendConnection conn) {
@@ -83,6 +85,9 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 			}
 			if (autocommit != null) {
 				conn.autocommit = autocommit;
+			}
+			if (txReadonly != null) {
+				conn.txReadonly = txReadonly;
 			}
 		}
 
@@ -124,6 +129,8 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 	private Object attachment;
 
 	private volatile boolean autocommit=true;
+
+	private volatile boolean txReadonly=false;
 
 	private volatile boolean borrowed;
 
@@ -231,7 +238,7 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 		if(sc.getSession2().getXaTXID()!=null){
 			xaTXID = sc.getSession2().getXaTXID() +",'"+getSchema()+"'";
 		}
-		synAndDoExecute(xaTXID, rrn, sc.getCharsetIndex(), sc.getTxIsolation(), autocommit);
+		synAndDoExecute(xaTXID, rrn, sc.getCharsetIndex(), sc.getTxIsolation(), autocommit, sc.isTxReadonly());
 	}
 
 	@Override
@@ -244,6 +251,13 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 			sb.append(/*"SET autocommit=1;"*/"");//Fix bug  由于 PG9.0 开始不支持此选项，默认是为自动提交逻辑。
 		} else {
 			sb.append("begin transaction;");
+		}
+	}
+	private void getTxReadonly(StringBuilder sb, boolean txReadonly) {
+		if (txReadonly) {
+			sb.append("SET SESSION TRANSACTION READ ONLY;");
+		} else {
+			sb.append("SET SESSION TRANSACTION READ WRITE;");
 		}
 	}
 
@@ -289,6 +303,11 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 	@Override
 	public boolean isAutocommit() {
 		return autocommit;
+	}
+
+	@Override
+	public boolean isTxReadonly() {
+		return txReadonly;
 	}
 
 	@Override
@@ -347,7 +366,7 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 	@Override
 	public void query(String query) throws UnsupportedEncodingException {
 		RouteResultsetNode rrn = new RouteResultsetNode("default", ServerParse.SELECT, query);
-		synAndDoExecute(null, rrn, this.charsetIndex, this.txIsolation, true);
+		synAndDoExecute(null, rrn, this.charsetIndex, this.txIsolation, true, this.txReadonly);
 	}
 
 	@Override
@@ -457,10 +476,11 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 	}
 
 	private void synAndDoExecute(String xaTxID, RouteResultsetNode rrn, int clientCharSetIndex, int clientTxIsoLation,
-			boolean clientAutoCommit) {
+			boolean clientAutoCommit, boolean clientTxReadonly) {
 		String xaCmd = null;
 
 		boolean conAutoComit = this.autocommit;
+		boolean conTxReadonly = this.txReadonly;
 		String conSchema = this.schema;
 		// never executed modify sql,so auto commit
 		boolean expectAutocommit = !modifiedSQLExecuted || isFromSlaveDB() || clientAutoCommit;
@@ -473,7 +493,8 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 		int charsetSyn = (this.charsetIndex == clientCharSetIndex) ? 0 : 1;
 		int txIsoLationSyn = (txIsolation == clientTxIsoLation) ? 0 : 1;
 		int autoCommitSyn = (conAutoComit == expectAutocommit) ? 0 : 1;
-		int synCount = schemaSyn + charsetSyn + txIsoLationSyn + autoCommitSyn;
+		int txReadonlySyn = (conTxReadonly == clientTxReadonly) ? 0 : 1;
+		int synCount = schemaSyn + charsetSyn + txIsoLationSyn + autoCommitSyn + txReadonlySyn;
 
 		if (synCount == 0) {
 			String sql = rrn.getStatement();
@@ -495,6 +516,9 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 		if (autoCommitSyn == 1) {
 			getAutocommitCommand(sb, expectAutocommit);
 		}
+		if (txReadonlySyn == 1) {
+			getTxReadonly(sb, clientTxReadonly);
+		}
 		if (xaCmd != null) {
 			sb.append(xaCmd);
 		}
@@ -505,7 +529,7 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 
 		metaDataSyned = false;
 		statusSync = new StatusSync(xaCmd != null, conSchema, clientCharSetIndex, clientTxIsoLation, expectAutocommit,
-				synCount);
+				synCount, clientTxReadonly);
 		String sql = sb.append(PgSqlApaterUtils.apater(rrn.getStatement())).toString();
 		if(LOGGER.isDebugEnabled()){
 			LOGGER.debug("con={}, SQL={}", this, sql);

--- a/src/main/java/io/mycat/backend/postgresql/PostgreSQLBackendConnection.java
+++ b/src/main/java/io/mycat/backend/postgresql/PostgreSQLBackendConnection.java
@@ -311,6 +311,12 @@ public class PostgreSQLBackendConnection extends BackendAIOConnection {
 	}
 
 	@Override
+	public int getSqlSelectLimit() {
+		// todo
+		return -1;
+	}
+
+	@Override
 	public boolean isBorrowed() {
 		return borrowed;
 	}

--- a/src/main/java/io/mycat/manager/handler/ReloadHandler.java
+++ b/src/main/java/io/mycat/manager/handler/ReloadHandler.java
@@ -28,6 +28,7 @@ import io.mycat.manager.ManagerConnection;
 import io.mycat.manager.response.ReloadConfig;
 import io.mycat.manager.response.ReloadQueryCf;
 import io.mycat.manager.response.ReloadSqlSlowTime;
+import io.mycat.manager.response.ReloadSqlStat;
 import io.mycat.manager.response.ReloadUser;
 import io.mycat.manager.response.ReloadUserStat;
 import io.mycat.route.parser.ManagerParseReload;
@@ -65,7 +66,11 @@ public final class ReloadHandler
             case ManagerParseReload.QUERY_CF:            	
             	String filted = ParseUtil.parseString(stmt) ;
             	ReloadQueryCf.execute(c, filted);
-            	break;                
+            	break;
+            case ManagerParseReload.SQL_STAT:
+                String openCloseFlag = ParseUtil.parseString(stmt) ;
+                ReloadSqlStat.execute(c, openCloseFlag);
+                break;
             default:
                 c.writeErrMessage(ErrorCode.ER_YES, "Unsupported statement");
         }

--- a/src/main/java/io/mycat/manager/response/ReloadConfig.java
+++ b/src/main/java/io/mycat/manager/response/ReloadConfig.java
@@ -158,11 +158,16 @@ public final class ReloadConfig {
 		 *  新的 dataHosts 是否初始化成功
 		 */
 		if ( isReloadStatusOK ) {
+
+			config.getSystem().setUseSqlStat(loader.getSystem().getUseSqlStat());
+			MycatServer.getInstance().ensureSqlstatRecycleFuture();
 			
 			/**
 			 * 2.3、 在老的配置上，应用新的配置，开始准备承接任务
 			 */
 			config.reload(newUsers, newSchemas, newDataNodes, newDataHosts, newCluster, newFirewall, true);
+
+
 
 			/**
 			 * 2.4、 处理旧的资源
@@ -232,6 +237,10 @@ public final class ReloadConfig {
         Map<String, PhysicalDBPool> dataHosts = loader.getDataHosts();
         MycatCluster cluster = loader.getCluster();
         FirewallConfig firewall = loader.getFirewall();
+
+
+		MycatServer.getInstance().getConfig().getSystem().setUseSqlStat(loader.getSystem().getUseSqlStat());
+		MycatServer.getInstance().ensureSqlstatRecycleFuture();
         
         /**
          * 2、在老的配置上，应用新的配置

--- a/src/main/java/io/mycat/manager/response/ReloadSqlStat.java
+++ b/src/main/java/io/mycat/manager/response/ReloadSqlStat.java
@@ -1,0 +1,46 @@
+package io.mycat.manager.response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.mycat.MycatServer;
+import io.mycat.config.ErrorCode;
+import io.mycat.config.model.SystemConfig;
+import io.mycat.manager.ManagerConnection;
+import io.mycat.net.mysql.OkPacket;
+
+public class ReloadSqlStat {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReloadSqlStat.class);
+
+    public static void execute(ManagerConnection c, String openCloseFlag) {
+        SystemConfig system = MycatServer.getInstance().getConfig().getSystem();
+        int oldStat = system.getUseSqlStat();
+        int newStat = oldStat;
+        if ("open".equalsIgnoreCase(openCloseFlag)) {
+            newStat = 1;
+        } else if ("close".equalsIgnoreCase(openCloseFlag)) {
+            newStat = 0;
+        } else {
+            c.writeErrMessage(ErrorCode.ER_YES, "reload @@sqlstat=open|close");
+            return;
+        }
+
+        system.setUseSqlStat(newStat);
+        MycatServer.getInstance().ensureSqlstatRecycleFuture();
+
+        StringBuilder s = new StringBuilder();
+        s.append(c).append("Reset  @@sqlstat=" + openCloseFlag + " success by manager");
+
+        logger.warn(s.toString());
+
+        OkPacket ok = new OkPacket();
+        ok.packetId = 1;
+        ok.affectedRows = oldStat != newStat ? 1 : 0;
+        ok.serverStatus = 2;
+        ok.message = "Reset  @@sqlstat success".getBytes();
+        ok.write(c);
+        System.out.println(s.toString());
+    }
+
+}

--- a/src/main/java/io/mycat/manager/response/ShowBackend.java
+++ b/src/main/java/io/mycat/manager/response/ShowBackend.java
@@ -50,7 +50,7 @@ import io.mycat.util.TimeUtil;
  */
 public class ShowBackend {
 
-	private static final int FIELD_COUNT = 16;
+	private static final int FIELD_COUNT = 17;
 	private static final ResultSetHeaderPacket header = PacketUtil
 			.getHeader(FIELD_COUNT);
 	private static final FieldPacket[] fields = new FieldPacket[FIELD_COUNT];
@@ -96,6 +96,9 @@ public class ShowBackend {
 				.getField("txlevel", Fields.FIELD_TYPE_VAR_STRING);
 		fields[i++].packetId = ++packetId;
 		fields[i] = PacketUtil.getField("autocommit",
+				Fields.FIELD_TYPE_VAR_STRING);
+		fields[i++].packetId = ++packetId;
+		fields[i] = PacketUtil.getField("tx_readonly",
 				Fields.FIELD_TYPE_VAR_STRING);
 		fields[i++].packetId = ++packetId;
 		eof.packetId = ++packetId;
@@ -158,6 +161,7 @@ public class ShowBackend {
 		String charsetInf = "";
 		String txLevel = "";
 		String txAutommit = "";
+		String txReadonly = "";
 
 		if (c instanceof MySQLConnection) {
 			MySQLConnection mysqlC = (MySQLConnection) c;
@@ -166,12 +170,14 @@ public class ShowBackend {
 			charsetInf = mysqlC.getCharset() + ":" + mysqlC.getCharsetIndex();
 			txLevel = mysqlC.getTxIsolation() + "";
 			txAutommit = mysqlC.isAutocommit() + "";
+			txReadonly = mysqlC.isTxReadonly() + "";
 		}
 		row.add(IntegerUtil.toBytes(writeQueueSize));
 		row.add(schema.getBytes());
 		row.add(charsetInf.getBytes());
 		row.add(txLevel.getBytes());
 		row.add(txAutommit.getBytes());
+		row.add(txReadonly.getBytes());
 		return row;
 	}
 }

--- a/src/main/java/io/mycat/manager/response/ShowSysParam.java
+++ b/src/main/java/io/mycat/manager/response/ShowSysParam.java
@@ -82,6 +82,7 @@ public class ShowSysParam {
         paramValues.add(sysConfig.getBindIp() + "");
         paramValues.add(sysConfig.getServerPort()+ "");
         paramValues.add(sysConfig.getManagerPort() + "");
+		paramValues.add(sysConfig.getUseSqlStat() + "");
 
 		for(int i = 0; i < PARAMNAMES.length ; i++){
 	        RowDataPacket row =  new RowDataPacket(FIELD_COUNT);
@@ -119,7 +120,8 @@ public class ShowSysParam {
 		"Mycat_dataNodeHeartbeatPeriod",
 		"Mycat_bindIp",
 		"Mycat_serverPort",
-		"Mycat_managerPort"};
+		"Mycat_managerPort",
+		"Mycat_useSqlStat"};
 	
 	private static final String[] PARAM_DESCRIPTION = {
 		"主要用于指定系统可用的线程数，默认值为Runtime.getRuntime().availableProcessors()方法返回的值。主要影响processorBufferPool、processorBufferLocalPercent、processorExecutor属性。NIOProcessor的个数也是由这个属性定义的，所以调优的时候可以适当的调高这个属性。",
@@ -139,7 +141,8 @@ public class ShowSysParam {
 		"对后端所有读、写库发起心跳的间隔时间，默认是10秒",
 		"mycat服务监听的IP地址，默认值为0.0.0.0",
 		"mycat的使用端口，默认值为8066",
-		"mycat的管理端口，默认值为9066"};
+		"mycat的管理端口，默认值为9066",
+		"mycat是否开启SQL统计,1开启，0未开启"};
 	
     public static final String[] ISOLATIONS = {"", "READ_UNCOMMITTED", "READ_COMMITTED", "REPEATED_READ", "SERIALIZABLE"};
 }

--- a/src/main/java/io/mycat/route/function/PartitionByMonth.java
+++ b/src/main/java/io/mycat/route/function/PartitionByMonth.java
@@ -1,12 +1,16 @@
 package io.mycat.route.function;
 
-import io.mycat.config.model.rule.RuleAlgorithm;
-import io.mycat.util.StringUtil;
-import org.apache.log4j.Logger;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+import io.mycat.config.model.rule.RuleAlgorithm;
+import io.mycat.util.StringUtil;
 
 /**
  * 例子 按月份列分区 ，每个自然月一个分片，格式 between操作解析的范例
@@ -15,165 +19,179 @@ import java.util.*;
  *
  */
 public class PartitionByMonth extends AbstractPartitionAlgorithm implements
-		RuleAlgorithm {
-	private static final Logger LOGGER = Logger.getLogger(PartitionByDate.class);
-	private String sBeginDate;
-	/** 默认格式 */
-	private String dateFormat = "yyyy-MM-dd";
-	/** 场景 */
-	private int scene = -1;
-	private String sEndDate;
-	private Calendar beginDate;
-	private Calendar endDate;
-	private int nPartition;
+    RuleAlgorithm {
 
-	private ThreadLocal<SimpleDateFormat> formatter;
+    private static final Logger LOGGER = Logger.getLogger(PartitionByDate.class);
+    private String sBeginDate;
+    /** 默认格式 */
+    private String dateFormat = "yyyy-MM-dd";
+    /** 场景 */
+    private int scene = -1;
+    private String sEndDate;
+    private Calendar beginDate;
+    private Calendar endDate;
+    private int nPartition;
 
-	@Override
-	public void init() {
-		try {
-			if (StringUtil.isEmpty(sBeginDate) && StringUtil.isEmpty(sEndDate)) {
-				nPartition = 12;
-				scene = 1;
-				initFormatter();
-				beginDate = Calendar.getInstance();
-				beginDate.set(Calendar.MONTH, 0);
-				endDate = Calendar.getInstance();
-				endDate.set(Calendar.MONTH, 11);
-				return;
-			}
-			beginDate = Calendar.getInstance();
-			beginDate.setTime(new SimpleDateFormat(dateFormat)
-									  .parse(sBeginDate));
-			initFormatter();
-			if(sEndDate!=null&&!sEndDate.equals("")) {
-				endDate = Calendar.getInstance();
-				endDate.setTime(new SimpleDateFormat(dateFormat).parse(sEndDate));
-				nPartition = ((endDate.get(Calendar.YEAR) - beginDate.get(Calendar.YEAR)) * 12
-						+ endDate.get(Calendar.MONTH) - beginDate.get(Calendar.MONTH)) + 1;
+    private ThreadLocal<SimpleDateFormat> formatter;
 
-				if (nPartition <= 0) {
-					throw new java.lang.IllegalArgumentException("Incorrect time range for month partitioning!");
-				}
-			} else {
-				nPartition = -1;
-			}
-		} catch (ParseException e) {
-			throw new java.lang.IllegalArgumentException(e);
-		}
-	}
+    @Override
+    public void init() {
+        try {
+            if (StringUtil.isEmpty(sBeginDate) && StringUtil.isEmpty(sEndDate)) {
+                nPartition = 12;
+                scene = 1;
+                initFormatter();
+                beginDate = Calendar.getInstance();
+                beginDate.set(Calendar.MONTH, 0);
+                endDate = Calendar.getInstance();
+                endDate.set(Calendar.MONTH, 11);
+                return;
+            }
+            beginDate = Calendar.getInstance();
+            beginDate.setTime(new SimpleDateFormat(dateFormat)
+                .parse(sBeginDate));
+            initFormatter();
+            if (sEndDate != null && !sEndDate.equals("")) {
+                endDate = Calendar.getInstance();
+                endDate.setTime(new SimpleDateFormat(dateFormat).parse(sEndDate));
+                nPartition = ((endDate.get(Calendar.YEAR) - beginDate.get(Calendar.YEAR)) * 12
+                    + endDate.get(Calendar.MONTH) - beginDate.get(Calendar.MONTH)) + 1;
 
-	private void initFormatter() {
-		formatter = new ThreadLocal<SimpleDateFormat>() {
+                if (nPartition <= 0) {
+                    throw new java.lang.IllegalArgumentException("Incorrect time range for month partitioning!");
+                }
+            } else {
+                nPartition = -1;
+            }
+        } catch (ParseException e) {
+            throw new java.lang.IllegalArgumentException(e);
+        }
+    }
+
+    private void initFormatter() {
+        formatter = new ThreadLocal<SimpleDateFormat>() {
             @Override
             protected SimpleDateFormat initialValue() {
                 return new SimpleDateFormat(dateFormat);
             }
         };
-	}
+    }
 
-	/**
-	 * For circulatory partition, calculated value of target partition needs to be
-	 * rotated to fit the partition range
-	 */
-	private int reCalculatePartition(int targetPartition) {
-		/**
-		 * If target date is previous of start time of partition setting, shift
-		 * the delta range between target and start date to be positive value
-		 */
-		if (targetPartition < 0) {
-			targetPartition = nPartition - (-targetPartition) % nPartition;
-		}
+    /**
+     * For circulatory partition, calculated value of target partition needs to be
+     * rotated to fit the partition range
+     */
+    private int reCalculatePartition(int targetPartition) {
+        // 没有指定end_date，不是循环使用的情况，直接返回对应的targetPartition
+        if (nPartition == -1) {
+            return targetPartition;
+        }
+        /**
+         * If target date is previous of start time of partition setting, shift
+         * the delta range between target and start date to be positive value
+         */
+        if (targetPartition < 0) {
+            targetPartition = nPartition - (-targetPartition) % nPartition;
+        }
 
-		if (targetPartition >= nPartition) {
-			targetPartition =  targetPartition % nPartition;
-		}
+        if (targetPartition >= nPartition) {
+            targetPartition = targetPartition % nPartition;
+        }
 
-		return targetPartition;
-	}
+        return targetPartition;
+    }
 
-	@Override
-	public Integer calculate(String columnValue)  {
-		try {
-			if (scene == 1) {
-				Calendar curTime = Calendar.getInstance();
-				curTime.setTime(formatter.get().parse(columnValue));
-				return curTime.get(Calendar.MONTH);
-			}
-			int targetPartition;
-			Calendar curTime = Calendar.getInstance();
-			curTime.setTime(formatter.get().parse(columnValue));
-			targetPartition = ((curTime.get(Calendar.YEAR) - beginDate.get(Calendar.YEAR))
-					* 12 + curTime.get(Calendar.MONTH)
-					- beginDate.get(Calendar.MONTH));
+    @Override
+    public Integer calculate(String columnValue) {
+        try {
+            if (scene == 1) {
+                Calendar curTime = Calendar.getInstance();
+                curTime.setTime(formatter.get().parse(columnValue));
+                return curTime.get(Calendar.MONTH);
+            }
+            int targetPartition;
+            Calendar curTime = Calendar.getInstance();
+            curTime.setTime(formatter.get().parse(columnValue));
+            targetPartition = ((curTime.get(Calendar.YEAR) - beginDate.get(Calendar.YEAR))
+                * 12 + curTime.get(Calendar.MONTH)
+                - beginDate.get(Calendar.MONTH));
 
-			/**
-			 * For circulatory partition, calculated value of target partition needs to be
-			 * rotated to fit the partition range
- 			 */
-			if (nPartition > 0) {
-				targetPartition = reCalculatePartition(targetPartition);
-			}
-			return targetPartition;
+            /**
+             * For circulatory partition, calculated value of target partition needs to be
+             * rotated to fit the partition range
+             */
+            if (nPartition > 0) {
+                targetPartition = reCalculatePartition(targetPartition);
+            }
+            // 防止越界的情况
+            if (targetPartition < 0) {
+                targetPartition = 0;
+            }
+            return targetPartition;
 
-		} catch (ParseException e) {
-			throw new IllegalArgumentException(new StringBuilder().append("columnValue:").append(columnValue).append(" Please check if the format satisfied.").toString(),e);
-		}
-	}
+        } catch (ParseException e) {
+            throw new IllegalArgumentException(new StringBuilder().append("columnValue:").append(columnValue)
+                .append(" Please check if the format satisfied.").toString(), e);
+        }
+    }
 
-	@Override
-	public Integer[] calculateRange(String beginValue, String endValue) {
-		try {
-			return doCalculateRange(beginValue, endValue,beginDate);
-		} catch (ParseException e) {
-			LOGGER.error("error",e);
-			return new Integer[0];
-		}
-	}
+    @Override
+    public Integer[] calculateRange(String beginValue, String endValue) {
+        try {
+            return doCalculateRange(beginValue, endValue, beginDate);
+        } catch (ParseException e) {
+            LOGGER.error("error", e);
+            return new Integer[0];
+        }
+    }
 
-	private Integer[] doCalculateRange(String beginValue, String endValue,Calendar beginDate) throws ParseException {
-		int startPartition, endPartition;
-		Calendar partitionTime = Calendar.getInstance();
-		SimpleDateFormat format = new SimpleDateFormat(dateFormat);
-		partitionTime.setTime(format.parse(beginValue));
-		startPartition = ((partitionTime.get(Calendar.YEAR) - beginDate.get(Calendar.YEAR))
-				* 12 + partitionTime.get(Calendar.MONTH)
-				- beginDate.get(Calendar.MONTH));
-		partitionTime.setTime(format.parse(endValue));
-		endPartition = ((partitionTime.get(Calendar.YEAR) - beginDate.get(Calendar.YEAR))
-				* 12 + partitionTime.get(Calendar.MONTH)
-				- beginDate.get(Calendar.MONTH));
+    private Integer[] doCalculateRange(String beginValue, String endValue, Calendar beginDate) throws ParseException {
+        int startPartition, endPartition;
+        Calendar partitionTime = Calendar.getInstance();
+        SimpleDateFormat format = new SimpleDateFormat(dateFormat);
+        partitionTime.setTime(format.parse(beginValue));
+        startPartition = ((partitionTime.get(Calendar.YEAR) - beginDate.get(Calendar.YEAR))
+            * 12 + partitionTime.get(Calendar.MONTH)
+            - beginDate.get(Calendar.MONTH));
+        partitionTime.setTime(format.parse(endValue));
+        endPartition = ((partitionTime.get(Calendar.YEAR) - beginDate.get(Calendar.YEAR))
+            * 12 + partitionTime.get(Calendar.MONTH)
+            - beginDate.get(Calendar.MONTH));
 
-		List<Integer> list = new ArrayList<>();
+        List<Integer> list = new ArrayList<>();
 
-		while (startPartition <= endPartition) {
-			Integer nodeValue = reCalculatePartition(startPartition);
-			if (Collections.frequency(list, nodeValue) < 1)
-				list.add(nodeValue);
-			startPartition++;
-		}
-		int size = list.size();
-		// 当在场景1： "2015-01-01", "2014-04-03" 范围出现的时候
-		// 是应该返回null 还是返回 [] ?
-		return (list.toArray(new Integer[size]));
-	}
+        while (startPartition <= endPartition) {
+            Integer nodeValue = reCalculatePartition(startPartition);
+            if (nodeValue < 0) {
+                nodeValue = 0;
+            }
+            if (Collections.frequency(list, nodeValue) < 1) {
+                list.add(nodeValue);
+            }
+            startPartition++;
+        }
+        int size = list.size();
+        // 当在场景1： "2015-01-01", "2014-04-03" 范围出现的时候
+        // 是应该返回null 还是返回 [] ?
+        return (list.toArray(new Integer[size]));
+    }
 
-	@Override
-	public int getPartitionNum() {
-		int nPartition = this.nPartition;
-		return nPartition;
-	}
+    @Override
+    public int getPartitionNum() {
+        int nPartition = this.nPartition;
+        return nPartition;
+    }
 
-	public void setsBeginDate(String sBeginDate) {
-		this.sBeginDate = sBeginDate;
-	}
+    public void setsBeginDate(String sBeginDate) {
+        this.sBeginDate = sBeginDate;
+    }
 
-	public void setDateFormat(String dateFormat) {
-		this.dateFormat = dateFormat;
-	}
+    public void setDateFormat(String dateFormat) {
+        this.dateFormat = dateFormat;
+    }
 
-	public void setsEndDate(String sEndDate) {
-		this.sEndDate = sEndDate;
-	}
+    public void setsEndDate(String sEndDate) {
+        this.sEndDate = sEndDate;
+    }
 
 }

--- a/src/main/java/io/mycat/route/parser/ManagerParseReload.java
+++ b/src/main/java/io/mycat/route/parser/ManagerParseReload.java
@@ -38,6 +38,7 @@ public final class ManagerParseReload {
     public static final int CONFIG_ALL = 5;
     public static final int SQL_SLOW = 6;
     public static final int QUERY_CF = 8;
+    public static final int SQL_STAT = 9;
        
     public static int parse(String stmt, int offset) {
         int i = offset;
@@ -180,6 +181,13 @@ public final class ManagerParseReload {
                     && (c4 == 'L' || c4 == 'l') && (c5 == 'O' || c5 == 'o') && (c6 == 'W' || c6 == 'w')
                     && stmt.length() > ++offset && stmt.charAt(offset) != ' ') {
                     return SQL_SLOW ;
+            }
+
+            // reload @@sqlstat
+            if ((c1 == 'Q' || c1 == 'q') && (c2 == 'L' || c2 == 'l') && (c3 == 's' || c3 == 'S')
+                && (c4 == 'T' || c4 == 't') && (c5 == 'A' || c5 == 'a') && (c6 == 'T' || c6 == 't')
+                && stmt.length() > ++offset && stmt.charAt(offset) != ' ') {
+                return SQL_STAT ;
             }
 
             return OTHER;

--- a/src/main/java/io/mycat/server/NonBlockingSession.java
+++ b/src/main/java/io/mycat/server/NonBlockingSession.java
@@ -383,7 +383,13 @@ public class NonBlockingSession implements Session {
         BackendConnection c = target.remove(rrn);
         if (c != null) {
             if (debug) {
-                LOGGER.debug("release connection " + c);
+                //LOGGER.debug("release connection " + c);
+                String sql =  rrn.getStatement();
+                if(sql!=null){
+                    sql = sql.replaceAll("[\r\n]+", "");
+                }
+                LOGGER.debug("releaseConnection Connection@{} [id={}] for node={}, sql={}",
+                    new Object[]{c.hashCode(), c.getId(), rrn.getName(), sql});
             }
             if (c.getAttachment() != null) {
                 c.setAttachment(null);
@@ -436,6 +442,15 @@ public class NonBlockingSession implements Session {
                                             BackendConnection conn) {
         // System.out.println("bind connection "+conn+
         // " to key "+key.getName()+" on sesion "+this);
+        if(LOGGER.isDebugEnabled()){
+            String sql =  key.getStatement();
+            if(sql!=null){
+                sql = sql.replaceAll("[\r\n]+", "");
+            }
+            LOGGER.debug("bindConnection Connection@{} [id={}] for node={}, sql={}",
+                new Object[]{conn.hashCode(), conn.getId(), key.getName(), sql});
+        }
+
         return target.put(key, conn);
     }
     

--- a/src/main/java/io/mycat/server/ServerConnection.java
+++ b/src/main/java/io/mycat/server/ServerConnection.java
@@ -36,11 +36,11 @@ import io.mycat.config.ErrorCode;
 import io.mycat.config.model.SchemaConfig;
 import io.mycat.net.FrontendConnection;
 import io.mycat.route.RouteResultset;
-import io.mycat.server.handler.MysqlInformationSchemaHandler;
 import io.mycat.server.handler.MysqlProcHandler;
 import io.mycat.server.parser.ServerParse;
 import io.mycat.server.response.Heartbeat;
 import io.mycat.server.response.InformationSchemaProfiling;
+import io.mycat.server.response.InformationSchemaProfilingSqlyog;
 import io.mycat.server.response.Ping;
 import io.mycat.server.util.SchemaUtil;
 import io.mycat.util.SplitUtil;
@@ -224,7 +224,13 @@ public class ServerConnection extends FrontendConnection {
 			InformationSchemaProfiling.response(this);
 			return;
 		}
-		
+
+		//fix sqlyog select state, round(sum(duration),5) as `duration (summed) in sec` from information_schema.profiling where query_id = 0 group by state order by `duration (summed) in sec` desc
+		if(ServerParse.SELECT == type &&sql.contains(" information_schema.profiling ")&&sql.contains("duration (summed) in sec"))
+		{
+			InformationSchemaProfilingSqlyog.response(this);
+			return;
+		}
 		/* 当已经设置默认schema时，可以通过在sql中指定其它schema的方式执行
 		 * 相关sql，已经在mysql客户端中验证。
 		 * 所以在此处增加关于sql中指定Schema方式的支持。

--- a/src/main/java/io/mycat/server/ServerConnection.java
+++ b/src/main/java/io/mycat/server/ServerConnection.java
@@ -54,6 +54,8 @@ public class ServerConnection extends FrontendConnection {
 			.getLogger(ServerConnection.class);
 	private static final long AUTH_TIMEOUT = 15 * 1000L;
 
+	/** 保存SET SQL_SELECT_LIMIT的值, default 解析为-1. */
+	private volatile  int sqlSelectLimit = -1;
 	private volatile  boolean txReadonly;
 	private volatile int txIsolation;
 	private volatile boolean autocommit;
@@ -108,6 +110,14 @@ public class ServerConnection extends FrontendConnection {
 
 	public void setTxReadonly(boolean txReadonly) {
 		this.txReadonly = txReadonly;
+	}
+
+	public int getSqlSelectLimit() {
+		return sqlSelectLimit;
+	}
+
+	public void setSqlSelectLimit(int sqlSelectLimit) {
+		this.sqlSelectLimit = sqlSelectLimit;
 	}
 
 	public long getLastInsertId() {

--- a/src/main/java/io/mycat/server/ServerConnection.java
+++ b/src/main/java/io/mycat/server/ServerConnection.java
@@ -54,6 +54,7 @@ public class ServerConnection extends FrontendConnection {
 			.getLogger(ServerConnection.class);
 	private static final long AUTH_TIMEOUT = 15 * 1000L;
 
+	private volatile  boolean txReadonly;
 	private volatile int txIsolation;
 	private volatile boolean autocommit;
 	private volatile boolean preAcStates; //上一个ac状态,默认为true
@@ -72,6 +73,7 @@ public class ServerConnection extends FrontendConnection {
 		this.txInterrupted = false;
 		this.autocommit = true;
 		this.preAcStates = true;
+		this.txReadonly = false;
 	}
 
 	@Override
@@ -98,6 +100,14 @@ public class ServerConnection extends FrontendConnection {
 
 	public void setAutocommit(boolean autocommit) {
 		this.autocommit = autocommit;
+	}
+
+	public boolean isTxReadonly() {
+		return txReadonly;
+	}
+
+	public void setTxReadonly(boolean txReadonly) {
+		this.txReadonly = txReadonly;
 	}
 
 	public long getLastInsertId() {

--- a/src/main/java/io/mycat/server/ServerQueryHandler.java
+++ b/src/main/java/io/mycat/server/ServerQueryHandler.java
@@ -23,13 +23,13 @@
  */
 package io.mycat.server;
 
-import io.mycat.route.RouteService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.mycat.config.ErrorCode;
 import io.mycat.net.handler.FrontendQueryHandler;
 import io.mycat.net.mysql.OkPacket;
+import io.mycat.route.RouteService;
 import io.mycat.server.handler.BeginHandler;
 import io.mycat.server.handler.CommandHandler;
 import io.mycat.server.handler.Explain2Handler;
@@ -167,6 +167,18 @@ public class ServerQueryHandler implements FrontendQueryHandler {
 				break;
 			}
 			c.execute(sql, rs & 0xff);
+		}
+
+		switch (sqlType) {
+			case ServerParse.SELECT:
+			case ServerParse.DELETE:
+			case ServerParse.UPDATE:
+			case ServerParse.INSERT:
+			case ServerParse.COMMAND:
+				// curd 在后面会更新
+				break;
+			default:
+				c.setExecuteSql(null);
 		}
 	}
 

--- a/src/main/java/io/mycat/server/handler/SelectHandler.java
+++ b/src/main/java/io/mycat/server/handler/SelectHandler.java
@@ -36,6 +36,7 @@ public final class SelectHandler {
 
 	public static void handle(String stmt, ServerConnection c, int offs) {
 		int offset = offs;
+		c.setExecuteSql(null);
 		switch (ServerParseSelect.parse(stmt, offs)) {
 		case ServerParseSelect.VERSION_COMMENT:
 			SelectVersionComment.response(c);
@@ -102,6 +103,7 @@ public final class SelectHandler {
 				SelectTxReadOnly.response(c);
 				break;
 		default:
+			c.setExecuteSql(stmt);
 			c.execute(stmt, ServerParse.SELECT);
 		}
 	}

--- a/src/main/java/io/mycat/server/handler/SetHandler.java
+++ b/src/main/java/io/mycat/server/handler/SetHandler.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import io.mycat.config.ErrorCode;
 import io.mycat.config.Isolations;
 import io.mycat.net.mysql.OkPacket;
+import io.mycat.route.parser.util.ParseUtil;
 import io.mycat.server.ServerConnection;
 import io.mycat.server.parser.ServerParse;
 import io.mycat.server.parser.ServerParseSet;
@@ -41,6 +42,7 @@ import static io.mycat.server.parser.ServerParseSet.CHARACTER_SET_CLIENT;
 import static io.mycat.server.parser.ServerParseSet.CHARACTER_SET_CONNECTION;
 import static io.mycat.server.parser.ServerParseSet.CHARACTER_SET_RESULTS;
 import static io.mycat.server.parser.ServerParseSet.NAMES;
+import static io.mycat.server.parser.ServerParseSet.SQL_SELECT_LIMIT;
 import static io.mycat.server.parser.ServerParseSet.TX_READONLY;
 import static io.mycat.server.parser.ServerParseSet.TX_READWRITE;
 import static io.mycat.server.parser.ServerParseSet.TX_READ_COMMITTED;
@@ -162,6 +164,23 @@ public final class SetHandler {
 					c.writeErrMessage(ErrorCode.ER_UNKNOWN_CHARACTER_SET, "Unknown charset '" + charset + "'");
 				}
 			}
+			break;
+		case SQL_SELECT_LIMIT:
+			String limit = ParseUtil.parseString(stmt);
+			int sqlSelectLimit = -1;
+			if ("default".equalsIgnoreCase(limit)) {
+				sqlSelectLimit = -1;
+			} else {
+				try{
+					sqlSelectLimit = Integer.parseInt(limit);
+				} catch ( Exception  ex) {
+					c.writeErrMessage(ErrorCode.ER_YES, "Unsupported statement:"+ex.getMessage());
+					break;
+				}
+
+			}
+			c.setSqlSelectLimit(sqlSelectLimit);
+			c.write(c.writeToBuffer(OkPacket.OK, c.allocate()));
 			break;
 		case CHARACTER_SET_CLIENT:
 		case CHARACTER_SET_CONNECTION:

--- a/src/main/java/io/mycat/server/handler/SetHandler.java
+++ b/src/main/java/io/mycat/server/handler/SetHandler.java
@@ -23,29 +23,32 @@
  */
 package io.mycat.server.handler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.mycat.config.ErrorCode;
+import io.mycat.config.Isolations;
+import io.mycat.net.mysql.OkPacket;
+import io.mycat.server.ServerConnection;
+import io.mycat.server.parser.ServerParse;
+import io.mycat.server.parser.ServerParseSet;
+import io.mycat.server.response.CharacterSet;
+import io.mycat.util.SetIgnoreUtil;
+
 import static io.mycat.server.parser.ServerParseSet.AUTOCOMMIT_OFF;
 import static io.mycat.server.parser.ServerParseSet.AUTOCOMMIT_ON;
 import static io.mycat.server.parser.ServerParseSet.CHARACTER_SET_CLIENT;
 import static io.mycat.server.parser.ServerParseSet.CHARACTER_SET_CONNECTION;
 import static io.mycat.server.parser.ServerParseSet.CHARACTER_SET_RESULTS;
 import static io.mycat.server.parser.ServerParseSet.NAMES;
+import static io.mycat.server.parser.ServerParseSet.TX_READONLY;
+import static io.mycat.server.parser.ServerParseSet.TX_READWRITE;
 import static io.mycat.server.parser.ServerParseSet.TX_READ_COMMITTED;
 import static io.mycat.server.parser.ServerParseSet.TX_READ_UNCOMMITTED;
 import static io.mycat.server.parser.ServerParseSet.TX_REPEATED_READ;
 import static io.mycat.server.parser.ServerParseSet.TX_SERIALIZABLE;
 import static io.mycat.server.parser.ServerParseSet.XA_FLAG_OFF;
 import static io.mycat.server.parser.ServerParseSet.XA_FLAG_ON;
-
-import io.mycat.server.parser.ServerParse;
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
-
-import io.mycat.config.ErrorCode;
-import io.mycat.config.Isolations;
-import io.mycat.net.mysql.OkPacket;
-import io.mycat.server.ServerConnection;
-import io.mycat.server.parser.ServerParseSet;
-import io.mycat.server.response.CharacterSet;
-import io.mycat.util.SetIgnoreUtil;
 
 /**
  * SET 语句处理
@@ -112,6 +115,16 @@ public final class SetHandler {
 		}
 		case TX_SERIALIZABLE: {
 			c.setTxIsolation(Isolations.SERIALIZABLE);
+			c.write(c.writeToBuffer(OkPacket.OK, c.allocate()));
+			break;
+		}
+		case TX_READONLY: {
+			c.setTxReadonly(true);
+			c.write(c.writeToBuffer(OkPacket.OK, c.allocate()));
+			break;
+		}
+		case TX_READWRITE: {
+			c.setTxReadonly(false);
 			c.write(c.writeToBuffer(OkPacket.OK, c.allocate()));
 			break;
 		}

--- a/src/main/java/io/mycat/server/parser/ServerParseSet.java
+++ b/src/main/java/io/mycat/server/parser/ServerParseSet.java
@@ -44,6 +44,9 @@ public final class ServerParseSet {
 	public static final int XA_FLAG_ON = 11;
 	public static final int XA_FLAG_OFF = 12;
 
+	public static final int TX_READONLY = 13;
+	public static final int TX_READWRITE = 14;
+
 	public static int parse(String stmt, int offset) {
 		int i = offset;
 		for (; i < stmt.length(); i++) {
@@ -483,12 +486,85 @@ public final class ServerParseSet {
 						case 'I':
 						case 'i':
 							return isolation(stmt, offset);
+						case 'R':
+						case 'r':
+							return transactionRead(stmt, offset);
 						default:
 							return OTHER;
 						}
 					}
 //					return OTHER;
 //				}
+			}
+		}
+		return OTHER;
+	}
+
+	// SET [SESSION] TRANSACTION READ WRITE|ONLY
+	private static int transactionRead(String stmt, int offset) {
+		if (stmt.length() > offset + 4) {
+			char c1 = stmt.charAt(++offset);
+			char c2 = stmt.charAt(++offset);
+			char c3 = stmt.charAt(++offset);
+			if ((c1 == 'E' || c1 == 'e') && (c2 == 'A' || c2 == 'a')
+				&& (c3 == 'D' || c3 == 'd')) {
+//				for (;;) {
+				while (stmt.length() > ++offset) {
+					switch (stmt.charAt(offset)) {
+						case ' ':
+						case '\r':
+						case '\n':
+						case '\t':
+							continue;
+						case 'W':
+						case 'w':
+							return transactionReadWrite(stmt, offset);
+						case 'O':
+						case 'o':
+							return transactionReadOnly(stmt, offset);
+						default:
+							return OTHER;
+					}
+				}
+//					return OTHER;
+//				}
+			}
+		}
+		return OTHER;
+	}
+
+	// SET [SESSION] TRANSACTION READ WRITE
+	private static int transactionReadWrite(String stmt, int offset) {
+		if (stmt.length() > offset + 4) {
+			char c1 = stmt.charAt(++offset);
+			char c2 = stmt.charAt(++offset);
+			char c3 = stmt.charAt(++offset);
+			char c4 = stmt.charAt(++offset);
+
+			if ((c1 == 'R' || c1 == 'r')
+				&& (c2 == 'I' || c2 == 'i')
+				&& (c3 == 'T' || c3 == 't')
+				&& (c4 == 'E' || c4 == 'e')
+				&& (stmt.length() == ++offset || ParseUtil.isEOF(stmt
+				.charAt(offset)))) {
+				return TX_READWRITE;
+			}
+		}
+		return OTHER;
+	}
+	// SET [SESSION] TRANSACTION READ ONLY
+	private static int transactionReadOnly(String stmt, int offset) {
+		if (stmt.length() > offset + 3) {
+			char c1 = stmt.charAt(++offset);
+			char c2 = stmt.charAt(++offset);
+			char c3 = stmt.charAt(++offset);
+
+			if ((c1 == 'N' || c1 == 'n')
+				&& (c2 == 'L' || c2 == 'l')
+				&& (c3 == 'Y' || c3 == 'y')
+				&& (stmt.length() == ++offset || ParseUtil.isEOF(stmt
+				.charAt(offset)))) {
+				return TX_READONLY;
 			}
 		}
 		return OTHER;

--- a/src/main/java/io/mycat/server/parser/ServerParseSet.java
+++ b/src/main/java/io/mycat/server/parser/ServerParseSet.java
@@ -46,6 +46,7 @@ public final class ServerParseSet {
 
 	public static final int TX_READONLY = 13;
 	public static final int TX_READWRITE = 14;
+	public static final int SQL_SELECT_LIMIT = 15;
 
 	public static int parse(String stmt, int offset) {
 		int i = offset;
@@ -71,7 +72,7 @@ public final class ServerParseSet {
 				return names(stmt, i);
 			case 'S':
 			case 's':
-				return session(stmt, i);
+				return parseS(stmt, i);
 			case 'T':
 			case 't':
 				return transaction(stmt, i);
@@ -421,7 +422,34 @@ public final class ServerParseSet {
 		return OTHER;
 	}
 
+	private static int parseS(String stmt, int offset) {
+		if (stmt.length() > offset + 1) {
+			char c1 = stmt.charAt(offset + 1);
+			if(c1=='E' || c1=='e'){
+				return session(stmt, offset);
+			}
+			if(c1=='Q' || c1=='q'){
+				return sqlSelectLimit(stmt, offset);
+			}
+		}
+		return OTHER;
+	}
+
+
+	// SET SQL_SELECT_LIMIT=N|DEFAULT
+	private static int sqlSelectLimit(String stmt, int offset) {
+		// SET SQL_SELECT_LIMIT=N|DEFAULT
+		if (stmt.length() > offset + 15) {
+			String var = stmt.substring(offset, offset+16);
+			if(var.equalsIgnoreCase("SQL_SELECT_LIMIT")) {
+				return SQL_SELECT_LIMIT;
+			}
+		}
+		return OTHER;
+	}
+
 	// SET SESSION' '
+	// SET SQL_SELECT_LIMIT=N|DEFAULT
 	private static int session(String stmt, int offset) {
 		if (stmt.length() > offset + 7) {
 			char c1 = stmt.charAt(++offset);

--- a/src/main/java/io/mycat/server/response/InformationSchemaProfilingSqlyog.java
+++ b/src/main/java/io/mycat/server/response/InformationSchemaProfilingSqlyog.java
@@ -1,0 +1,74 @@
+package io.mycat.server.response;
+
+import java.nio.ByteBuffer;
+
+import io.mycat.backend.mysql.PacketUtil;
+import io.mycat.config.Fields;
+import io.mycat.net.mysql.EOFPacket;
+import io.mycat.net.mysql.FieldPacket;
+import io.mycat.net.mysql.ResultSetHeaderPacket;
+import io.mycat.server.ServerConnection;
+
+
+public class InformationSchemaProfilingSqlyog
+{
+
+    private static final int FIELD_COUNT = 2;
+
+
+
+	/**
+	 * response method.
+	 * @param c
+	 */
+	public static void response(ServerConnection c) {
+
+        ResultSetHeaderPacket header = PacketUtil.getHeader(FIELD_COUNT);
+        FieldPacket[] fields = new FieldPacket[FIELD_COUNT];
+        EOFPacket eof = new EOFPacket();
+
+
+        int i = 0;
+        byte packetId = 0;
+        header.packetId = ++packetId;
+        fields[i] = PacketUtil.getField("State" , Fields.FIELD_TYPE_VAR_STRING);
+        fields[i].packetId = ++packetId;
+        fields[i+1] = PacketUtil.getField("duration (summed) in sec" , Fields.FIELD_TYPE_DECIMAL);
+        fields[i+1].packetId = ++packetId;
+
+        eof.packetId = ++packetId;
+        ByteBuffer buffer = c.allocate();
+
+        // write header
+        buffer = header.write(buffer, c,true);
+
+        // write fields
+        for (FieldPacket field : fields) {
+            buffer = field.write(buffer, c,true);
+        }
+
+        // write eof
+        buffer = eof.write(buffer, c,true);
+
+        // write rows
+         packetId = eof.packetId;
+
+
+        // write last eof
+        EOFPacket lastEof = new EOFPacket();
+        lastEof.packetId = ++packetId;
+        buffer = lastEof.write(buffer, c,true);
+
+        // post write
+        c.write(buffer);
+		
+		
+    }
+
+
+
+
+
+
+	
+}

--- a/src/test/java/io/mycat/parser/ServerParserTest.java
+++ b/src/test/java/io/mycat/parser/ServerParserTest.java
@@ -311,6 +311,26 @@ public class ServerParserTest {
     }
 
     @Test
+    public void testTxReadOnly() {
+        Assert.assertEquals(ServerParseSet.TX_READONLY,
+            ServerParseSet.parse("  SET SESSION TRANSACTION READ ONLY  ", "  SET".length()));
+        Assert.assertEquals(ServerParseSet.TX_READONLY,
+            ServerParseSet.parse(" set session transaction read only  ", " SET".length()));
+        Assert.assertEquals(ServerParseSet.TX_READONLY,
+            ServerParseSet.parse(" set session transaCTION Read Only ", " SET".length()));
+    }
+
+    @Test
+    public void testTxReadWrite() {
+        Assert.assertEquals(ServerParseSet.TX_READWRITE,
+            ServerParseSet.parse("  SET SESSION TRANSACTION READ WRITE  ", "  SET".length()));
+        Assert.assertEquals(ServerParseSet.TX_READWRITE,
+            ServerParseSet.parse(" set session transaction read write  ", " SET".length()));
+        Assert.assertEquals(ServerParseSet.TX_READWRITE,
+            ServerParseSet.parse(" set session transaCTION Read Write ", " SET".length()));
+    }
+
+    @Test
     public void testTxRepeatedRead() {
         Assert.assertEquals(ServerParseSet.TX_REPEATED_READ,
                 ServerParseSet.parse("  SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE   READ  ", "  SET".length()));

--- a/src/test/java/io/mycat/parser/ServerParserTest.java
+++ b/src/test/java/io/mycat/parser/ServerParserTest.java
@@ -321,6 +321,16 @@ public class ServerParserTest {
     }
 
     @Test
+    public void testSqlSelectLimit() {
+        Assert.assertEquals(ServerParseSet.SQL_SELECT_LIMIT,
+            ServerParseSet.parse("  SET SQL_SELECT_LIMIT=1  ", "  SET".length()));
+        Assert.assertEquals(ServerParseSet.SQL_SELECT_LIMIT,
+            ServerParseSet.parse(" set sql_select_limit=1  ", " SET".length()));
+        Assert.assertEquals(ServerParseSet.SQL_SELECT_LIMIT,
+            ServerParseSet.parse(" Set Sql_Select_Limit=1 ", " SET".length()));
+    }
+
+    @Test
     public void testTxReadWrite() {
         Assert.assertEquals(ServerParseSet.TX_READWRITE,
             ServerParseSet.parse("  SET SESSION TRANSACTION READ WRITE  ", "  SET".length()));


### PR DESCRIPTION
1.参考fix navicat增加fix sqlyog应答，下面的语句参考navicat处理方式直接应答成功
`//fix sqlyog select state, round(sum(duration),5) as `duration (summed) in sec` from information_schema.profiling where query_id = 0 group by state order by `duration (summed) in sec` desc`

2.修正按月分区函数没有指定end_date时范围条件计算的索引都是0问题，增加索引号小于0时调整为0逻辑

3.管理端口，新增支持reload @@sqlstat=open|close动态设置sql监控

4.增加设置事务只读语句支持，传递事务只读状态都后端连接，解决Cannot execute statement in a READ ONLY transaction错误.
SET SESSION TRANSACTION READ ONLY;SET SESSION TRANSACTION READ WRITE;

5.修正旧版mysql客户端发送COM_FIELD_LIST命令获取表字段信息时只有fieldEof没有RowEof包导致后面的查询语句数据解析错误问题，增加连接获取和释放日志打印信息

6.增加SET SQL_SELECT_LIMIT=N|DEFAULT语句解析，保存解析结果到前端连接，发送语句到后端查询的时候再传递到后端。防止前端设置了这个值，后端连接给其他查询语句使用返回结果被限制问题（只返回1条记录问题)。对jdbc和mysql协议已测试会传递到后端，对PostgreSQLBackendConnection暂时还不支持传递都后端数据库。