### PR TITLE
fix: 解决因"浅解析"错误识别SQL类型导致进入了DESC类型分支的死循环问题

### DIFF
--- a/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
+++ b/src/main/java/io/mycat/route/impl/DruidMycatRouteStrategy.java
@@ -773,6 +773,8 @@ public class DruidMycatRouteStrategy extends AbstractRouteStrategy {
 				} else {
 					pos++;
 				}
+			} else {
+				break;
 			}
 		}
 

--- a/src/main/java/io/mycat/server/parser/ServerParse.java
+++ b/src/main/java/io/mycat/server/parser/ServerParse.java
@@ -70,8 +70,6 @@ public final class ServerParse {
 
     public static int parse(String stmt) {
 		int length = stmt.length();
-		//FIX BUG FOR SQL SUCH AS /XXXX/SQL
-		int rt = -1;
 		for (int i = 0; i < length; ++i) {
 			switch (stmt.charAt(i)) {
 			case ' ':
@@ -94,104 +92,48 @@ public final class ServerParse {
 				continue;
 			case 'A':
 			case 'a':
-				rt = aCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return aCheck(stmt, i);
 			case 'B':
 			case 'b':
-				rt = beginCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return beginCheck(stmt, i);
 			case 'C':
 			case 'c':
-				rt = commitOrCallCheckOrCreate(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return commitOrCallCheckOrCreate(stmt, i);
 			case 'D':
 			case 'd':
-				rt = deleteOrdCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return deleteOrdCheck(stmt, i);
 			case 'E':
 			case 'e':
-				rt = explainCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return explainCheck(stmt, i);
 			case 'I':
 			case 'i':
-				rt = insertCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
-				case 'M':
-				case 'm':
-					rt = migrateCheck(stmt, i);
-					if (rt != OTHER) {
-						return rt;
-					}
-					continue;
+				return insertCheck(stmt, i);
+			case 'M':
+			case 'm':
+				return migrateCheck(stmt, i);
 			case 'R':
 			case 'r':
-				rt = rCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return rCheck(stmt, i);
 			case 'S':
 			case 's':
-				rt = sCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return sCheck(stmt, i);
 			case 'T':
 			case 't':
-				rt = tCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return tCheck(stmt, i);
 			case 'U':
 			case 'u':
-				rt = uCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return uCheck(stmt, i);
 			case 'K':
 			case 'k':
-				rt = killCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return killCheck(stmt, i);
 			case 'H':
 			case 'h':
-				rt = helpCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return helpCheck(stmt, i);
 			case 'L':
 			case 'l':
-				rt = lCheck(stmt, i);
-				if (rt != OTHER) {
-					return rt;
-				}
-				continue;
+				return lCheck(stmt, i);
 			default:
-				continue;
+				return OTHER;
 			}
 		}
 		return OTHER;


### PR DESCRIPTION
1. 补全DESC类型分支中的循环闭环。
2. 执行浅解析时，仅匹配第一个可见起始词，一旦匹配失败，则直接将其判定为OTHER类型，防止进入其他语句类型的分支中，最终交由 Druid Parse 进行语法解析，并反馈错误信息。
3. 此修复方式对 HintSQL 的类型识别无影响。

Fixes #2498