### PR TITLE
#2589 批量Insert丢数据问题 

### DIFF
--- a/src/main/java/io/mycat/net/AbstractConnection.java
+++ b/src/main/java/io/mycat/net/AbstractConnection.java
@@ -553,7 +553,7 @@ public abstract class AbstractConnection implements NIOConnection {
 	/**
 	 * 清理资源
 	 */
-	protected void cleanup() {
+    synchronized protected void cleanup() {
 		
 		// 清理资源占用
 		if (readBuffer != null) {

--- a/src/main/java/io/mycat/net/FrontendConnection.java
+++ b/src/main/java/io/mycat/net/FrontendConnection.java
@@ -613,7 +613,7 @@ public abstract class FrontendConnection extends AbstractConnection {
 		flag |= Capabilities.CLIENT_TRANSACTIONS;
 		// flag |= ServerDefs.CLIENT_RESERVED;
 		flag |= Capabilities.CLIENT_SECURE_CONNECTION;
-        flag |= Capabilities.CLIENT_MULTI_STATEMENTS;
+        // flag |= Capabilities.CLIENT_MULTI_STATEMENTS;
         flag |= Capabilities.CLIENT_MULTI_RESULTS;
         boolean useHandshakeV10 = MycatServer.getInstance().getConfig().getSystem().getUseHandshakeV10() == 1;
         if(useHandshakeV10) {

--- a/src/main/java/io/mycat/net/handler/FrontendAuthenticator.java
+++ b/src/main/java/io/mycat/net/handler/FrontendAuthenticator.java
@@ -214,6 +214,15 @@ public class FrontendAuthenticator implements NIOHandler {
         source.setUser(auth.user);
         source.setSchema(auth.database);
         source.setCharsetIndex(auth.charsetIndex);
+        if (auth.allowMultiStatements) {
+            // #2589 url里面包含allowMultiQueries=true，allowMultiStatements这个参数会在握手协议时候返回
+            // 因为mycat目前不能很好地支持这个特性，直接报错
+            String errMsg = "Mycat does not support the allowMultiQueries value to be true, please set the value to false and try again.";
+            LOGGER.error(errMsg);
+            failure(ErrorCode.ER_HANDSHAKE_ERROR, errMsg);
+            return;
+        }
+
         source.setHandler(new FrontendCommandHandler(source));
 
         if (LOGGER.isInfoEnabled()) {

--- a/src/main/java/io/mycat/net/handler/FrontendAuthenticator.java
+++ b/src/main/java/io/mycat/net/handler/FrontendAuthenticator.java
@@ -215,12 +215,18 @@ public class FrontendAuthenticator implements NIOHandler {
         source.setSchema(auth.database);
         source.setCharsetIndex(auth.charsetIndex);
         if (auth.allowMultiStatements) {
-            // #2589 url里面包含allowMultiQueries=true，allowMultiStatements这个参数会在握手协议时候返回
-            // 因为mycat目前不能很好地支持这个特性，直接报错
-            String errMsg = "Mycat does not support the allowMultiQueries value to be true, please set the value to false and try again.";
-            LOGGER.error(errMsg);
-            failure(ErrorCode.ER_HANDSHAKE_ERROR, errMsg);
-            return;
+            /**
+             * #2589 url里面包含allowMultiQueries=true，allowMultiStatements这个参数会在握手协议时候返回
+             * mysql命令行客户端或navicat都会把这个参数设置为true，表示它会发送”multiple statements “
+             * 参考https://dev.mysql.com/doc/internals/en/capability-flags.html。
+             * 因为mycat目前不能支持这个特性，只能先日志记录下，便于以后排查问题
+             **/
+            String warnMsg = "Mycat does not support the allowMultiQueries value to be true, maybe occur some error.Client connection is[{}]";
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info(warnMsg, this);
+            }
+            // failure(ErrorCode.ER_HANDSHAKE_ERROR, errMsg);
+            // return;
         }
 
         source.setHandler(new FrontendCommandHandler(source));

--- a/src/main/java/io/mycat/net/mysql/AuthPacket.java
+++ b/src/main/java/io/mycat/net/mysql/AuthPacket.java
@@ -62,6 +62,7 @@ public class AuthPacket extends MySQLPacket {
     public String user;
     public byte[] password;
     public String database;
+    public boolean allowMultiStatements;
 
     public void read(byte[] data) {
         MySQLMessage mm = new MySQLMessage(data);
@@ -83,6 +84,10 @@ public class AuthPacket extends MySQLPacket {
         password = mm.readBytesWithLength();
         if (((clientFlags & Capabilities.CLIENT_CONNECT_WITH_DB) != 0) && mm.hasRemaining()) {
             database = mm.readStringWithNull();
+        }
+        
+        if ((clientFlags & Capabilities.CLIENT_MULTI_STATEMENTS) != 0) {
+            allowMultiStatements = true;
         }
     }
 


### PR DESCRIPTION
#### 修复内容如下：
- 1 连接参数里面出现allowMultiQueries=true，日志记录便于以后排查。PS: 完全禁用影响navicat和mysql cmd方式登陆
- 2 sql里面的带句，如“update customer set name=1;update customer set name=2”，在解析时候直接报错
- 3 AbstractConnection.cleanup() 加锁，防止并发情况下buffer多次释放，导致buffer被多个connection共用，引发数据错乱