### PR TITLE
取消查询出的表名强制小写的限制

### DIFF
--- a/src/main/java/io/mycat/server/response/ShowFullTables.java
+++ b/src/main/java/io/mycat/server/response/ShowFullTables.java
@@ -101,7 +101,7 @@ public class ShowFullTables {
 
         for (String name : tableSet) {
             RowDataPacket row = new RowDataPacket(FIELD_COUNT);
-            row.add(StringUtil.encode(name.toLowerCase(), c.getCharset()));
+            row.add(StringUtil.encode(name, c.getCharset()));
             row.add(StringUtil.encode("BASE TABLE", c.getCharset()));
             row.packetId = ++packetId;
             buffer = row.write(buffer, c,true);


### PR DESCRIPTION
Mycat通过SHOW FULL TABLES FROM 命令查询表名时，将表名name强制小写
部分mysql引擎对于表名大小写敏感，所以建议取消该限制