### PR TITLE
#2733 修复SHOW FULL TABLES FROM INFORMATION_SCHEMA多发送一个空select包问题

### DIFF
--- a/src/main/java/io/mycat/server/response/ShowFullTables.java
+++ b/src/main/java/io/mycat/server/response/ShowFullTables.java
@@ -62,7 +62,8 @@ public class ShowFullTables
                 return;
             }
         } else {
-             c.writeErrMessage(ErrorCode.ER_NO_DB_ERROR,"No database selected");
+            c.writeErrMessage(ErrorCode.ER_NO_DB_ERROR, "Cannot find the corresponding logic schema of Mycat");
+            return;
         }
 
         //分库的schema，直接从SchemaConfig中获取所有表名


### PR DESCRIPTION

mysql> SHOW FULL TABLES FROM INFORMATION_SCHEMA LIKE 'PARAMETERS';
ERROR 1046 (HY000): No database selected
mysql>
mysql>
mysql> SHOW FULL TABLES FROM INFORMATION_SCHEMA LIKE 'PARAMETERS';
**Empty set (0.00 sec)**

mysql> SHOW FULL TABLES FROM INFORMATION_SCHEMA LIKE 'PARAMETERS';
ERROR 1046 (HY000): No database selected
