### PR TITLE
在团队开发的系统使用中使用mycat，发现进行insert操作，当语句中有插入的值为转义符 [例：INSERT INTO table(co…

### DIFF
--- a/src/main/java/io/mycat/route/util/RouterUtil.java
+++ b/src/main/java/io/mycat/route/util/RouterUtil.java
@@ -812,6 +812,10 @@ public class RouterUtil {
 						currentValue.append(nextCode);
 						pos++;
 						continue;
+					} else if (nextCode == '\\') {
+						currentValue.append(nextCode);
+						pos++;
+						continue;
 					}
 				}
 				if (c == '\"' && flag == 1) {


### PR DESCRIPTION
…lumn1, column2, column3, column4)  VALUES ('value1' ,  'value2', '\\',  'value4');]，出现Cause: java.sql.SQLSyntaxErrorException: String index out of range: -1报错，查看源码，源代码io.mycat.route.util.RouterUtil#parseSqlValueArrayAndSuffixStr发现连续的转义符('\\')没有被正确的处理，修改此方法解决报错，在处理 VALUES 后面的值，处理值中含有单引号或双引号后，添加对连续的转义符的支持，代码如下：
if (flag == 1  || flag == 2) {
    currentValue.append(c);
    if (c == '\\') {
        char nextCode = valuesAndSuffixStr.charAt(pos + 1);
        if (nextCode == '\'' || nextCode == '\"') {
            currentValue.append(nextCode);
            pos++;
            continue;
        // 新增代码开始
        } else if (nextCode == '\\') {
            currentValue.append(nextCode);
            pos++;
            continue;
        // 新增代码结束
        }
    }
    if (c == '\"' && flag == 1) {
        flag = 0;
        continue;
    }
    if (c == '\'' && flag == 2) {
        flag = 0;
        continue;
    }
}