### PR TITLE
fix bug for statistic with delete statement:

### DIFF
--- a/src/main/java/io/mycat/statistic/stat/SqlResultSizeRecorder.java
+++ b/src/main/java/io/mycat/statistic/stat/SqlResultSizeRecorder.java
@@ -22,7 +22,7 @@ public class SqlResultSizeRecorder {
 		    sqlResultSet =this.sqlResultSetMap.get(sql);
 			sqlResultSet.count();
 			sqlResultSet.setSql(sql);
-			System.out.println(sql);
+			//System.out.println(sql);
 			sqlResultSet.setResultSetSize(resultSetSize);
 		}else{
 		sqlResultSet = new SqlResultSet();


### PR DESCRIPTION
test case:

	delete from tb1;
	delete tb1 from tb1;

	delete tb1 from tb1, tb2 where tb1.f1 = tb2.f1;
	delete tb1 from tb1, tb2 where tb1.f1 = tb2.f1;
	delete tb1, tb2 from tb1, tb2 where tb1.f1 = tb2.f1;

	delete tb1 from tb1 left join tb2 on tb1.f1 = tb2.f1;
	delete tb2 from tb1 left join tb2 on tb1.f1 = tb2.f1;
	delete tb1, tb2 from tb1 left join tb2 on tb1.f1 = tb2.f1;

	delete t1 from tb1 as t1, tb2 as t2 where t1.f1 = t2.f1;
	delete t2 from tb1 as t1, tb2 as t2 where t1.f1 = t2.f1;
	delete t1, t2 from tb1 as t1, tb2 as t2 where t1.f1 = t2.f1;

	delete t1 from tb1 as t1 left join tb2 as t2 on t1.f1 = t2.f1;
	delete t2 from tb1 as t1 left join tb2 as t2 on t1.f1 = t2.f1;
	delete t1, t2 from tb1 as t1 left join tb2 as t2 on t1.f1 = t2.f1;