### PR TITLE
#2689 分片使用PartitionByMod函数插入非int类型数据时报数组下标越界异常修复

### DIFF
--- a/src/main/java/io/mycat/route/function/PartitionByMod.java
+++ b/src/main/java/io/mycat/route/function/PartitionByMod.java
@@ -63,8 +63,14 @@ public class PartitionByMod extends AbstractPartitionAlgorithm implements RuleAl
             // throw new IllegalArgumentException(new
             // StringBuilder().append("columnValue:").append(columnValue).append(" Please
             // eliminate any quote and non number within it.").toString(),e);
-            int value = Math.abs((columnValue).hashCode());
-            return value % count;
+ //           int value = Math.abs((columnValue).hashCode());
+//            return value % count;
+			/**
+ 			* hashcode后的值使用int类型超出数值范围时，返回负数，报数组下标越界
+ 			* date 2020/12/21
+ 			*/
+			long value = Math.abs(Long.valueOf((columnValue).hashCode()));
+			return (int)(value%count);
 		}
 
 	}


### PR DESCRIPTION
int类型的数值范围刚好是 -2^31——2^31-1,即-2147483648——2147483647
报错insert语句中HASH_ID的值取其String.hashCode(),刚好为-2147483648，对其math.abs(-2147483648)结果依旧为负数，即计算hashCode后取绝对值时可能会发生位数溢出，因此使用math.abs(long)来求绝对值，然后使用long来接收字符串的hashCode()的值