### PR TITLE
修复在调用bin/init_zk_data.sh时，Log4j2调用shutdown的钩子报错的问题

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration shutdownHook="disable" status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d [%-5p][%t] %m %throwable{full} (%C:%F:%L) %n"/>


### PR DESCRIPTION
通过在`log4j2.xml`中，增加`shutdownHook="disable"`，来解决在调用`init_zk_data.sh`出现的如下报错：

``` 
o2021-11-12 23:57:13 INFO JAVA_CMD=/usr/local/java/bin/java
o2021-11-12 23:57:13 INFO Start to initialize /mycat of ZooKeeper
2021-11-12 23:57:14,798 Thread-1 ERROR Unable to register shutdown hook because JVM is shutting down. java.lang.IllegalStateException: Cannot add new shutdown hook as this is not started. Current state: STOPPED
	at org.apache.logging.log4j.core.util.DefaultShutdownCallbackRegistry.addShutdownCallback(DefaultShutdownCallbackRegistry.java:113)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.addShutdownCallback(Log4jContextFactory.java:273)
	at org.apache.logging.log4j.core.LoggerContext.setUpShutdownHook(LoggerContext.java:256)
	at org.apache.logging.log4j.core.LoggerContext.start(LoggerContext.java:216)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:145)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:41)
	at org.apache.logging.log4j.LogManager.getContext(LogManager.java:182)
	at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getContext(AbstractLoggerAdapter.java:103)
	at org.apache.logging.slf4j.Log4jLoggerFactory.getContext(Log4jLoggerFactory.java:43)
	at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:42)
	at org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:29)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:242)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:254)
	at org.apache.curator.utils.CloseableUtils.<clinit>(CloseableUtils.java:33)
	at org.apache.curator.ConnectionState.close(ConnectionState.java:111)
	at org.apache.curator.CuratorZookeeperClient.close(CuratorZookeeperClient.java:203)
	at org.apache.curator.framework.imps.CuratorFrameworkImpl.close(CuratorFrameworkImpl.java:321)
	at io.mycat.util.ZKUtils$1.run(ZKUtils.java:40)
	at java.lang.Thread.run(Thread.java:748)

```